### PR TITLE
BPANE-0006: Formalize Session Manager Boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ Current product shape:
   - `transport.rs`: browser connection loop, per-client policy, relay behavior.
   - `session_hub.rs`: fan-out, late-join bootstrap, viewer cap, telemetry.
   - `session_control.rs`: Phase 0 versioned session-resource store and Postgres integration.
-  - `runtime_manager.rs`: session-id-to-runtime resolution seam; currently supports `static_single`, `docker_single`, and `docker_pool` backends. The default stack still uses the single-runtime path; `docker_pool` adds explicit runtime caps for parallel session workers and can now be exercised from local compose for browser sessions. Docker-backed workers now carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are now persisted/reconciled through Postgres on gateway restart.
+  - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
+  - `runtime_manager.rs`: current `SessionManager` backend implementation; supports `static_single`, `docker_single`, and `docker_pool`. The default stack still uses the single-runtime path; `docker_pool` adds explicit runtime caps for parallel session workers and can now be exercised from local compose for browser sessions. Docker-backed workers carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are persisted/reconciled through Postgres on gateway restart.
   - `api.rs`: legacy compatibility endpoints plus the frozen owner-scoped `/api/v1/sessions` surface and session-scoped `access-tokens`, `automation-owner`, `status`, and `mcp-owner` routes.
 - `code/shared/bpane-protocol`
   - Shared wire protocol, frame envelope, channel IDs, and message types.
@@ -75,7 +76,7 @@ Current product shape:
   - Source of truth for local dev runtime defaults.
   - Local auth in compose is OIDC via Keycloak on `:8091`.
   - Local session-control persistence in compose is Postgres on `:5433`.
-  - Local compose can now be switched to `docker_pool` for browser-session workers via gateway env overrides; the local `mcp-bridge` still targets the single-runtime path.
+  - Local compose can now be switched to `docker_pool` for browser-session workers via gateway env overrides; `mcp-bridge` resolves the delegated session's runtime endpoint dynamically in that mode.
 
 ## Protocol and media facts
 

--- a/ARCH.md
+++ b/ARCH.md
@@ -208,7 +208,14 @@ Stateless relay between host agent and browser clients.
   - in-memory backend fallback for tests and dev fallback mode
   - session-scoped connect metadata and routing keyed by public `session_id`
   - `legacy_single_runtime` compatibility gating so Phase 0 can expose session resources before true multi-session workers land
-- **Runtime manager** (`runtime_manager.rs`): resolves `session_id -> runtime endpoint`
+- **Session manager** (`session_manager.rs`): internal gateway boundary for session lifecycle/runtime orchestration
+  - this is the only runtime-lifecycle surface the rest of the gateway should depend on
+  - current responsibilities are:
+    - resolve `session_id -> runtime endpoint`
+    - attach/reconcile persisted runtime assignments
+    - expose runtime profile/capacity semantics to session control
+    - mark runtime-backed sessions active/idle and release them on stop
+- **Runtime manager** (`runtime_manager.rs`): current backend implementation behind `SessionManager`
   - current backends are:
     - `static_single`: one shared host socket, with idle release semantics in the gateway
     - `docker_single`: opt-in Docker-backed worker startup/shutdown for the active session, with idle timeout and one active runtime at a time

--- a/ISSUE_6_MULTI_SESSION_PLAN.md
+++ b/ISSUE_6_MULTI_SESSION_PLAN.md
@@ -49,22 +49,25 @@ The main blockers are outside that abstraction:
 - `code/apps/bpane-gateway/src/api.rs`
   - public API now has both legacy global compatibility routes and owner-scoped `/api/v1/sessions` plus session-scoped `status` / `mcp-owner`
   - formal delegation and access-ticket flows across mixed principals now exist
-  - the remaining gap is real runtime selection and worker lifecycle behind those session resources
+  - the remaining work is contract hardening and later operational policy, not first-pass routing/lifecycle
 - `code/apps/bpane-gateway/src/transport.rs`
   - WebTransport now resolves a session-scoped connect ticket and routes browser connections through the public `session_id`
-  - the remaining compatibility limit is that session routing still resolves to one active host runtime candidate
+  - runtime routing is now session-scoped against the public control-plane session id
+- `code/apps/bpane-gateway/src/session_manager.rs`
+  - this is now the internal gateway boundary for session lifecycle/runtime orchestration
+  - the rest of the gateway depends on `SessionManager`, not directly on runtime backend details
 - `code/apps/bpane-gateway/src/runtime_manager.rs`
-  - this seam now exists and currently supports:
+  - current backend implementation behind `SessionManager`; supports:
     - `static_single`: one shared host socket
     - `docker_single`: one start-on-demand runtime container with idle shutdown
     - `docker_pool`: multiple start-on-demand runtime containers with explicit active/startup caps
-  - `docker_single` still enforces one active runtime at a time; `docker_pool` is the first backend that can run multiple session workers in parallel
+  - `docker_single` still enforces one active runtime at a time; `docker_pool` runs multiple session workers in parallel
   - local compose is now wired so `docker_pool` can be exercised end to end for browser sessions
   - runtime assignment metadata is now persisted and reconciled on gateway restart
   - stopped sessions can now restart against the same persisted Chromium profile in Docker-backed modes
   - the remaining work is hardening and broader operational policy, not first-pass runtime identity/routing
 - `code/apps/bpane-gateway/src/main.rs` and `config.rs`
-  - one `--agent-socket`, one host endpoint
+  - bootstrap the `SessionManager` boundary and select the current runtime backend/profile
 - `code/integrations/mcp-bridge/src/index.ts`
   - can now resolve a control session, use session-scoped ownership/status APIs, and bind to the delegated session's runtime-specific CDP endpoint
   - still limits one managed control session per bridge instance
@@ -307,7 +310,8 @@ Exit criteria:
 
 Deliverables:
 
-- new internal host-side manager process or crate
+- explicit internal session-manager boundary between gateway control-plane logic and runtime backend implementation: done in the current branch as `session_manager.rs`
+- current backend implementation remains in `runtime_manager.rs`
 - per-session runtime allocation:
   - display
   - socket path
@@ -320,8 +324,9 @@ Deliverables:
 
 Exit criteria:
 
-- two independent session workers can run in parallel on one host
-- stopping one session does not disturb the other
+- two independent session workers can run in parallel on one host: done in `docker_pool`
+- stopping one session does not disturb the other: done
+- gateway modules depend on the session-manager boundary rather than backend implementation details: done
 
 ### Phase 2: Make gateway routing session-scoped
 
@@ -334,9 +339,8 @@ Deliverables:
 
 Exit criteria:
 
-- completed in the current branch for the single-runtime compatibility model
+- completed in the current branch
 - browser clients for session A cannot attach to session B accidentally
-- remaining follow-up: replace the legacy single-runtime lookup with true per-session host runtime resolution
 
 ### Phase 3: Ship the public control plane
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Current limitation:
 
 - the public session resource model is now versioned and persistent
 - gateway transport and runtime compatibility APIs are now session-scoped
+- gateway runtime orchestration now goes through an internal `SessionManager` boundary; the current runtime backend implementation still lives in `runtime_manager.rs`
 - the default runtime backend is still `legacy_single_runtime` compatibility mode
 - the optional `docker_single` backend can now start and stop one runtime container for the active session
 - the optional `docker_pool` backend can start multiple runtime containers in parallel, but only up to its configured runtime caps

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -12,12 +12,12 @@ use uuid::Uuid;
 use crate::auth::{AuthValidator, AuthenticatedPrincipal};
 use crate::connect_ticket::SessionConnectTicketManager;
 use crate::idle_stop::schedule_idle_session_stop;
-use crate::runtime_manager::{ResolvedSessionRuntime, RuntimeManagerError, SessionRuntimeManager};
 use crate::session_control::{
     CreateSessionRequest, SessionLifecycleState, SessionListResponse, SessionOwnerMode,
     SessionResource, SessionStore, SessionStoreError, SetAutomationDelegateRequest, StoredSession,
 };
 use crate::session_hub::SessionTelemetrySnapshot;
+use crate::session_manager::{SessionManager, SessionManagerError, SessionRuntime};
 use crate::session_registry::SessionRegistry;
 
 /// Shared state for the HTTP API.
@@ -26,7 +26,7 @@ struct ApiState {
     auth_validator: Arc<AuthValidator>,
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
-    runtime_manager: Arc<SessionRuntimeManager>,
+    session_manager: Arc<SessionManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
     default_owner_mode: SessionOwnerMode,
@@ -108,7 +108,7 @@ async fn create_session(
         state.idle_stop_timeout,
         state.registry.clone(),
         state.session_store.clone(),
-        state.runtime_manager.clone(),
+        state.session_manager.clone(),
     );
 
     Ok((
@@ -238,7 +238,7 @@ async fn issue_session_access_token(
             state.idle_stop_timeout,
             state.registry.clone(),
             state.session_store.clone(),
-            state.runtime_manager.clone(),
+            state.session_manager.clone(),
         );
         prepared
     } else {
@@ -330,7 +330,10 @@ async fn delete_session(
 
     if should_block_session_stop(
         stored.state,
-        state.runtime_manager.profile().supports_legacy_global_routes,
+        state
+            .session_manager
+            .profile()
+            .supports_legacy_global_routes,
         runtime_is_currently_in_use(&state).await,
     ) {
         return Err((
@@ -356,7 +359,7 @@ async fn delete_session(
             )
         })?;
 
-    state.runtime_manager.release(session_id).await;
+    state.session_manager.release(session_id).await;
     state.registry.remove_session(session_id).await;
 
     Ok(Json(session_resource(&state, &stopped, None)))
@@ -462,7 +465,7 @@ async fn set_mcp_owner(
         })?;
 
     hub.set_mcp_owner(req.width, req.height).await;
-    state.runtime_manager.mark_session_active(session_id).await;
+    state.session_manager.mark_session_active(session_id).await;
     let _ = state.session_store.mark_session_active(session_id).await;
 
     Ok(Json(OkResponse { ok: true }))
@@ -490,7 +493,7 @@ async fn set_session_mcp_owner(
         })?;
 
     hub.set_mcp_owner(req.width, req.height).await;
-    state.runtime_manager.mark_session_active(session_id).await;
+    state.session_manager.mark_session_active(session_id).await;
     let _ = state.session_store.mark_session_active(session_id).await;
 
     Ok(Json(OkResponse { ok: true }))
@@ -505,7 +508,7 @@ async fn clear_mcp_owner(
         .await
         .map_err(|_| StatusCode::UNAUTHORIZED)?;
     if !state
-        .runtime_manager
+        .session_manager
         .profile()
         .supports_legacy_global_routes
     {
@@ -527,13 +530,13 @@ async fn clear_mcp_owner(
     let snapshot = hub.telemetry_snapshot().await;
     if snapshot.browser_clients == 0 && snapshot.viewer_clients == 0 && !snapshot.mcp_owner {
         let _ = state.session_store.mark_session_idle(session_id).await;
-        state.runtime_manager.mark_session_idle(session_id).await;
+        state.session_manager.mark_session_idle(session_id).await;
         schedule_idle_session_stop(
             session_id,
             state.idle_stop_timeout,
             state.registry.clone(),
             state.session_store.clone(),
-            state.runtime_manager.clone(),
+            state.session_manager.clone(),
         );
     }
 
@@ -564,13 +567,13 @@ async fn clear_session_mcp_owner(
     let snapshot = hub.telemetry_snapshot().await;
     if snapshot.browser_clients == 0 && snapshot.viewer_clients == 0 && !snapshot.mcp_owner {
         let _ = state.session_store.mark_session_idle(session_id).await;
-        state.runtime_manager.mark_session_idle(session_id).await;
+        state.session_manager.mark_session_idle(session_id).await;
         schedule_idle_session_stop(
             session_id,
             state.idle_stop_timeout,
             state.registry.clone(),
             state.session_store.clone(),
-            state.runtime_manager.clone(),
+            state.session_manager.clone(),
         );
     }
 
@@ -584,7 +587,7 @@ pub async fn run_api_server(
     auth_validator: Arc<AuthValidator>,
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
-    runtime_manager: Arc<SessionRuntimeManager>,
+    session_manager: Arc<SessionManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
     default_owner_mode: SessionOwnerMode,
@@ -594,7 +597,7 @@ pub async fn run_api_server(
         auth_validator,
         connect_ticket_manager,
         session_store,
-        runtime_manager,
+        session_manager,
         idle_stop_timeout,
         public_gateway_url,
         default_owner_mode,
@@ -629,7 +632,7 @@ fn session_resource(
     stored.to_resource(
         &state.public_gateway_url,
         state
-            .runtime_manager
+            .session_manager
             .describe_session_runtime(stored.id)
             .into(),
         state_override,
@@ -789,26 +792,26 @@ fn should_block_session_stop(
 async fn resolve_runtime(
     state: &ApiState,
     session_id: Uuid,
-) -> Result<ResolvedSessionRuntime, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<SessionRuntime, (StatusCode, Json<ErrorResponse>)> {
     state
-        .runtime_manager
+        .session_manager
         .resolve(session_id)
         .await
-        .map_err(map_runtime_manager_error)
+        .map_err(map_session_manager_error)
 }
 
 async fn resolve_runtime_compat(
     state: &ApiState,
     session_id: Uuid,
-) -> Result<ResolvedSessionRuntime, StatusCode> {
+) -> Result<SessionRuntime, StatusCode> {
     state
-        .runtime_manager
+        .session_manager
         .resolve(session_id)
         .await
         .map_err(|_| StatusCode::CONFLICT)
 }
 
-fn map_runtime_manager_error(error: RuntimeManagerError) -> (StatusCode, Json<ErrorResponse>) {
+fn map_session_manager_error(error: SessionManagerError) -> (StatusCode, Json<ErrorResponse>) {
     (
         StatusCode::CONFLICT,
         Json(ErrorResponse {
@@ -835,7 +838,7 @@ fn ensure_legacy_runtime_routes_supported(
     state: &ApiState,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
     if state
-        .runtime_manager
+        .session_manager
         .profile()
         .supports_legacy_global_routes
     {

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -9,7 +9,7 @@ use tower::ServiceExt;
 use super::*;
 use crate::auth::AuthValidator;
 use crate::connect_ticket::SessionConnectTicketManager;
-use crate::runtime_manager::{RuntimeManagerConfig, SessionRuntimeManager};
+use crate::session_manager::{SessionManager, SessionManagerConfig};
 
 fn test_router() -> (Router, String) {
     let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
@@ -24,8 +24,8 @@ fn test_router() -> (Router, String) {
             Duration::from_secs(300),
         )),
         session_store: SessionStore::in_memory(),
-        runtime_manager: Arc::new(
-            SessionRuntimeManager::new(RuntimeManagerConfig::StaticSingle {
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
                 agent_socket_path: "/tmp/test.sock".to_string(),
                 cdp_endpoint: Some("http://host:9223".to_string()),
                 idle_timeout: Duration::from_secs(300),
@@ -361,8 +361,8 @@ async fn scopes_session_resources_to_the_authenticated_owner() {
             Duration::from_secs(300),
         )),
         session_store: SessionStore::in_memory(),
-        runtime_manager: Arc::new(
-            SessionRuntimeManager::new(RuntimeManagerConfig::StaticSingle {
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
                 agent_socket_path: "/tmp/test.sock".to_string(),
                 cdp_endpoint: Some("http://host:9223".to_string()),
                 idle_timeout: Duration::from_secs(300),
@@ -421,8 +421,8 @@ async fn rejects_session_scoped_runtime_routes_for_unknown_or_foreign_sessions_b
             Duration::from_secs(300),
         )),
         session_store: SessionStore::in_memory(),
-        runtime_manager: Arc::new(
-            SessionRuntimeManager::new(RuntimeManagerConfig::StaticSingle {
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
                 agent_socket_path: "/tmp/test.sock".to_string(),
                 cdp_endpoint: Some("http://host:9223".to_string()),
                 idle_timeout: Duration::from_secs(300),

--- a/code/apps/bpane-gateway/src/idle_stop.rs
+++ b/code/apps/bpane-gateway/src/idle_stop.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::runtime_manager::SessionRuntimeManager;
 use crate::session_control::{SessionLifecycleState, SessionStore};
+use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
 
 pub fn schedule_idle_session_stop(
@@ -13,7 +13,7 @@ pub fn schedule_idle_session_stop(
     default_timeout: Duration,
     registry: Arc<SessionRegistry>,
     session_store: SessionStore,
-    runtime_manager: Arc<SessionRuntimeManager>,
+    session_manager: Arc<SessionManager>,
 ) {
     tokio::spawn(async move {
         let timeout = match session_store.get_session_by_id(session_id).await {
@@ -38,7 +38,7 @@ pub fn schedule_idle_session_stop(
 
         match session_store.stop_session_if_idle(session_id).await {
             Ok(Some(session)) if session.state == SessionLifecycleState::Stopped => {
-                runtime_manager.release(session_id).await;
+                session_manager.release(session_id).await;
                 registry.remove_session(session_id).await;
                 info!(%session_id, "stopped idle session after {:?}", timeout);
             }

--- a/code/apps/bpane-gateway/src/main.rs
+++ b/code/apps/bpane-gateway/src/main.rs
@@ -8,6 +8,7 @@ mod runtime_manager;
 mod session;
 mod session_control;
 mod session_hub;
+mod session_manager;
 mod session_registry;
 mod transport;
 
@@ -23,8 +24,8 @@ use wtransport::Identity;
 use auth::{AuthValidator, OidcConfig};
 use config::Config;
 use connect_ticket::SessionConnectTicketManager;
-use runtime_manager::{DockerRuntimeConfig, RuntimeManagerConfig, SessionRuntimeManager};
 use session_control::{SessionOwnerMode, SessionStore};
+use session_manager::{SessionManager, SessionManagerConfig, SessionManagerDockerConfig};
 use session_registry::SessionRegistry;
 use transport::TransportServer;
 
@@ -112,14 +113,14 @@ async fn main() -> anyhow::Result<()> {
     ));
 
     let agent_socket_str = config.agent_socket.to_str().unwrap().to_string();
-    let runtime_manager = Arc::new(SessionRuntimeManager::new(
+    let session_manager = Arc::new(SessionManager::new(
         match config.runtime_backend.as_str() {
-            "static_single" => RuntimeManagerConfig::StaticSingle {
+            "static_single" => SessionManagerConfig::StaticSingle {
                 agent_socket_path: agent_socket_str,
                 cdp_endpoint: config.runtime_cdp_endpoint.clone(),
                 idle_timeout: Duration::from_secs(config.runtime_idle_timeout_secs),
             },
-            "docker_single" => RuntimeManagerConfig::DockerSingle(DockerRuntimeConfig {
+            "docker_single" => SessionManagerConfig::DockerSingle(SessionManagerDockerConfig {
                 docker_bin: config.docker_runtime_bin.clone(),
                 image: config.docker_runtime_image.clone().ok_or_else(|| {
                     anyhow::anyhow!(
@@ -147,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
                 seccomp_unconfined: config.docker_runtime_seccomp_unconfined,
                 env_file: config.docker_runtime_env_file.clone(),
             }),
-            "docker_pool" => RuntimeManagerConfig::DockerPool(DockerRuntimeConfig {
+            "docker_pool" => SessionManagerConfig::DockerPool(SessionManagerDockerConfig {
                 docker_bin: config.docker_runtime_bin.clone(),
                 image: config.docker_runtime_image.clone().ok_or_else(|| {
                     anyhow::anyhow!(
@@ -181,22 +182,22 @@ async fn main() -> anyhow::Result<()> {
 
     let session_store = if let Some(database_url) = &config.database_url {
         info!("using postgres-backed session control store");
-        SessionStore::from_database_url_with_config(database_url, runtime_manager.profile().clone())
+        SessionStore::from_database_url_with_config(database_url, session_manager.profile().clone())
             .await?
     } else {
         warn!("no --database-url configured; /api/v1 sessions will use an in-memory store");
-        SessionStore::in_memory_with_config(runtime_manager.profile().clone())
+        SessionStore::in_memory_with_config(session_manager.profile().clone())
     };
 
-    runtime_manager
+    session_manager
         .attach_session_store(session_store.clone())
         .await;
-    runtime_manager.reconcile_persisted_state().await?;
+    session_manager.reconcile_persisted_state().await?;
 
     let server = TransportServer::new(
         bind_addr,
         identity,
-        runtime_manager.clone(),
+        session_manager.clone(),
         auth_validator.clone(),
         connect_ticket_manager.clone(),
         session_store.clone(),
@@ -223,7 +224,7 @@ async fn main() -> anyhow::Result<()> {
             auth_validator,
             connect_ticket_manager,
             session_store,
-            runtime_manager,
+            session_manager,
             Duration::from_secs(config.runtime_idle_timeout_secs),
             config.public_gateway_url,
             if config.exclusive_browser_owner {

--- a/code/apps/bpane-gateway/src/session_control.rs
+++ b/code/apps/bpane-gateway/src/session_control.rs
@@ -12,8 +12,9 @@ use tokio_postgres::{Client, Connection, NoTls, Row, Socket};
 use uuid::Uuid;
 
 use crate::auth::AuthenticatedPrincipal;
-use crate::runtime_manager::{
-    PersistedRuntimeAssignment, RuntimeAssignmentStatus, RuntimeProfile, RuntimeSessionAccessInfo,
+use crate::session_manager::{
+    PersistedSessionRuntimeAssignment, SessionManagerProfile, SessionRuntimeAccess,
+    SessionRuntimeAssignmentStatus,
 };
 
 const DEFAULT_VIEWPORT_WIDTH: u16 = 1600;
@@ -173,8 +174,8 @@ pub struct SessionRuntimeInfo {
     pub cdp_endpoint: Option<String>,
 }
 
-impl From<RuntimeSessionAccessInfo> for SessionRuntimeInfo {
-    fn from(value: RuntimeSessionAccessInfo) -> Self {
+impl From<SessionRuntimeAccess> for SessionRuntimeInfo {
+    fn from(value: SessionRuntimeAccess) -> Self {
         Self {
             binding: value.binding,
             compatibility_mode: value.compatibility_mode,
@@ -329,8 +330,8 @@ enum SessionStoreBackend {
     Postgres(Arc<PostgresSessionStore>),
 }
 
-impl From<RuntimeProfile> for SessionStoreConfig {
-    fn from(runtime_profile: RuntimeProfile) -> Self {
+impl From<SessionManagerProfile> for SessionStoreConfig {
+    fn from(runtime_profile: SessionManagerProfile) -> Self {
         Self {
             runtime_binding: runtime_profile.runtime_binding,
             max_runtime_candidates: runtime_profile.max_runtime_sessions,
@@ -339,8 +340,8 @@ impl From<RuntimeProfile> for SessionStoreConfig {
 }
 
 #[cfg(test)]
-fn legacy_runtime_profile() -> RuntimeProfile {
-    RuntimeProfile {
+fn legacy_runtime_profile() -> SessionManagerProfile {
+    SessionManagerProfile {
         runtime_binding: "legacy_single_session".to_string(),
         compatibility_mode: "legacy_single_runtime".to_string(),
         max_runtime_sessions: 1,
@@ -354,7 +355,7 @@ impl SessionStore {
         Self::in_memory_with_config(legacy_runtime_profile())
     }
 
-    pub fn in_memory_with_config(runtime_profile: RuntimeProfile) -> Self {
+    pub fn in_memory_with_config(runtime_profile: SessionManagerProfile) -> Self {
         Self {
             backend: SessionStoreBackend::InMemory(Arc::new(InMemorySessionStore {
                 sessions: Mutex::new(Vec::new()),
@@ -366,7 +367,7 @@ impl SessionStore {
 
     pub async fn from_database_url_with_config(
         database_url: &str,
-        runtime_profile: RuntimeProfile,
+        runtime_profile: SessionManagerProfile,
     ) -> Result<Self, SessionStoreError> {
         let (client, connection) = connect_to_postgres_with_retry(database_url).await?;
         tokio::spawn(async move {
@@ -573,7 +574,7 @@ impl SessionStore {
 
     pub async fn upsert_runtime_assignment(
         &self,
-        assignment: PersistedRuntimeAssignment,
+        assignment: PersistedSessionRuntimeAssignment,
     ) -> Result<(), SessionStoreError> {
         match &self.backend {
             SessionStoreBackend::InMemory(store) => {
@@ -595,7 +596,7 @@ impl SessionStore {
     pub async fn list_runtime_assignments(
         &self,
         runtime_binding: &str,
-    ) -> Result<Vec<PersistedRuntimeAssignment>, SessionStoreError> {
+    ) -> Result<Vec<PersistedSessionRuntimeAssignment>, SessionStoreError> {
         match &self.backend {
             SessionStoreBackend::InMemory(store) => {
                 store.list_runtime_assignments(runtime_binding).await
@@ -688,7 +689,7 @@ fn validate_automation_delegate_request(
 
 struct InMemorySessionStore {
     sessions: Mutex<Vec<StoredSession>>,
-    runtime_assignments: Mutex<HashMap<Uuid, PersistedRuntimeAssignment>>,
+    runtime_assignments: Mutex<HashMap<Uuid, PersistedSessionRuntimeAssignment>>,
     config: SessionStoreConfig,
 }
 
@@ -957,7 +958,7 @@ impl InMemorySessionStore {
 
     async fn upsert_runtime_assignment(
         &self,
-        assignment: PersistedRuntimeAssignment,
+        assignment: PersistedSessionRuntimeAssignment,
     ) -> Result<(), SessionStoreError> {
         self.runtime_assignments
             .lock()
@@ -974,7 +975,7 @@ impl InMemorySessionStore {
     async fn list_runtime_assignments(
         &self,
         runtime_binding: &str,
-    ) -> Result<Vec<PersistedRuntimeAssignment>, SessionStoreError> {
+    ) -> Result<Vec<PersistedSessionRuntimeAssignment>, SessionStoreError> {
         let assignments = self.runtime_assignments.lock().await;
         let mut values = assignments
             .values()
@@ -1778,7 +1779,7 @@ impl PostgresSessionStore {
 
     async fn upsert_runtime_assignment(
         &self,
-        assignment: PersistedRuntimeAssignment,
+        assignment: PersistedSessionRuntimeAssignment,
     ) -> Result<(), SessionStoreError> {
         self.client
             .lock()
@@ -1839,7 +1840,7 @@ impl PostgresSessionStore {
     async fn list_runtime_assignments(
         &self,
         runtime_binding: &str,
-    ) -> Result<Vec<PersistedRuntimeAssignment>, SessionStoreError> {
+    ) -> Result<Vec<PersistedSessionRuntimeAssignment>, SessionStoreError> {
         let rows = self
             .client
             .lock()
@@ -2004,12 +2005,14 @@ fn row_to_stored_session(row: &Row) -> Result<StoredSession, SessionStoreError> 
     })
 }
 
-fn row_to_runtime_assignment(row: &Row) -> Result<PersistedRuntimeAssignment, SessionStoreError> {
+fn row_to_runtime_assignment(
+    row: &Row,
+) -> Result<PersistedSessionRuntimeAssignment, SessionStoreError> {
     let status = row
         .get::<_, String>("status")
-        .parse::<RuntimeAssignmentStatus>()
+        .parse::<SessionRuntimeAssignmentStatus>()
         .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
-    Ok(PersistedRuntimeAssignment {
+    Ok(PersistedSessionRuntimeAssignment {
         session_id: row.get("session_id"),
         runtime_binding: row.get("runtime_binding"),
         status,
@@ -2126,7 +2129,7 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_store_respects_runtime_pool_capacity() {
-        let store = SessionStore::in_memory_with_config(RuntimeProfile {
+        let store = SessionStore::in_memory_with_config(SessionManagerProfile {
             runtime_binding: "docker_runtime_pool".to_string(),
             compatibility_mode: "session_runtime_pool".to_string(),
             max_runtime_sessions: 2,
@@ -2330,7 +2333,7 @@ mod tests {
 
     #[tokio::test]
     async fn reconnect_prep_respects_runtime_pool_capacity() {
-        let store = SessionStore::in_memory_with_config(RuntimeProfile {
+        let store = SessionStore::in_memory_with_config(SessionManagerProfile {
             runtime_binding: "docker_runtime_pool".to_string(),
             compatibility_mode: "session_runtime_pool".to_string(),
             max_runtime_sessions: 1,
@@ -2393,7 +2396,7 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_store_persists_runtime_assignments_and_can_clear_them() {
-        let store = SessionStore::in_memory_with_config(RuntimeProfile {
+        let store = SessionStore::in_memory_with_config(SessionManagerProfile {
             runtime_binding: "docker_runtime_pool".to_string(),
             compatibility_mode: "session_runtime_pool".to_string(),
             max_runtime_sessions: 2,
@@ -2417,10 +2420,10 @@ mod tests {
             .unwrap();
 
         store
-            .upsert_runtime_assignment(PersistedRuntimeAssignment {
+            .upsert_runtime_assignment(PersistedSessionRuntimeAssignment {
                 session_id: session.id,
                 runtime_binding: "docker_runtime_pool".to_string(),
-                status: RuntimeAssignmentStatus::Ready,
+                status: SessionRuntimeAssignmentStatus::Ready,
                 agent_socket_path: format!("/run/bpane/sessions/{}.sock", session.id),
                 container_name: Some(format!("bpane-runtime-{}", session.id.as_simple())),
                 cdp_endpoint: Some(format!(
@@ -2437,7 +2440,7 @@ mod tests {
             .unwrap();
         assert_eq!(assignments.len(), 1);
         assert_eq!(assignments[0].session_id, session.id);
-        assert_eq!(assignments[0].status, RuntimeAssignmentStatus::Ready);
+        assert_eq!(assignments[0].status, SessionRuntimeAssignmentStatus::Ready);
 
         store.clear_runtime_assignment(session.id).await.unwrap();
         assert!(store

--- a/code/apps/bpane-gateway/src/session_manager.rs
+++ b/code/apps/bpane-gateway/src/session_manager.rs
@@ -1,0 +1,148 @@
+use crate::runtime_manager::{
+    DockerRuntimeConfig, PersistedRuntimeAssignment, ResolvedSessionRuntime,
+    RuntimeAssignmentStatus, RuntimeManagerConfig, RuntimeManagerError, RuntimeProfile,
+    RuntimeSessionAccessInfo, SessionRuntimeManager,
+};
+use crate::session_control::SessionStore;
+use uuid::Uuid;
+
+pub type SessionManagerConfig = RuntimeManagerConfig;
+pub type SessionManagerDockerConfig = DockerRuntimeConfig;
+pub type SessionManagerError = RuntimeManagerError;
+pub type SessionManagerProfile = RuntimeProfile;
+pub type SessionRuntime = ResolvedSessionRuntime;
+pub type SessionRuntimeAccess = RuntimeSessionAccessInfo;
+pub type SessionRuntimeAssignmentStatus = RuntimeAssignmentStatus;
+pub type PersistedSessionRuntimeAssignment = PersistedRuntimeAssignment;
+
+/// Internal gateway boundary for session runtime lifecycle.
+///
+/// `SessionManager` is the only runtime-lifecycle surface that the rest of the
+/// gateway should depend on. The concrete worker startup and routing
+/// implementation remains in `runtime_manager.rs`.
+#[derive(Clone)]
+pub struct SessionManager {
+    inner: SessionRuntimeManager,
+}
+
+impl SessionManager {
+    pub fn new(config: SessionManagerConfig) -> Result<Self, SessionManagerError> {
+        Ok(Self {
+            inner: SessionRuntimeManager::new(config)?,
+        })
+    }
+
+    pub fn profile(&self) -> &SessionManagerProfile {
+        self.inner.profile()
+    }
+
+    pub async fn attach_session_store(&self, store: SessionStore) {
+        self.inner.attach_session_store(store).await;
+    }
+
+    pub async fn reconcile_persisted_state(&self) -> Result<(), SessionManagerError> {
+        self.inner.reconcile_persisted_state().await
+    }
+
+    pub fn describe_session_runtime(&self, session_id: Uuid) -> SessionRuntimeAccess {
+        self.inner.describe_session_runtime(session_id)
+    }
+
+    pub async fn resolve(&self, session_id: Uuid) -> Result<SessionRuntime, SessionManagerError> {
+        self.inner.resolve(session_id).await
+    }
+
+    pub async fn release(&self, session_id: Uuid) {
+        self.inner.release(session_id).await;
+    }
+
+    pub async fn mark_session_active(&self, session_id: Uuid) {
+        self.inner.mark_session_active(session_id).await;
+    }
+
+    pub async fn mark_session_idle(&self, session_id: Uuid) {
+        self.inner.mark_session_idle(session_id).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn docker_config() -> SessionManagerDockerConfig {
+        SessionManagerDockerConfig {
+            docker_bin: "docker".to_string(),
+            image: "deploy-host".to_string(),
+            network: "deploy_bpane-internal".to_string(),
+            shared_run_volume: "deploy_agent-socket".to_string(),
+            container_name_prefix: "bpane-runtime".to_string(),
+            socket_root: "/run/bpane/sessions".to_string(),
+            cdp_proxy_port: 9223,
+            shm_size: "128m".to_string(),
+            start_timeout: Duration::from_secs(30),
+            idle_timeout: Duration::from_secs(300),
+            max_active_runtimes: 2,
+            max_starting_runtimes: 1,
+            seccomp_unconfined: true,
+            env_file: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn session_manager_reuses_runtime_for_same_static_session() {
+        let manager = SessionManager::new(SessionManagerConfig::StaticSingle {
+            agent_socket_path: "/tmp/bpane.sock".to_string(),
+            cdp_endpoint: Some("http://host:9223".to_string()),
+            idle_timeout: Duration::from_secs(300),
+        })
+        .unwrap();
+        let session_id = Uuid::now_v7();
+
+        let first = manager.resolve(session_id).await.unwrap();
+        let second = manager.resolve(session_id).await.unwrap();
+
+        assert_eq!(first, second);
+        assert_eq!(
+            manager.profile().compatibility_mode,
+            "legacy_single_runtime"
+        );
+        assert_eq!(
+            manager
+                .describe_session_runtime(session_id)
+                .cdp_endpoint
+                .as_deref(),
+            Some("http://host:9223")
+        );
+    }
+
+    #[test]
+    fn session_manager_exposes_docker_pool_capacity_contract() {
+        let manager =
+            SessionManager::new(SessionManagerConfig::DockerPool(docker_config())).unwrap();
+
+        assert_eq!(manager.profile().compatibility_mode, "session_runtime_pool");
+        assert_eq!(manager.profile().max_runtime_sessions, 2);
+        assert!(!manager.profile().supports_legacy_global_routes);
+        assert_eq!(
+            manager
+                .describe_session_runtime(Uuid::nil())
+                .cdp_endpoint
+                .as_deref(),
+            Some("http://bpane-runtime-00000000000000000000000000000000:9223")
+        );
+    }
+
+    #[tokio::test]
+    async fn session_manager_reconcile_is_exposed_as_a_boundary_operation() {
+        let manager = SessionManager::new(SessionManagerConfig::StaticSingle {
+            agent_socket_path: "/tmp/bpane.sock".to_string(),
+            cdp_endpoint: None,
+            idle_timeout: Duration::from_secs(300),
+        })
+        .unwrap();
+
+        manager.reconcile_persisted_state().await.unwrap();
+    }
+}

--- a/code/apps/bpane-gateway/src/transport.rs
+++ b/code/apps/bpane-gateway/src/transport.rs
@@ -22,14 +22,14 @@ use self::request::{validate_request_path, RequestValidationError};
 use self::session_task::handle_session;
 use crate::auth::AuthValidator;
 use crate::connect_ticket::SessionConnectTicketManager;
-use crate::runtime_manager::SessionRuntimeManager;
 use crate::session_control::SessionStore;
+use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
 
 pub struct TransportServer {
     bind_addr: SocketAddr,
     identity: Identity,
-    runtime_manager: Arc<SessionRuntimeManager>,
+    session_manager: Arc<SessionManager>,
     auth_validator: Arc<AuthValidator>,
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
@@ -42,7 +42,7 @@ impl TransportServer {
     pub fn new(
         bind_addr: SocketAddr,
         identity: Identity,
-        runtime_manager: Arc<SessionRuntimeManager>,
+        session_manager: Arc<SessionManager>,
         auth_validator: Arc<AuthValidator>,
         connect_ticket_manager: Arc<SessionConnectTicketManager>,
         session_store: SessionStore,
@@ -53,7 +53,7 @@ impl TransportServer {
         Self {
             bind_addr,
             identity,
-            runtime_manager,
+            session_manager,
             auth_validator,
             connect_ticket_manager,
             session_store,
@@ -136,7 +136,7 @@ impl TransportServer {
             };
 
             let runtime = match self
-                .runtime_manager
+                .session_manager
                 .resolve(validated_request.session_id)
                 .await
             {
@@ -150,7 +150,7 @@ impl TransportServer {
                     continue;
                 }
             };
-            self.runtime_manager
+            self.session_manager
                 .mark_session_active(validated_request.session_id)
                 .await;
             if let Err(error) = self
@@ -178,7 +178,7 @@ impl TransportServer {
             let heartbeat_timeout = self.heartbeat_timeout;
             let active_sessions_clone = active_sessions.clone();
             let registry = self.registry.clone();
-            let runtime_manager = self.runtime_manager.clone();
+            let session_manager = self.session_manager.clone();
             let session_store = self.session_store.clone();
             let idle_stop_timeout = self.idle_stop_timeout;
             active_sessions.fetch_add(1, Ordering::Relaxed);
@@ -194,7 +194,7 @@ impl TransportServer {
                     connection,
                     session_id,
                     validated_request,
-                    runtime_manager,
+                    session_manager,
                     session_store,
                     idle_stop_timeout,
                     &agent_path,

--- a/code/apps/bpane-gateway/src/transport/session_task.rs
+++ b/code/apps/bpane-gateway/src/transport/session_task.rs
@@ -10,16 +10,16 @@ use super::ingress::spawn_browser_to_agent_task;
 use super::request::ValidatedConnectRequest;
 use super::tasks::{spawn_bitrate_hint_task, spawn_direct_control_task, spawn_gateway_pinger};
 use crate::idle_stop::schedule_idle_session_stop;
-use crate::runtime_manager::SessionRuntimeManager;
 use crate::session::Session;
 use crate::session_control::SessionStore;
+use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
 
 pub(super) async fn handle_session(
     connection: wtransport::Connection,
     session_id: u64,
     connect_request: ValidatedConnectRequest,
-    runtime_manager: Arc<SessionRuntimeManager>,
+    session_manager: Arc<SessionManager>,
     session_store: SessionStore,
     idle_stop_timeout: Duration,
     agent_socket_path: &str,
@@ -111,24 +111,24 @@ pub(super) async fn handle_session(
     if let Some(snapshot) = registry.telemetry_snapshot_if_live(routed_session_id).await {
         if snapshot.browser_clients == 0 && snapshot.viewer_clients == 0 && !snapshot.mcp_owner {
             let _ = session_store.mark_session_idle(routed_session_id).await;
-            runtime_manager.mark_session_idle(routed_session_id).await;
+            session_manager.mark_session_idle(routed_session_id).await;
             schedule_idle_session_stop(
                 routed_session_id,
                 idle_stop_timeout,
                 registry.clone(),
                 session_store.clone(),
-                runtime_manager.clone(),
+                session_manager.clone(),
             );
         }
     } else {
         let _ = session_store.mark_session_idle(routed_session_id).await;
-        runtime_manager.mark_session_idle(routed_session_id).await;
+        session_manager.mark_session_idle(routed_session_id).await;
         schedule_idle_session_stop(
             routed_session_id,
             idle_stop_timeout,
             registry.clone(),
             session_store,
-            runtime_manager.clone(),
+            session_manager.clone(),
         );
     }
 


### PR DESCRIPTION
# BPANE-0006: Formalize Session Manager Boundary

## Summary

This branch does one architectural completion step for issue `#6`:

- introduces an explicit internal `SessionManager` boundary in `bpane-gateway`
- rewires gateway modules to depend on that boundary instead of the concrete runtime backend
- updates the maintained docs so the architecture matches the code

The goal is to make the multi-session control-plane work complete at the architectural boundary level, without changing the public v1 API surface.

## Why

The session-control and runtime work was already in place, but the gateway still depended directly on the concrete runtime implementation.

That left the last major gap from issue `#6`:

- the public control plane was stable
- the runtime backends were real
- but the internal session-manager boundary was still implicit

This branch makes that boundary explicit, so the gateway now has a clear internal contract:

- public API and transport depend on `SessionManager`
- `runtime_manager.rs` remains the current backend implementation behind it

## What Changed

### Internal Boundary

Added:

- `code/apps/bpane-gateway/src/session_manager.rs`

This new module is the internal gateway façade for:

- runtime profile/capacity exposure
- session runtime resolution
- persisted runtime reconciliation
- active/idle tracking
- runtime release on stop

### Gateway Wiring

The following gateway areas now depend on `SessionManager` instead of the concrete runtime backend:

- startup/bootstrap in `main.rs`
- HTTP API in `api.rs`
- transport/session lifecycle in `transport.rs` and `transport/session_task.rs`
- idle-stop handling in `idle_stop.rs`
- runtime-facing session-store types in `session_control.rs`
- gateway API tests

This is intended as an architectural refactor, not a public API change.

### Documentation

Updated:

- `README.md`
- `ARCH.md`
- `AGENTS.md`
- `ISSUE_6_MULTI_SESSION_PLAN.md`

The docs now describe the runtime stack as:

- public control plane
- internal `SessionManager` boundary
- current runtime backend implementation in `runtime_manager.rs`

## Public API Impact

No frozen v1 API changes are intended in this branch.

The public contract remains:

- `openapi/bpane-control-v1.yaml`

Legacy compatibility routes are still compatibility-only, unchanged by this refactor.

## Validation

Validated on this branch with:

- `cargo fmt --package bpane-gateway`
- `cargo test -p bpane-gateway`
- `BPANE_GATEWAY_RUNTIME_BACKEND=docker_pool BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES=2 docker compose -f deploy/compose.yml up --build -d postgres keycloak host gateway web mcp-bridge`
- `cd code/web/bpane-client && npm run smoke:multisession -- --headless`

The smoke run passed on the current branch, including:

- two parallel pool-mode sessions
- joining an existing session from another page
- MCP delegation and bridge switching

## Review Focus

Please focus review on:

- whether `SessionManager` is the right internal lifecycle boundary
- whether gateway modules are now cleanly decoupled from runtime backend details
- whether the docs accurately describe the new internal architecture

## Out Of Scope

This branch does not add:

- new public API surface
- multi-bridge coordination
- cluster scheduling
- new runtime behavior beyond the existing backends

It is the architectural completion/refinement step for the already-built issue `#6` control-plane work.
