### PR TITLE
BPANE-0005: feat(recording) add low-overhead session recording pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist/
 .vscode/
 .idea/
 .github_token
+PLAN_*.md
+plan-*.md
+*_PLAN.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ Run these in `code/web/bpane-client`:
 - `npx tsc --noEmit`
 - `npm test`
 - `npm run build`
+- `npm run smoke:recording -- --headless`
 - `npm run smoke:multisession -- --headless`
 - `npm run test:coverage`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Current product shape:
   - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
   - `recording_artifact_store.rs`: recording artifact storage boundary. `local_fs` is the current implementation; the gateway persists opaque artifact refs instead of raw filesystem paths.
   - `recording_lifecycle.rs`: recorder-worker launch, persisted assignment tracking, and restart reconciliation for session-scoped recording, including `recording.mode=always`. Recording resources are contiguous segments; restart recovery fails the stale in-flight segment and starts a linked fresh one instead of pretending the artifact is continuous.
+  - `recording_playback.rs`: derives session-level playback/export resources from retained recording segments and packages a zipped playback bundle with manifest + player + included media files.
+  - `recording_observability.rs`: gateway-local counters/timestamps for recording finalization, playback export generation, and retention passes.
   - `recording_retention.rs`: periodic cleanup of completed recording artifacts after the session-scoped retention window expires; it clears artifact refs but preserves recording segment metadata.
   - `runtime_manager.rs`: current `SessionManager` backend implementation; supports `static_single`, `docker_single`, and `docker_pool`. The default stack still uses the single-runtime path; `docker_pool` adds explicit runtime caps for parallel session workers and can now be exercised from local compose for browser sessions. Docker-backed workers carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are persisted/reconciled through Postgres on gateway restart.
   - `api.rs`: legacy compatibility endpoints plus the frozen owner-scoped `/api/v1/sessions` surface and session-scoped `access-tokens`, `automation-owner`, `status`, and `mcp-owner` routes.
@@ -104,6 +106,7 @@ Current product shape:
 - Gateway session status reports:
   - browser and viewer counts
   - `max_viewers` and remaining slots
+  - session-scoped recording playback/export summary derived from retained segments
   - join latency telemetry
   - full-refresh burst telemetry
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,9 @@ Current product shape:
   - `session_hub.rs`: fan-out, late-join bootstrap, viewer cap, telemetry.
   - `session_control.rs`: Phase 0 versioned session-resource store and Postgres integration.
   - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
+  - `recording_artifact_store.rs`: recording artifact storage boundary. `local_fs` is the current implementation; the gateway persists opaque artifact refs instead of raw filesystem paths.
+  - `recording_lifecycle.rs`: recorder-worker launch, persisted assignment tracking, and restart reconciliation for session-scoped recording, including `recording.mode=always`. Recording resources are contiguous segments; restart recovery fails the stale in-flight segment and starts a linked fresh one instead of pretending the artifact is continuous.
+  - `recording_retention.rs`: periodic cleanup of completed recording artifacts after the session-scoped retention window expires; it clears artifact refs but preserves recording segment metadata.
   - `runtime_manager.rs`: current `SessionManager` backend implementation; supports `static_single`, `docker_single`, and `docker_pool`. The default stack still uses the single-runtime path; `docker_pool` adds explicit runtime caps for parallel session workers and can now be exercised from local compose for browser sessions. Docker-backed workers carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are persisted/reconciled through Postgres on gateway restart.
   - `api.rs`: legacy compatibility endpoints plus the frozen owner-scoped `/api/v1/sessions` surface and session-scoped `access-tokens`, `automation-owner`, `status`, and `mcp-owner` routes.
 - `code/shared/bpane-protocol`
@@ -72,6 +75,9 @@ Current product shape:
 - `code/integrations/mcp-bridge`
   - SSE bridge to `@playwright/mcp`; owns session registration and MCP supervision behavior.
   - Can resolve an explicit control-plane session via `/api/v1/sessions`, accepts delegated-session assignment through its local `/control-session` API, resolves the managed session's runtime CDP endpoint from the session resource, and uses session-scoped `status` / `mcp-owner` APIs when a managed session is configured, including in `docker_pool` mode.
+- `code/integrations/recording-worker`
+  - Playwright-driven recorder worker that attaches as a `recorder` browser client through the control plane.
+  - Creates or adopts session recording resources via `/api/v1/sessions/{id}/recordings`, waits for stop/finalize signals, then hands a temporary local file path back to the gateway for artifact-store finalization.
 - `deploy/compose.yml`
   - Source of truth for local dev runtime defaults.
   - Local auth in compose is OIDC via Keycloak on `:8091`.
@@ -118,6 +124,7 @@ Run these in `code/web/bpane-client`:
 
 Run these where applicable:
 - `cd code/integrations/mcp-bridge && npm run build`
+- `cd code/integrations/recording-worker && npm run build`
 
 ## Local development flow
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ name = "bpane-gateway"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "base64",
  "bpane-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +341,7 @@ dependencies = [
  "tracing-subscriber",
  "uuid",
  "wtransport",
+ "zip",
 ]
 
 [[package]]
@@ -573,6 +583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +652,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3546,6 +3582,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ npm ci
 npx tsc --noEmit
 npm test
 npm run build
+npm run smoke:recording -- --headless
 ```
 
 Other useful checks:
@@ -240,6 +241,7 @@ cargo test -p bpane-protocol
 cargo test -p bpane-host
 cargo test -p bpane-gateway
 cd code/integrations/mcp-bridge && npm run build
+cd code/web/bpane-client && npm run smoke:recording -- --headless
 cd code/web/bpane-client && npm run smoke:multisession -- --headless
 ```
 

--- a/code/apps/bpane-gateway/Cargo.toml
+++ b/code/apps/bpane-gateway/Cargo.toml
@@ -34,6 +34,7 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_j
 uuid = { version = "1", features = ["serde", "v7"] }
 chrono = { version = "0.4", features = ["serde"] }
 async-trait = "0.1"
+zip = { version = "2", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/code/apps/bpane-gateway/Cargo.toml
+++ b/code/apps/bpane-gateway/Cargo.toml
@@ -33,6 +33,7 @@ jsonwebtoken = { version = "9", features = ["use_pem"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 uuid = { version = "1", features = ["serde", "v7"] }
 chrono = { version = "0.4", features = ["serde"] }
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -2,7 +2,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::extract::{Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::Response;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
@@ -12,9 +14,17 @@ use uuid::Uuid;
 use crate::auth::{AuthValidator, AuthenticatedPrincipal};
 use crate::connect_ticket::SessionConnectTicketManager;
 use crate::idle_stop::schedule_idle_session_stop;
+use crate::recording_artifact_store::{
+    FinalizeRecordingArtifactRequest, RecordingArtifactStore, RecordingArtifactStoreError,
+};
+use crate::recording_lifecycle::{RecordingLifecycleError, RecordingLifecycleManager};
 use crate::session_control::{
-    CreateSessionRequest, SessionLifecycleState, SessionListResponse, SessionOwnerMode,
-    SessionResource, SessionStore, SessionStoreError, SetAutomationDelegateRequest, StoredSession,
+    CompleteSessionRecordingRequest, CreateSessionRequest, FailSessionRecordingRequest,
+    PersistCompletedSessionRecordingRequest, SessionLifecycleState, SessionListResponse,
+    SessionOwnerMode, SessionRecordingFormat, SessionRecordingListResponse, SessionRecordingMode,
+    SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
+    SessionRecordingTerminationReason, SessionResource, SessionStore, SessionStoreError,
+    SetAutomationDelegateRequest, StoredSession, StoredSessionRecording,
 };
 use crate::session_hub::SessionTelemetrySnapshot;
 use crate::session_manager::{SessionManager, SessionManagerError, SessionRuntime};
@@ -27,6 +37,8 @@ struct ApiState {
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
     session_manager: Arc<SessionManager>,
+    recording_artifact_store: Arc<RecordingArtifactStore>,
+    recording_lifecycle: Arc<RecordingLifecycleManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
     default_owner_mode: SessionOwnerMode,
@@ -42,7 +54,32 @@ struct SessionStatus {
     exclusive_browser_owner: bool,
     mcp_owner: bool,
     resolution: (u16, u16),
+    recording: SessionRecordingStatus,
     telemetry: SessionTelemetry,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SessionRecordingStatusState {
+    Disabled,
+    Idle,
+    Recording,
+    Finalizing,
+    Ready,
+    Failed,
+}
+
+#[derive(Serialize)]
+struct SessionRecordingStatus {
+    configured_mode: SessionRecordingMode,
+    format: SessionRecordingFormat,
+    retention_sec: Option<u32>,
+    state: SessionRecordingStatusState,
+    active_recording_id: Option<String>,
+    recorder_attached: bool,
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+    bytes_written: Option<u64>,
+    duration_ms: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -97,12 +134,29 @@ async fn create_session(
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    state
+        .recording_lifecycle
+        .validate_mode(request.recording.mode)
+        .map_err(map_recording_lifecycle_error)?;
     let owner_mode = resolve_owner_mode(&state, request.owner_mode)?;
     let stored = state
         .session_store
         .create_session(&principal, request, owner_mode)
         .await
         .map_err(map_session_store_error)?;
+    if let Err(error) = state
+        .recording_lifecycle
+        .ensure_auto_recording(&stored)
+        .await
+    {
+        let _ = state
+            .session_store
+            .stop_session_for_owner(&principal, stored.id)
+            .await;
+        state.session_manager.release(stored.id).await;
+        state.registry.remove_session(stored.id).await;
+        return Err(map_recording_lifecycle_error(error));
+    }
 
     schedule_idle_session_stop(
         stored.id,
@@ -110,6 +164,7 @@ async fn create_session(
         state.registry.clone(),
         state.session_store.clone(),
         state.session_manager.clone(),
+        state.recording_lifecycle.clone(),
     );
 
     Ok((
@@ -145,6 +200,262 @@ async fn get_session(
     let stored = authorize_visible_session_request(&headers, &state, session_id).await?;
 
     Ok(Json(session_resource(&state, &stored, None)))
+}
+
+async fn list_session_recordings(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionRecordingListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let recordings = state
+        .session_store
+        .list_recordings_for_session(session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .into_iter()
+        .map(|recording| recording.to_resource())
+        .collect();
+
+    Ok(Json(SessionRecordingListResponse { recordings }))
+}
+
+async fn create_session_recording(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<(StatusCode, Json<SessionRecordingResource>), (StatusCode, Json<ErrorResponse>)> {
+    let session = authorize_runtime_session_request(&headers, &state, session_id).await?;
+    if session.recording.mode == SessionRecordingMode::Disabled {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: format!("recording is disabled for session {session_id}"),
+            }),
+        ));
+    }
+
+    let recording = state
+        .session_store
+        .create_recording_for_session(session_id, session.recording.format, None)
+        .await
+        .map_err(map_session_store_error)?;
+
+    Ok((StatusCode::CREATED, Json(recording.to_resource())))
+}
+
+async fn get_session_recording(
+    headers: HeaderMap,
+    Path((session_id, recording_id)): Path<(Uuid, Uuid)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionRecordingResource>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let recording = load_session_recording(&state, session_id, recording_id).await?;
+    Ok(Json(recording.to_resource()))
+}
+
+async fn stop_session_recording(
+    headers: HeaderMap,
+    Path((session_id, recording_id)): Path<(Uuid, Uuid)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionRecordingResource>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_runtime_session_request(&headers, &state, session_id).await?;
+    let recording = state
+        .session_store
+        .stop_recording_for_session(
+            session_id,
+            recording_id,
+            SessionRecordingTerminationReason::ManualStop,
+        )
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!(
+                        "recording {recording_id} was not found for session {session_id}"
+                    ),
+                }),
+            )
+        })?;
+    Ok(Json(recording.to_resource()))
+}
+
+async fn complete_session_recording(
+    headers: HeaderMap,
+    Path((session_id, recording_id)): Path<(Uuid, Uuid)>,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<CompleteSessionRecordingRequest>,
+) -> Result<Json<SessionRecordingResource>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let recording = load_session_recording(&state, session_id, recording_id).await?;
+    let CompleteSessionRecordingRequest {
+        source_path,
+        mime_type,
+        bytes,
+        duration_ms,
+    } = request;
+    let stored_artifact = state
+        .recording_artifact_store
+        .finalize(FinalizeRecordingArtifactRequest {
+            session_id,
+            recording_id,
+            format: recording.format,
+            source_path,
+        })
+        .await
+        .map_err(map_recording_artifact_store_error)?;
+    let recording = state
+        .session_store
+        .complete_recording_for_session(
+            session_id,
+            recording_id,
+            PersistCompletedSessionRecordingRequest {
+                artifact_ref: stored_artifact.artifact_ref.clone(),
+                mime_type,
+                bytes,
+                duration_ms,
+            },
+        )
+        .await
+        .map_err(|error| {
+            let artifact_store = state.recording_artifact_store.clone();
+            let artifact_ref = stored_artifact.artifact_ref.clone();
+            tokio::spawn(async move {
+                let _ = artifact_store.delete(&artifact_ref).await;
+            });
+            map_session_store_error(error)
+        })?
+        .ok_or_else(|| {
+            let artifact_store = state.recording_artifact_store.clone();
+            let artifact_ref = stored_artifact.artifact_ref.clone();
+            tokio::spawn(async move {
+                let _ = artifact_store.delete(&artifact_ref).await;
+            });
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!(
+                        "recording {recording_id} was not found for session {session_id}"
+                    ),
+                }),
+            )
+        })?;
+    Ok(Json(recording.to_resource()))
+}
+
+async fn fail_session_recording(
+    headers: HeaderMap,
+    Path((session_id, recording_id)): Path<(Uuid, Uuid)>,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<FailSessionRecordingRequest>,
+) -> Result<Json<SessionRecordingResource>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let recording = state
+        .session_store
+        .fail_recording_for_session(session_id, recording_id, request)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!(
+                        "recording {recording_id} was not found for session {session_id}"
+                    ),
+                }),
+            )
+        })?;
+    Ok(Json(recording.to_resource()))
+}
+
+async fn get_session_recording_content(
+    headers: HeaderMap,
+    Path((session_id, recording_id)): Path<(Uuid, Uuid)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let recording = load_session_recording(&state, session_id, recording_id).await?;
+    let artifact_ref = recording.artifact_ref.as_ref().ok_or_else(|| {
+        if recording.state.is_terminal() {
+            (
+                StatusCode::GONE,
+                Json(ErrorResponse {
+                    error: format!("recording artifact for {recording_id} is no longer available"),
+                }),
+            )
+        } else {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("recording {recording_id} does not have an artifact yet"),
+                }),
+            )
+        }
+    })?;
+    let bytes = state
+        .recording_artifact_store
+        .read(artifact_ref)
+        .await
+        .map_err(|error| match error.io_kind() {
+            Some(std::io::ErrorKind::NotFound) => (
+                StatusCode::GONE,
+                Json(ErrorResponse {
+                    error: format!("recording artifact for {recording_id} is no longer available"),
+                }),
+            ),
+            _ => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse {
+                    error: format!("failed to read recording artifact: {error}"),
+                }),
+            ),
+        })?;
+
+    let filename = format!("browserpane-{session_id}-{recording_id}.webm");
+    let mime_type = recording
+        .mime_type
+        .as_deref()
+        .unwrap_or(recording_mime_type(recording.format));
+
+    let mut response = Response::new(axum::body::Body::from(bytes.clone()));
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(mime_type).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("failed to encode content type header: {error}"),
+                }),
+            )
+        })?,
+    );
+    response.headers_mut().insert(
+        CONTENT_LENGTH,
+        HeaderValue::from_str(&bytes.len().to_string()).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("failed to encode content length header: {error}"),
+                }),
+            )
+        })?,
+    );
+    response.headers_mut().insert(
+        CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\"")).map_err(
+            |error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("failed to encode content disposition header: {error}"),
+                    }),
+                )
+            },
+        )?,
+    );
+    Ok(response)
 }
 
 async fn set_automation_owner(
@@ -219,8 +530,9 @@ async fn issue_session_access_token(
                 }),
             )
         })?;
+    let was_stopped = stored.state == SessionLifecycleState::Stopped;
 
-    let connectable = if stored.state == SessionLifecycleState::Stopped {
+    let connectable = if was_stopped {
         let prepared = state
             .session_store
             .prepare_session_for_connect(session_id)
@@ -240,11 +552,25 @@ async fn issue_session_access_token(
             state.registry.clone(),
             state.session_store.clone(),
             state.session_manager.clone(),
+            state.recording_lifecycle.clone(),
         );
         prepared
     } else {
         stored
     };
+
+    if let Err(error) = state
+        .recording_lifecycle
+        .ensure_auto_recording(&connectable)
+        .await
+    {
+        if was_stopped {
+            let _ = state.session_store.stop_session_if_idle(session_id).await;
+            state.session_manager.release(session_id).await;
+            state.registry.remove_session(session_id).await;
+        }
+        return Err(map_recording_lifecycle_error(error));
+    }
 
     if !connectable.state.is_runtime_candidate() {
         return Err((
@@ -285,7 +611,7 @@ async fn get_session_status(
     Path(session_id): Path<Uuid>,
     State(state): State<Arc<ApiState>>,
 ) -> Result<Json<SessionStatus>, (StatusCode, Json<ErrorResponse>)> {
-    let _session = authorize_runtime_session_request(&headers, &state, session_id).await?;
+    let session = authorize_runtime_session_request(&headers, &state, session_id).await?;
     let hub = state
         .registry
         .ensure_hub_for_session(
@@ -302,8 +628,17 @@ async fn get_session_status(
             )
         })?;
     let snapshot = hub.telemetry_snapshot().await;
+    let latest_recording = state
+        .session_store
+        .get_latest_recording_for_session(session_id)
+        .await
+        .map_err(map_session_store_error)?;
 
-    Ok(Json(session_status_from_snapshot(snapshot)))
+    Ok(Json(session_status_from_snapshot(
+        snapshot,
+        &session.recording,
+        latest_recording.as_ref(),
+    )))
 }
 
 async fn delete_session(
@@ -360,6 +695,13 @@ async fn delete_session(
             )
         })?;
 
+    if let Err(error) = state
+        .recording_lifecycle
+        .request_stop_and_wait(session_id, SessionRecordingTerminationReason::SessionStop)
+        .await
+    {
+        info!(%session_id, "recording finalization before session stop returned: {error}");
+    }
     state.session_manager.release(session_id).await;
     state.registry.remove_session(session_id).await;
 
@@ -386,6 +728,19 @@ async fn session_status(
     let runtime = resolve_runtime_compat(&state, session_id)
         .await
         .map_err(map_runtime_compat_status)?;
+    let session = state
+        .session_store
+        .get_session_by_id(session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
     let hub = state
         .registry
         .ensure_hub_for_session(session_id, &runtime.agent_socket_path)
@@ -399,11 +754,24 @@ async fn session_status(
             )
         })?;
     let snapshot = hub.telemetry_snapshot().await;
+    let latest_recording = state
+        .session_store
+        .get_latest_recording_for_session(session_id)
+        .await
+        .map_err(map_session_store_error)?;
 
-    Ok(Json(session_status_from_snapshot(snapshot)))
+    Ok(Json(session_status_from_snapshot(
+        snapshot,
+        &session.recording,
+        latest_recording.as_ref(),
+    )))
 }
 
-fn session_status_from_snapshot(snapshot: SessionTelemetrySnapshot) -> SessionStatus {
+fn session_status_from_snapshot(
+    snapshot: SessionTelemetrySnapshot,
+    recording_policy: &SessionRecordingPolicy,
+    latest_recording: Option<&StoredSessionRecording>,
+) -> SessionStatus {
     SessionStatus {
         browser_clients: snapshot.browser_clients,
         viewer_clients: snapshot.viewer_clients,
@@ -413,6 +781,7 @@ fn session_status_from_snapshot(snapshot: SessionTelemetrySnapshot) -> SessionSt
         exclusive_browser_owner: snapshot.exclusive_browser_owner,
         mcp_owner: snapshot.mcp_owner,
         resolution: snapshot.resolution,
+        recording: recording_status_from_snapshot(snapshot, recording_policy, latest_recording),
         telemetry: SessionTelemetry {
             joins_accepted: snapshot.joins_accepted,
             joins_rejected_viewer_cap: snapshot.joins_rejected_viewer_cap,
@@ -431,6 +800,44 @@ fn session_status_from_snapshot(snapshot: SessionTelemetrySnapshot) -> SessionSt
             egress_lagged_receives_total: snapshot.egress_lagged_receives_total,
             egress_lagged_frames_total: snapshot.egress_lagged_frames_total,
         },
+    }
+}
+
+fn recording_status_from_snapshot(
+    snapshot: SessionTelemetrySnapshot,
+    recording_policy: &SessionRecordingPolicy,
+    latest_recording: Option<&StoredSessionRecording>,
+) -> SessionRecordingStatus {
+    let active_recording_id = latest_recording
+        .filter(|recording| recording.state.is_active())
+        .map(|recording| recording.id.to_string());
+    let state = if let Some(recording) = latest_recording {
+        match recording.state {
+            SessionRecordingState::Starting | SessionRecordingState::Recording => {
+                SessionRecordingStatusState::Recording
+            }
+            SessionRecordingState::Finalizing => SessionRecordingStatusState::Finalizing,
+            SessionRecordingState::Ready => SessionRecordingStatusState::Ready,
+            SessionRecordingState::Failed => SessionRecordingStatusState::Failed,
+        }
+    } else if recording_policy.mode == SessionRecordingMode::Disabled {
+        SessionRecordingStatusState::Disabled
+    } else if snapshot.recorder_clients > 0 {
+        SessionRecordingStatusState::Recording
+    } else {
+        SessionRecordingStatusState::Idle
+    };
+
+    SessionRecordingStatus {
+        configured_mode: recording_policy.mode,
+        format: recording_policy.format,
+        retention_sec: recording_policy.retention_sec,
+        state,
+        active_recording_id,
+        recorder_attached: snapshot.recorder_clients > 0,
+        started_at: latest_recording.map(|recording| recording.started_at),
+        bytes_written: latest_recording.and_then(|recording| recording.bytes),
+        duration_ms: latest_recording.and_then(|recording| recording.duration_ms),
     }
 }
 
@@ -539,6 +946,7 @@ async fn clear_mcp_owner(
             state.registry.clone(),
             state.session_store.clone(),
             state.session_manager.clone(),
+            state.recording_lifecycle.clone(),
         );
     }
 
@@ -576,6 +984,7 @@ async fn clear_session_mcp_owner(
             state.registry.clone(),
             state.session_store.clone(),
             state.session_manager.clone(),
+            state.recording_lifecycle.clone(),
         );
     }
 
@@ -590,6 +999,8 @@ pub async fn run_api_server(
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
     session_manager: Arc<SessionManager>,
+    recording_artifact_store: Arc<RecordingArtifactStore>,
+    recording_lifecycle: Arc<RecordingLifecycleManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
     default_owner_mode: SessionOwnerMode,
@@ -600,6 +1011,8 @@ pub async fn run_api_server(
         connect_ticket_manager,
         session_store,
         session_manager,
+        recording_artifact_store,
+        recording_lifecycle,
         idle_stop_timeout,
         public_gateway_url,
         default_owner_mode,
@@ -657,6 +1070,30 @@ fn build_api_router(state: Arc<ApiState>) -> Router {
             get(get_session).delete(delete_session),
         )
         .route(
+            "/api/v1/sessions/{session_id}/recordings",
+            post(create_session_recording).get(list_session_recordings),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recordings/{recording_id}",
+            get(get_session_recording),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recordings/{recording_id}/stop",
+            post(stop_session_recording),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recordings/{recording_id}/complete",
+            post(complete_session_recording),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recordings/{recording_id}/fail",
+            post(fail_session_recording),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recordings/{recording_id}/content",
+            get(get_session_recording_content),
+        )
+        .route(
             "/api/v1/sessions/{session_id}/access-tokens",
             post(issue_session_access_token),
         )
@@ -705,6 +1142,12 @@ fn map_session_store_error(error: SessionStoreError) -> (StatusCode, Json<ErrorR
                 error: error.to_string(),
             }),
         ),
+        SessionStoreError::Conflict(_) => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
         SessionStoreError::InvalidRequest(_) => (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
@@ -712,6 +1155,47 @@ fn map_session_store_error(error: SessionStoreError) -> (StatusCode, Json<ErrorR
             }),
         ),
         SessionStoreError::Backend(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+    }
+}
+
+fn map_recording_artifact_store_error(
+    error: RecordingArtifactStoreError,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match error {
+        RecordingArtifactStoreError::InvalidSourcePath(_)
+        | RecordingArtifactStoreError::InvalidReference(_) => (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+        RecordingArtifactStoreError::Backend(_) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+    }
+}
+
+fn map_recording_lifecycle_error(
+    error: RecordingLifecycleError,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match error {
+        RecordingLifecycleError::Disabled(_) => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+        RecordingLifecycleError::InvalidConfiguration(_)
+        | RecordingLifecycleError::LaunchFailed(_)
+        | RecordingLifecycleError::Store(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
             Json(ErrorResponse {
                 error: error.to_string(),
@@ -746,6 +1230,28 @@ async fn authorize_runtime_session_request(
     }
 
     Ok(session)
+}
+
+async fn load_session_recording(
+    state: &ApiState,
+    session_id: Uuid,
+    recording_id: Uuid,
+) -> Result<StoredSessionRecording, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .session_store
+        .get_recording_for_session(session_id, recording_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!(
+                        "recording {recording_id} was not found for session {session_id}"
+                    ),
+                }),
+            )
+        })
 }
 
 async fn authorize_visible_session_request(
@@ -789,6 +1295,12 @@ fn should_block_session_stop(
     runtime_in_use: bool,
 ) -> bool {
     supports_legacy_global_routes && state.is_runtime_candidate() && runtime_in_use
+}
+
+fn recording_mime_type(format: SessionRecordingFormat) -> &'static str {
+    match format {
+        SessionRecordingFormat::Webm => "video/webm",
+    }
 }
 
 async fn resolve_runtime(

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -7,6 +7,7 @@ use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 use uuid::Uuid;
@@ -18,6 +19,11 @@ use crate::recording_artifact_store::{
     FinalizeRecordingArtifactRequest, RecordingArtifactStore, RecordingArtifactStoreError,
 };
 use crate::recording_lifecycle::{RecordingLifecycleError, RecordingLifecycleManager};
+use crate::recording_observability::{RecordingObservability, RecordingObservabilitySnapshot};
+use crate::recording_playback::{
+    prepare_session_recording_playback, PreparedSessionRecordingPlayback, RecordingPlaybackError,
+    SessionRecordingPlaybackManifest, SessionRecordingPlaybackResource,
+};
 use crate::session_control::{
     CompleteSessionRecordingRequest, CreateSessionRequest, FailSessionRecordingRequest,
     PersistCompletedSessionRecordingRequest, SessionLifecycleState, SessionListResponse,
@@ -38,6 +44,7 @@ struct ApiState {
     session_store: SessionStore,
     session_manager: Arc<SessionManager>,
     recording_artifact_store: Arc<RecordingArtifactStore>,
+    recording_observability: Arc<RecordingObservability>,
     recording_lifecycle: Arc<RecordingLifecycleManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
@@ -55,6 +62,7 @@ struct SessionStatus {
     mcp_owner: bool,
     resolution: (u16, u16),
     recording: SessionRecordingStatus,
+    playback: SessionRecordingPlaybackResource,
     telemetry: SessionTelemetry,
 }
 
@@ -296,6 +304,9 @@ async fn complete_session_recording(
         bytes,
         duration_ms,
     } = request;
+    state
+        .recording_observability
+        .record_artifact_finalize_request();
     let stored_artifact = state
         .recording_artifact_store
         .finalize(FinalizeRecordingArtifactRequest {
@@ -305,7 +316,12 @@ async fn complete_session_recording(
             source_path,
         })
         .await
-        .map_err(map_recording_artifact_store_error)?;
+        .map_err(|error| {
+            state
+                .recording_observability
+                .record_artifact_finalize_failure();
+            map_recording_artifact_store_error(error)
+        })?;
     let recording = state
         .session_store
         .complete_recording_for_session(
@@ -325,6 +341,9 @@ async fn complete_session_recording(
             tokio::spawn(async move {
                 let _ = artifact_store.delete(&artifact_ref).await;
             });
+            state
+                .recording_observability
+                .record_artifact_finalize_failure();
             map_session_store_error(error)
         })?
         .ok_or_else(|| {
@@ -333,6 +352,9 @@ async fn complete_session_recording(
             tokio::spawn(async move {
                 let _ = artifact_store.delete(&artifact_ref).await;
             });
+            state
+                .recording_observability
+                .record_artifact_finalize_failure();
             (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {
@@ -342,6 +364,9 @@ async fn complete_session_recording(
                 }),
             )
         })?;
+    state
+        .recording_observability
+        .record_artifact_finalize_success();
     Ok(Json(recording.to_resource()))
 }
 
@@ -367,6 +392,7 @@ async fn fail_session_recording(
                 }),
             )
         })?;
+    state.recording_observability.record_recording_failure();
     Ok(Json(recording.to_resource()))
 }
 
@@ -456,6 +482,95 @@ async fn get_session_recording_content(
         )?,
     );
     Ok(response)
+}
+
+async fn get_session_recording_playback(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionRecordingPlaybackResource>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    let playback = load_session_recording_playback(&state, session_id).await?;
+    Ok(Json(playback.resource))
+}
+
+async fn get_session_recording_playback_manifest(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionRecordingPlaybackManifest>, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    state
+        .recording_observability
+        .record_playback_manifest_request();
+    let playback = load_session_recording_playback(&state, session_id).await?;
+    Ok(Json(playback.manifest))
+}
+
+async fn get_session_recording_playback_export(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let _session = authorize_visible_session_request(&headers, &state, session_id).await?;
+    state
+        .recording_observability
+        .record_playback_export_request();
+    let playback = load_session_recording_playback(&state, session_id).await?;
+    let bytes = playback
+        .export_bundle(&state.recording_artifact_store)
+        .await
+        .map_err(|error| {
+            state
+                .recording_observability
+                .record_playback_export_failure();
+            map_recording_playback_error(error)
+        })?;
+    state
+        .recording_observability
+        .record_playback_export_success(bytes.len() as u64, Utc::now())
+        .await;
+
+    let filename = format!("browserpane-{session_id}-recording-playback.zip");
+    let mut response = Response::new(axum::body::Body::from(bytes.clone()));
+    response
+        .headers_mut()
+        .insert(CONTENT_TYPE, HeaderValue::from_static("application/zip"));
+    response.headers_mut().insert(
+        CONTENT_LENGTH,
+        HeaderValue::from_str(&bytes.len().to_string()).map_err(|error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("failed to encode content length header: {error}"),
+                }),
+            )
+        })?,
+    );
+    response.headers_mut().insert(
+        CONTENT_DISPOSITION,
+        HeaderValue::from_str(&format!("attachment; filename=\"{filename}\"")).map_err(
+            |error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse {
+                        error: format!("failed to encode content disposition header: {error}"),
+                    }),
+                )
+            },
+        )?,
+    );
+    Ok(response)
+}
+
+async fn get_recording_operations(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<RecordingObservabilitySnapshot>, (StatusCode, Json<ErrorResponse>)> {
+    authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    Ok(Json(state.recording_observability.snapshot().await))
 }
 
 async fn set_automation_owner(
@@ -628,16 +743,19 @@ async fn get_session_status(
             )
         })?;
     let snapshot = hub.telemetry_snapshot().await;
-    let latest_recording = state
+    let recordings = state
         .session_store
-        .get_latest_recording_for_session(session_id)
+        .list_recordings_for_session(session_id)
         .await
         .map_err(map_session_store_error)?;
+    let latest_recording = latest_recording(&recordings);
+    let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
 
     Ok(Json(session_status_from_snapshot(
         snapshot,
         &session.recording,
-        latest_recording.as_ref(),
+        latest_recording,
+        playback.resource,
     )))
 }
 
@@ -754,16 +872,19 @@ async fn session_status(
             )
         })?;
     let snapshot = hub.telemetry_snapshot().await;
-    let latest_recording = state
+    let recordings = state
         .session_store
-        .get_latest_recording_for_session(session_id)
+        .list_recordings_for_session(session_id)
         .await
         .map_err(map_session_store_error)?;
+    let latest_recording = latest_recording(&recordings);
+    let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
 
     Ok(Json(session_status_from_snapshot(
         snapshot,
         &session.recording,
-        latest_recording.as_ref(),
+        latest_recording,
+        playback.resource,
     )))
 }
 
@@ -771,6 +892,7 @@ fn session_status_from_snapshot(
     snapshot: SessionTelemetrySnapshot,
     recording_policy: &SessionRecordingPolicy,
     latest_recording: Option<&StoredSessionRecording>,
+    playback: SessionRecordingPlaybackResource,
 ) -> SessionStatus {
     SessionStatus {
         browser_clients: snapshot.browser_clients,
@@ -782,6 +904,7 @@ fn session_status_from_snapshot(
         mcp_owner: snapshot.mcp_owner,
         resolution: snapshot.resolution,
         recording: recording_status_from_snapshot(snapshot, recording_policy, latest_recording),
+        playback,
         telemetry: SessionTelemetry {
             joins_accepted: snapshot.joins_accepted,
             joins_rejected_viewer_cap: snapshot.joins_rejected_viewer_cap,
@@ -1000,6 +1123,7 @@ pub async fn run_api_server(
     session_store: SessionStore,
     session_manager: Arc<SessionManager>,
     recording_artifact_store: Arc<RecordingArtifactStore>,
+    recording_observability: Arc<RecordingObservability>,
     recording_lifecycle: Arc<RecordingLifecycleManager>,
     idle_stop_timeout: std::time::Duration,
     public_gateway_url: String,
@@ -1012,6 +1136,7 @@ pub async fn run_api_server(
         session_store,
         session_manager,
         recording_artifact_store,
+        recording_observability,
         recording_lifecycle,
         idle_stop_timeout,
         public_gateway_url,
@@ -1094,6 +1219,18 @@ fn build_api_router(state: Arc<ApiState>) -> Router {
             get(get_session_recording_content),
         )
         .route(
+            "/api/v1/sessions/{session_id}/recording-playback",
+            get(get_session_recording_playback),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recording-playback/manifest",
+            get(get_session_recording_playback_manifest),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/recording-playback/export",
+            get(get_session_recording_playback_export),
+        )
+        .route(
             "/api/v1/sessions/{session_id}/access-tokens",
             post(issue_session_access_token),
         )
@@ -1108,6 +1245,10 @@ fn build_api_router(state: Arc<ApiState>) -> Router {
         .route(
             "/api/v1/sessions/{session_id}/mcp-owner",
             post(set_session_mcp_owner).delete(clear_session_mcp_owner),
+        )
+        .route(
+            "/api/v1/recording/operations",
+            get(get_recording_operations),
         )
         .route("/api/session/status", get(session_status))
         .route("/api/session/mcp-owner", post(set_mcp_owner))
@@ -1176,6 +1317,38 @@ fn map_recording_artifact_store_error(
         ),
         RecordingArtifactStoreError::Backend(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+    }
+}
+
+fn map_recording_playback_error(
+    error: RecordingPlaybackError,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match error {
+        RecordingPlaybackError::Empty => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: error.to_string(),
+            }),
+        ),
+        RecordingPlaybackError::Artifact(RecordingArtifactStoreError::Backend(inner))
+            if inner.kind() == std::io::ErrorKind::NotFound =>
+        {
+            (
+                StatusCode::GONE,
+                Json(ErrorResponse {
+                    error: "a playback segment artifact is no longer available".to_string(),
+                }),
+            )
+        }
+        RecordingPlaybackError::Artifact(inner) => map_recording_artifact_store_error(inner),
+        RecordingPlaybackError::ManifestEncode(_)
+        | RecordingPlaybackError::Io(_)
+        | RecordingPlaybackError::Package(_) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(ErrorResponse {
                 error: error.to_string(),
             }),
@@ -1252,6 +1425,30 @@ async fn load_session_recording(
                 }),
             )
         })
+}
+
+async fn load_session_recording_playback(
+    state: &ApiState,
+    session_id: Uuid,
+) -> Result<PreparedSessionRecordingPlayback, (StatusCode, Json<ErrorResponse>)> {
+    let recordings = state
+        .session_store
+        .list_recordings_for_session(session_id)
+        .await
+        .map_err(map_session_store_error)?;
+    Ok(prepare_session_recording_playback(
+        session_id,
+        &recordings,
+        Utc::now(),
+    ))
+}
+
+fn latest_recording(recordings: &[StoredSessionRecording]) -> Option<&StoredSessionRecording> {
+    recordings.iter().max_by(|left, right| {
+        left.updated_at
+            .cmp(&right.updated_at)
+            .then_with(|| left.created_at.cmp(&right.created_at))
+    })
 }
 
 async fn authorize_visible_session_request(

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -36,6 +36,7 @@ struct ApiState {
 struct SessionStatus {
     browser_clients: u32,
     viewer_clients: u32,
+    recorder_clients: u32,
     max_viewers: u32,
     viewer_slots_remaining: u32,
     exclusive_browser_owner: bool,
@@ -406,6 +407,7 @@ fn session_status_from_snapshot(snapshot: SessionTelemetrySnapshot) -> SessionSt
     SessionStatus {
         browser_clients: snapshot.browser_clients,
         viewer_clients: snapshot.viewer_clients,
+        recorder_clients: snapshot.recorder_clients,
         max_viewers: snapshot.max_viewers,
         viewer_slots_remaining: snapshot.viewer_slots_remaining,
         exclusive_browser_owner: snapshot.exclusive_browser_owner,

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -11,6 +11,8 @@ use crate::auth::AuthValidator;
 use crate::connect_ticket::SessionConnectTicketManager;
 use crate::recording_artifact_store::RecordingArtifactStore;
 use crate::recording_lifecycle::RecordingLifecycleManager;
+use crate::recording_observability::RecordingObservability;
+use crate::recording_playback::prepare_session_recording_playback;
 use crate::recording_retention::RecordingRetentionManager;
 use crate::session_control::{
     SessionRecordingFormat, SessionRecordingMode, SessionRecordingPolicy,
@@ -40,6 +42,7 @@ fn test_router() -> (Router, String) {
             .unwrap(),
         ),
         recording_artifact_store: test_artifact_store(),
+        recording_observability: Arc::new(RecordingObservability::default()),
         recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
@@ -99,6 +102,25 @@ fn blocking_session_stop_only_applies_to_legacy_runtime_backends() {
 
 #[test]
 fn session_status_maps_recorder_clients() {
+    let latest_recording = StoredSessionRecording {
+        id: uuid::Uuid::now_v7(),
+        session_id: uuid::Uuid::now_v7(),
+        previous_recording_id: None,
+        state: StoredSessionRecordingState::Recording,
+        format: SessionRecordingFormat::Webm,
+        mime_type: Some("video/webm".to_string()),
+        bytes: Some(4096),
+        duration_ms: Some(1200),
+        error: None,
+        termination_reason: None,
+        artifact_ref: None,
+        started_at: chrono::Utc::now(),
+        completed_at: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    let playback =
+        prepare_session_recording_playback(latest_recording.session_id, &[], chrono::Utc::now());
     let status = session_status_from_snapshot(
         SessionTelemetrySnapshot {
             browser_clients: 3,
@@ -130,23 +152,8 @@ fn session_status_maps_recorder_clients() {
             format: SessionRecordingFormat::Webm,
             retention_sec: Some(86_400),
         },
-        Some(&StoredSessionRecording {
-            id: uuid::Uuid::now_v7(),
-            session_id: uuid::Uuid::now_v7(),
-            previous_recording_id: None,
-            state: StoredSessionRecordingState::Recording,
-            format: SessionRecordingFormat::Webm,
-            mime_type: Some("video/webm".to_string()),
-            bytes: Some(4096),
-            duration_ms: Some(1200),
-            error: None,
-            termination_reason: None,
-            artifact_ref: None,
-            started_at: chrono::Utc::now(),
-            completed_at: None,
-            created_at: chrono::Utc::now(),
-            updated_at: chrono::Utc::now(),
-        }),
+        Some(&latest_recording),
+        playback.resource,
     );
 
     assert_eq!(status.browser_clients, 3);
@@ -594,6 +601,443 @@ async fn recording_failure_updates_metadata_state() {
 }
 
 #[tokio::test]
+async fn playback_manifest_and_export_bundle_follow_ready_segments() {
+    let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
+    let token = auth_validator.generate_token().unwrap();
+    let session_store = SessionStore::in_memory();
+    let artifact_store = test_artifact_store();
+    let state = Arc::new(ApiState {
+        registry: Arc::new(SessionRegistry::new(10, false)),
+        auth_validator,
+        connect_ticket_manager: Arc::new(SessionConnectTicketManager::new(
+            vec![5; 32],
+            Duration::from_secs(300),
+        )),
+        session_store: session_store.clone(),
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
+                agent_socket_path: "/tmp/test.sock".to_string(),
+                cdp_endpoint: Some("http://host:9223".to_string()),
+                idle_timeout: Duration::from_secs(300),
+            })
+            .unwrap(),
+        ),
+        recording_artifact_store: artifact_store.clone(),
+        recording_observability: Arc::new(RecordingObservability::default()),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
+        idle_stop_timeout: Duration::from_secs(300),
+        public_gateway_url: "https://localhost:4433".to_string(),
+        default_owner_mode: SessionOwnerMode::Collaborative,
+    });
+    let app = build_api_router(state);
+
+    let create_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "recording": {
+                          "mode": "manual",
+                          "format": "webm"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let session = response_json(create_session_response).await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let create_first_recording = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let first_recording = response_json(create_first_recording).await;
+    let first_recording_id = first_recording["id"].as_str().unwrap().to_string();
+
+    let stop_first_recording = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{first_recording_id}/stop"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stop_first_recording.status(), StatusCode::OK);
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let artifact_path = temp_dir.path().join("segment-1.webm");
+    std::fs::write(&artifact_path, b"segment-one").unwrap();
+    let complete_first_recording = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{first_recording_id}/complete"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "source_path": artifact_path.to_string_lossy(),
+                        "mime_type": "video/webm",
+                        "bytes": 11,
+                        "duration_ms": 900
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(complete_first_recording.status(), StatusCode::OK);
+
+    let create_second_recording = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let second_recording = response_json(create_second_recording).await;
+    let second_recording_id = second_recording["id"].as_str().unwrap().to_string();
+
+    let fail_second_recording = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{second_recording_id}/fail"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "error": "recorder worker crashed",
+                        "termination_reason": "worker_exit"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fail_second_recording.status(), StatusCode::OK);
+
+    let playback_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}/recording-playback"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(playback_response.status(), StatusCode::OK);
+    let playback = response_json(playback_response).await;
+    assert_eq!(playback["state"], "partial");
+    assert_eq!(playback["segment_count"], 2);
+    assert_eq!(playback["included_segment_count"], 1);
+    assert_eq!(playback["failed_segment_count"], 1);
+    assert_eq!(playback["active_segment_count"], 0);
+    assert_eq!(playback["missing_artifact_segment_count"], 0);
+
+    let manifest_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recording-playback/manifest"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(manifest_response.status(), StatusCode::OK);
+    let manifest = response_json(manifest_response).await;
+    assert_eq!(
+        manifest["format_version"],
+        "browserpane_recording_playback_v1"
+    );
+    assert_eq!(manifest["segments"].as_array().unwrap().len(), 1);
+    assert_eq!(manifest["omitted_segments"].as_array().unwrap().len(), 1);
+    assert_eq!(manifest["omitted_segments"][0]["omitted_reason"], "failed");
+
+    let export_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recording-playback/export"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(export_response.status(), StatusCode::OK);
+    assert_eq!(
+        export_response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/zip"
+    );
+    let export_bytes = to_bytes(export_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let cursor = std::io::Cursor::new(export_bytes.to_vec());
+    let mut archive = zip::ZipArchive::new(cursor).unwrap();
+    let mut manifest_file = archive.by_name("manifest.json").unwrap();
+    let mut manifest_bytes = Vec::new();
+    use std::io::Read;
+    manifest_file.read_to_end(&mut manifest_bytes).unwrap();
+    drop(manifest_file);
+    let manifest_json: Value = serde_json::from_slice(&manifest_bytes).unwrap();
+    assert_eq!(manifest_json["segment_count"], 2);
+    assert!(archive.by_name("player.html").is_ok());
+    let segment_name = manifest_json["segments"][0]["file_name"].as_str().unwrap();
+    let mut segment_file = archive.by_name(segment_name).unwrap();
+    let mut segment_bytes = Vec::new();
+    segment_file.read_to_end(&mut segment_bytes).unwrap();
+    assert_eq!(segment_bytes.as_slice(), b"segment-one");
+}
+
+#[tokio::test]
+async fn recording_operations_snapshot_tracks_finalize_playback_and_failures() {
+    let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
+    let token = auth_validator.generate_token().unwrap();
+    let observability = Arc::new(RecordingObservability::default());
+    let state = Arc::new(ApiState {
+        registry: Arc::new(SessionRegistry::new(10, false)),
+        auth_validator,
+        connect_ticket_manager: Arc::new(SessionConnectTicketManager::new(
+            vec![5; 32],
+            Duration::from_secs(300),
+        )),
+        session_store: SessionStore::in_memory(),
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
+                agent_socket_path: "/tmp/test.sock".to_string(),
+                cdp_endpoint: Some("http://host:9223".to_string()),
+                idle_timeout: Duration::from_secs(300),
+            })
+            .unwrap(),
+        ),
+        recording_artifact_store: test_artifact_store(),
+        recording_observability: observability.clone(),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
+        idle_stop_timeout: Duration::from_secs(300),
+        public_gateway_url: "https://localhost:4433".to_string(),
+        default_owner_mode: SessionOwnerMode::Collaborative,
+    });
+    let app = build_api_router(state);
+
+    let session = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "recording": {
+                              "mode": "manual",
+                              "format": "webm"
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let recording = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let recording_id = recording["id"].as_str().unwrap().to_string();
+
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/stop"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let artifact_path = temp_dir.path().join("segment.webm");
+    std::fs::write(&artifact_path, b"segment").unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/complete"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "source_path": artifact_path.to_string_lossy(),
+                        "mime_type": "video/webm",
+                        "bytes": 7,
+                        "duration_ms": 700
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let failed_recording = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let failed_recording_id = failed_recording["id"].as_str().unwrap().to_string();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{failed_recording_id}/fail"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "error": "worker exited",
+                        "termination_reason": "worker_exit"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recording-playback/manifest"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recording-playback/export"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let operations_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/recording/operations")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(operations_response.status(), StatusCode::OK);
+    let operations = response_json(operations_response).await;
+    assert_eq!(operations["artifact_finalize_requests_total"], 1);
+    assert_eq!(operations["artifact_finalize_successes_total"], 1);
+    assert_eq!(operations["artifact_finalize_failures_total"], 0);
+    assert_eq!(operations["recording_failures_total"], 1);
+    assert_eq!(operations["playback_manifest_requests_total"], 1);
+    assert_eq!(operations["playback_export_requests_total"], 1);
+    assert_eq!(operations["playback_export_successes_total"], 1);
+    assert_eq!(operations["playback_export_failures_total"], 0);
+    assert!(operations["playback_export_bytes_total"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
 async fn expired_recording_artifacts_return_gone() {
     let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
     let token = auth_validator.generate_token().unwrap();
@@ -616,6 +1060,7 @@ async fn expired_recording_artifacts_return_gone() {
             .unwrap(),
         ),
         recording_artifact_store: artifact_store.clone(),
+        recording_observability: Arc::new(RecordingObservability::default()),
         recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
@@ -702,6 +1147,7 @@ async fn expired_recording_artifacts_return_gone() {
     let retention = RecordingRetentionManager::new(
         session_store.clone(),
         artifact_store,
+        Arc::new(RecordingObservability::default()),
         Duration::from_secs(60),
     );
     retention
@@ -866,6 +1312,7 @@ async fn scopes_session_resources_to_the_authenticated_owner() {
             .unwrap(),
         ),
         recording_artifact_store: test_artifact_store(),
+        recording_observability: Arc::new(RecordingObservability::default()),
         recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
@@ -928,6 +1375,7 @@ async fn rejects_session_scoped_runtime_routes_for_unknown_or_foreign_sessions_b
             .unwrap(),
         ),
         recording_artifact_store: test_artifact_store(),
+        recording_observability: Arc::new(RecordingObservability::default()),
         recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -9,6 +9,13 @@ use tower::ServiceExt;
 use super::*;
 use crate::auth::AuthValidator;
 use crate::connect_ticket::SessionConnectTicketManager;
+use crate::recording_artifact_store::RecordingArtifactStore;
+use crate::recording_lifecycle::RecordingLifecycleManager;
+use crate::recording_retention::RecordingRetentionManager;
+use crate::session_control::{
+    SessionRecordingFormat, SessionRecordingMode, SessionRecordingPolicy,
+    SessionRecordingState as StoredSessionRecordingState, StoredSessionRecording,
+};
 use crate::session_manager::{SessionManager, SessionManagerConfig};
 
 fn test_router() -> (Router, String) {
@@ -32,11 +39,18 @@ fn test_router() -> (Router, String) {
             })
             .unwrap(),
         ),
+        recording_artifact_store: test_artifact_store(),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
         default_owner_mode: SessionOwnerMode::Collaborative,
     });
     (build_api_router(state), token)
+}
+
+fn test_artifact_store() -> Arc<RecordingArtifactStore> {
+    let root = std::env::temp_dir().join(format!("bpane-artifacts-test-{}", uuid::Uuid::now_v7()));
+    Arc::new(RecordingArtifactStore::local_fs(root))
 }
 
 fn bearer(token: &str) -> String {
@@ -85,36 +99,74 @@ fn blocking_session_stop_only_applies_to_legacy_runtime_backends() {
 
 #[test]
 fn session_status_maps_recorder_clients() {
-    let status = session_status_from_snapshot(SessionTelemetrySnapshot {
-        browser_clients: 3,
-        viewer_clients: 1,
-        recorder_clients: 1,
-        max_viewers: 10,
-        viewer_slots_remaining: 9,
-        exclusive_browser_owner: false,
-        mcp_owner: false,
-        resolution: (1280, 720),
-        joins_accepted: 4,
-        joins_rejected_viewer_cap: 0,
-        last_join_latency_ms: 12,
-        average_join_latency_ms: 9.5,
-        max_join_latency_ms: 15,
-        full_refresh_requests: 1,
-        full_refresh_tiles_requested: 30,
-        last_full_refresh_tiles: 30,
-        max_full_refresh_tiles: 30,
-        egress_send_stream_lock_acquires_total: 10,
-        egress_send_stream_lock_wait_us_total: 20,
-        egress_send_stream_lock_wait_us_average: 2.0,
-        egress_send_stream_lock_wait_us_max: 6,
-        egress_lagged_receives_total: 0,
-        egress_lagged_frames_total: 0,
-    });
+    let status = session_status_from_snapshot(
+        SessionTelemetrySnapshot {
+            browser_clients: 3,
+            viewer_clients: 1,
+            recorder_clients: 1,
+            max_viewers: 10,
+            viewer_slots_remaining: 9,
+            exclusive_browser_owner: false,
+            mcp_owner: false,
+            resolution: (1280, 720),
+            joins_accepted: 4,
+            joins_rejected_viewer_cap: 0,
+            last_join_latency_ms: 12,
+            average_join_latency_ms: 9.5,
+            max_join_latency_ms: 15,
+            full_refresh_requests: 1,
+            full_refresh_tiles_requested: 30,
+            last_full_refresh_tiles: 30,
+            max_full_refresh_tiles: 30,
+            egress_send_stream_lock_acquires_total: 10,
+            egress_send_stream_lock_wait_us_total: 20,
+            egress_send_stream_lock_wait_us_average: 2.0,
+            egress_send_stream_lock_wait_us_max: 6,
+            egress_lagged_receives_total: 0,
+            egress_lagged_frames_total: 0,
+        },
+        &SessionRecordingPolicy {
+            mode: SessionRecordingMode::Manual,
+            format: SessionRecordingFormat::Webm,
+            retention_sec: Some(86_400),
+        },
+        Some(&StoredSessionRecording {
+            id: uuid::Uuid::now_v7(),
+            session_id: uuid::Uuid::now_v7(),
+            previous_recording_id: None,
+            state: StoredSessionRecordingState::Recording,
+            format: SessionRecordingFormat::Webm,
+            mime_type: Some("video/webm".to_string()),
+            bytes: Some(4096),
+            duration_ms: Some(1200),
+            error: None,
+            termination_reason: None,
+            artifact_ref: None,
+            started_at: chrono::Utc::now(),
+            completed_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }),
+    );
 
     assert_eq!(status.browser_clients, 3);
     assert_eq!(status.viewer_clients, 1);
     assert_eq!(status.recorder_clients, 1);
     assert_eq!(status.viewer_slots_remaining, 9);
+    assert_eq!(
+        status.recording.configured_mode,
+        SessionRecordingMode::Manual
+    );
+    assert_eq!(status.recording.format, SessionRecordingFormat::Webm);
+    assert_eq!(status.recording.retention_sec, Some(86_400));
+    assert!(matches!(
+        status.recording.state,
+        SessionRecordingStatusState::Recording
+    ));
+    assert!(status.recording.recorder_attached);
+    assert!(status.recording.active_recording_id.is_some());
+    assert_eq!(status.recording.bytes_written, Some(4096));
+    assert_eq!(status.recording.duration_ms, Some(1200));
 }
 
 #[tokio::test]
@@ -135,7 +187,12 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
                         "viewport": { "width": 1440, "height": 900 },
                         "idle_timeout_sec": 900,
                         "labels": { "suite": "contract" },
-                        "integration_context": { "ticket": "BPANE-6" }
+                        "integration_context": { "ticket": "BPANE-6" },
+                        "recording": {
+                          "mode": "manual",
+                          "format": "webm",
+                          "retention_sec": 86400
+                        }
                     })
                     .to_string(),
                 ))
@@ -165,6 +222,9 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
     assert!(created["owner"]["issuer"].is_string());
     assert_eq!(created["labels"]["suite"], "contract");
     assert_eq!(created["integration_context"]["ticket"], "BPANE-6");
+    assert_eq!(created["recording"]["mode"], "manual");
+    assert_eq!(created["recording"]["format"], "webm");
+    assert_eq!(created["recording"]["retention_sec"], 86400);
     assert_eq!(created["connect"]["gateway_url"], "https://localhost:4433");
     assert_eq!(created["connect"]["transport_path"], "/session");
     assert_eq!(created["connect"]["auth_type"], "session_connect_ticket");
@@ -217,6 +277,7 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
     let fetched = response_json(get_response).await;
     assert_eq!(fetched["id"], session_id);
     assert_eq!(fetched["labels"]["suite"], "contract");
+    assert_eq!(fetched["recording"]["mode"], "manual");
 
     let issue_response = app
         .clone()
@@ -265,6 +326,407 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
     assert_eq!(stopped["id"], session_id);
     assert_eq!(stopped["state"], "stopped");
     assert!(stopped["stopped_at"].is_string());
+}
+
+#[tokio::test]
+async fn rejects_always_mode_when_recording_worker_is_not_configured() {
+    let (app, token) = test_router();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "recording": {
+                          "mode": "always",
+                          "format": "webm"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let payload = response_json(response).await;
+    assert_eq!(
+        payload["error"],
+        "recording mode=always requires a configured recording worker"
+    );
+}
+
+#[tokio::test]
+async fn creates_lists_gets_and_stops_session_recording_metadata() {
+    let (app, token) = test_router();
+
+    let create_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "recording": {
+                          "mode": "manual",
+                          "format": "webm"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_session_response.status(), StatusCode::CREATED);
+    let session = response_json(create_session_response).await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let create_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_recording_response.status(), StatusCode::CREATED);
+    let created_recording = response_json(create_recording_response).await;
+    let recording_id = created_recording["id"].as_str().unwrap().to_string();
+    assert_eq!(created_recording["session_id"], session_id);
+    assert_eq!(created_recording["state"], "recording");
+    assert_eq!(created_recording["format"], "webm");
+    assert_eq!(created_recording["mime_type"], "video/webm");
+    assert!(created_recording["previous_recording_id"].is_null());
+    assert!(created_recording["termination_reason"].is_null());
+    assert_eq!(
+        created_recording["content_path"],
+        format!("/api/v1/sessions/{session_id}/recordings/{recording_id}/content")
+    );
+    assert_eq!(created_recording["artifact_available"], false);
+
+    let list_recordings_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_recordings_response.status(), StatusCode::OK);
+    let recordings = response_json(list_recordings_response).await;
+    assert_eq!(recordings["recordings"].as_array().unwrap().len(), 1);
+    assert_eq!(recordings["recordings"][0]["id"], recording_id);
+
+    let get_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_recording_response.status(), StatusCode::OK);
+    let fetched_recording = response_json(get_recording_response).await;
+    assert_eq!(fetched_recording["id"], recording_id);
+    assert_eq!(fetched_recording["state"], "recording");
+
+    let stop_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/stop"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stop_recording_response.status(), StatusCode::OK);
+    let stopped_recording = response_json(stop_recording_response).await;
+    assert_eq!(stopped_recording["state"], "finalizing");
+    assert_eq!(stopped_recording["termination_reason"], "manual_stop");
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let artifact_path = temp_dir.path().join("recording.webm");
+    std::fs::write(&artifact_path, b"webm-bytes").unwrap();
+
+    let complete_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/complete"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                      "source_path": artifact_path.to_string_lossy(),
+                      "mime_type": "video/webm",
+                      "bytes": 10,
+                      "duration_ms": 2500
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(complete_recording_response.status(), StatusCode::OK);
+    let completed_recording = response_json(complete_recording_response).await;
+    assert_eq!(completed_recording["state"], "ready");
+    assert_eq!(completed_recording["artifact_available"], true);
+    assert_eq!(completed_recording["bytes"], 10);
+    assert_eq!(completed_recording["duration_ms"], 2500);
+
+    let content_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/content"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(content_response.status(), StatusCode::OK);
+    let content_bytes = to_bytes(content_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(content_bytes.as_ref(), b"webm-bytes");
+}
+
+#[tokio::test]
+async fn recording_failure_updates_metadata_state() {
+    let (app, token) = test_router();
+
+    let create_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "recording": {
+                          "mode": "manual",
+                          "format": "webm"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let session = response_json(create_session_response).await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let create_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let recording = response_json(create_recording_response).await;
+    let recording_id = recording["id"].as_str().unwrap().to_string();
+
+    let fail_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/fail"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                      "error": "recorder worker crashed",
+                      "termination_reason": "worker_exit"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fail_response.status(), StatusCode::OK);
+    let failed = response_json(fail_response).await;
+    assert_eq!(failed["state"], "failed");
+    assert_eq!(failed["error"], "recorder worker crashed");
+    assert_eq!(failed["termination_reason"], "worker_exit");
+}
+
+#[tokio::test]
+async fn expired_recording_artifacts_return_gone() {
+    let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
+    let token = auth_validator.generate_token().unwrap();
+    let session_store = SessionStore::in_memory();
+    let artifact_store = test_artifact_store();
+    let state = Arc::new(ApiState {
+        registry: Arc::new(SessionRegistry::new(10, false)),
+        auth_validator,
+        connect_ticket_manager: Arc::new(SessionConnectTicketManager::new(
+            vec![5; 32],
+            Duration::from_secs(300),
+        )),
+        session_store: session_store.clone(),
+        session_manager: Arc::new(
+            SessionManager::new(SessionManagerConfig::StaticSingle {
+                agent_socket_path: "/tmp/test.sock".to_string(),
+                cdp_endpoint: Some("http://host:9223".to_string()),
+                idle_timeout: Duration::from_secs(300),
+            })
+            .unwrap(),
+        ),
+        recording_artifact_store: artifact_store.clone(),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
+        idle_stop_timeout: Duration::from_secs(300),
+        public_gateway_url: "https://localhost:4433".to_string(),
+        default_owner_mode: SessionOwnerMode::Collaborative,
+    });
+    let app = build_api_router(state);
+
+    let create_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "recording": {
+                          "mode": "manual",
+                          "format": "webm",
+                          "retention_sec": 60
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let session = response_json(create_session_response).await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let create_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/recordings"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let recording = response_json(create_recording_response).await;
+    let recording_id = recording["id"].as_str().unwrap().to_string();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let artifact_path = temp_dir.path().join("recording.webm");
+    std::fs::write(&artifact_path, b"webm-bytes").unwrap();
+
+    let complete_recording_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/complete"
+                ))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                      "source_path": artifact_path.to_string_lossy(),
+                      "mime_type": "video/webm",
+                      "bytes": 10,
+                      "duration_ms": 2500
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(complete_recording_response.status(), StatusCode::OK);
+
+    let recording_uuid = uuid::Uuid::parse_str(&recording_id).unwrap();
+    let session_uuid = uuid::Uuid::parse_str(&session_id).unwrap();
+    let stored = session_store
+        .get_recording_for_session(session_uuid, recording_uuid)
+        .await
+        .unwrap()
+        .unwrap();
+    let retention = RecordingRetentionManager::new(
+        session_store.clone(),
+        artifact_store,
+        Duration::from_secs(60),
+    );
+    retention
+        .run_cleanup_pass(stored.completed_at.unwrap() + chrono::Duration::seconds(61))
+        .await
+        .unwrap();
+
+    let content_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/recordings/{recording_id}/content"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(content_response.status(), StatusCode::GONE);
+    let body = response_json(content_response).await;
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("no longer available"));
 }
 
 #[tokio::test]
@@ -403,6 +865,8 @@ async fn scopes_session_resources_to_the_authenticated_owner() {
             })
             .unwrap(),
         ),
+        recording_artifact_store: test_artifact_store(),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
         default_owner_mode: SessionOwnerMode::Collaborative,
@@ -463,6 +927,8 @@ async fn rejects_session_scoped_runtime_routes_for_unknown_or_foreign_sessions_b
             })
             .unwrap(),
         ),
+        recording_artifact_store: test_artifact_store(),
+        recording_lifecycle: Arc::new(RecordingLifecycleManager::disabled()),
         idle_stop_timeout: Duration::from_secs(300),
         public_gateway_url: "https://localhost:4433".to_string(),
         default_owner_mode: SessionOwnerMode::Collaborative,

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -83,6 +83,40 @@ fn blocking_session_stop_only_applies_to_legacy_runtime_backends() {
     ));
 }
 
+#[test]
+fn session_status_maps_recorder_clients() {
+    let status = session_status_from_snapshot(SessionTelemetrySnapshot {
+        browser_clients: 3,
+        viewer_clients: 1,
+        recorder_clients: 1,
+        max_viewers: 10,
+        viewer_slots_remaining: 9,
+        exclusive_browser_owner: false,
+        mcp_owner: false,
+        resolution: (1280, 720),
+        joins_accepted: 4,
+        joins_rejected_viewer_cap: 0,
+        last_join_latency_ms: 12,
+        average_join_latency_ms: 9.5,
+        max_join_latency_ms: 15,
+        full_refresh_requests: 1,
+        full_refresh_tiles_requested: 30,
+        last_full_refresh_tiles: 30,
+        max_full_refresh_tiles: 30,
+        egress_send_stream_lock_acquires_total: 10,
+        egress_send_stream_lock_wait_us_total: 20,
+        egress_send_stream_lock_wait_us_average: 2.0,
+        egress_send_stream_lock_wait_us_max: 6,
+        egress_lagged_receives_total: 0,
+        egress_lagged_frames_total: 0,
+    });
+
+    assert_eq!(status.browser_clients, 3);
+    assert_eq!(status.viewer_clients, 1);
+    assert_eq!(status.recorder_clients, 1);
+    assert_eq!(status.viewer_slots_remaining, 9);
+}
+
 #[tokio::test]
 async fn creates_lists_gets_and_stops_a_session_resource() {
     let (app, token) = test_router();

--- a/code/apps/bpane-gateway/src/config.rs
+++ b/code/apps/bpane-gateway/src/config.rs
@@ -144,4 +144,77 @@ pub struct Config {
     /// browser clients join as restricted viewers.
     #[arg(long, default_value_t = false)]
     pub exclusive_browser_owner: bool,
+
+    /// Executable used to launch the optional recorder worker sidecar for recording.mode=always.
+    #[arg(long)]
+    pub recording_worker_bin: Option<PathBuf>,
+
+    /// Additional argument passed to the recorder worker executable. Repeat for multiple args.
+    #[arg(long = "recording-worker-arg")]
+    pub recording_worker_args: Vec<String>,
+
+    /// Chrome/Chromium executable path forwarded to the recorder worker.
+    #[arg(long)]
+    pub recording_worker_chrome: Option<PathBuf>,
+
+    /// Local API base URL used by the recorder worker to talk back to the gateway.
+    #[arg(long, default_value = "http://127.0.0.1:8932")]
+    pub recording_worker_api_url: String,
+
+    /// Browser page URL used by the recorder worker for the embedded client page.
+    #[arg(long, default_value = "http://127.0.0.1:8080")]
+    pub recording_worker_page_url: String,
+
+    /// Output root where the recorder worker stores local artifacts before API finalization.
+    #[arg(long, default_value = "/tmp/bpane-recordings")]
+    pub recording_worker_output_root: PathBuf,
+
+    /// Managed local root for finalized recording artifacts served by the gateway's local_fs artifact store.
+    #[arg(long, default_value = "/tmp/bpane-recording-artifacts")]
+    pub recording_artifact_local_root: PathBuf,
+
+    /// Optional SPKI pin forwarded to the recorder worker Chromium process.
+    #[arg(long)]
+    pub recording_worker_cert_spki: Option<String>,
+
+    /// Whether the recorder worker should run Chromium headless.
+    #[arg(long, action = clap::ArgAction::Set, default_value_t = true)]
+    pub recording_worker_headless: bool,
+
+    /// Recorder worker connection timeout in seconds.
+    #[arg(long, default_value_t = 30)]
+    pub recording_worker_connect_timeout_secs: u64,
+
+    /// Recorder worker polling interval for recording state updates in milliseconds.
+    #[arg(long, default_value_t = 2000)]
+    pub recording_worker_poll_interval_ms: u64,
+
+    /// How long the gateway waits for recorder finalization during session teardown.
+    #[arg(long, default_value_t = 30)]
+    pub recording_worker_finalize_timeout_secs: u64,
+
+    /// How often the gateway scans for completed recording artifacts whose per-session retention has expired.
+    /// Set to 0 to disable artifact retention cleanup.
+    #[arg(long, default_value_t = 60)]
+    pub recording_artifact_cleanup_interval_secs: u64,
+
+    /// Optional static bearer token forwarded to the recorder worker for gateway API access.
+    #[arg(long)]
+    pub recording_worker_bearer_token: Option<String>,
+
+    /// Optional OIDC token URL forwarded to the recorder worker when gateway auth is OIDC.
+    #[arg(long)]
+    pub recording_worker_oidc_token_url: Option<String>,
+
+    /// Optional OIDC client id forwarded to the recorder worker when gateway auth is OIDC.
+    #[arg(long)]
+    pub recording_worker_oidc_client_id: Option<String>,
+
+    /// Optional OIDC client secret forwarded to the recorder worker when gateway auth is OIDC.
+    #[arg(long)]
+    pub recording_worker_oidc_client_secret: Option<String>,
+
+    /// Optional OIDC scopes forwarded to the recorder worker when gateway auth is OIDC.
+    #[arg(long)]
+    pub recording_worker_oidc_scopes: Option<String>,
 }

--- a/code/apps/bpane-gateway/src/idle_stop.rs
+++ b/code/apps/bpane-gateway/src/idle_stop.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::session_control::{SessionLifecycleState, SessionStore};
+use crate::recording_lifecycle::RecordingLifecycleManager;
+use crate::session_control::{
+    SessionLifecycleState, SessionRecordingTerminationReason, SessionStore,
+};
 use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
 
@@ -14,6 +17,7 @@ pub fn schedule_idle_session_stop(
     registry: Arc<SessionRegistry>,
     session_store: SessionStore,
     session_manager: Arc<SessionManager>,
+    recording_lifecycle: Arc<RecordingLifecycleManager>,
 ) {
     tokio::spawn(async move {
         let timeout = match session_store.get_session_by_id(session_id).await {
@@ -34,6 +38,13 @@ pub fn schedule_idle_session_stop(
             if snapshot.browser_clients > 0 || snapshot.viewer_clients > 0 || snapshot.mcp_owner {
                 return;
             }
+        }
+
+        if let Err(error) = recording_lifecycle
+            .request_stop_and_wait(session_id, SessionRecordingTerminationReason::IdleStop)
+            .await
+        {
+            warn!(%session_id, "failed to finalize recording before idle stop: {error}");
         }
 
         match session_store.stop_session_if_idle(session_id).await {

--- a/code/apps/bpane-gateway/src/main.rs
+++ b/code/apps/bpane-gateway/src/main.rs
@@ -5,6 +5,8 @@ mod connect_ticket;
 mod idle_stop;
 mod recording_artifact_store;
 mod recording_lifecycle;
+mod recording_observability;
+mod recording_playback;
 mod recording_retention;
 mod relay;
 mod runtime_manager;
@@ -30,6 +32,7 @@ use config::Config;
 use connect_ticket::SessionConnectTicketManager;
 use recording_artifact_store::RecordingArtifactStore;
 use recording_lifecycle::{RecordingLifecycleManager, RecordingWorkerConfig};
+use recording_observability::RecordingObservability;
 use recording_retention::RecordingRetentionManager;
 use session_control::{SessionOwnerMode, SessionStore};
 use session_manager::{SessionManager, SessionManagerConfig, SessionManagerDockerConfig};
@@ -235,10 +238,12 @@ async fn main() -> anyhow::Result<()> {
     let recording_artifact_store = Arc::new(RecordingArtifactStore::local_fs(
         config.recording_artifact_local_root.clone(),
     ));
+    let recording_observability = Arc::new(RecordingObservability::default());
     if config.recording_artifact_cleanup_interval_secs > 0 {
         let recording_retention = Arc::new(RecordingRetentionManager::new(
             session_store.clone(),
             recording_artifact_store.clone(),
+            recording_observability.clone(),
             Duration::from_secs(config.recording_artifact_cleanup_interval_secs),
         ));
         recording_retention.run_cleanup_pass(Utc::now()).await?;
@@ -278,6 +283,7 @@ async fn main() -> anyhow::Result<()> {
             session_store,
             session_manager,
             recording_artifact_store,
+            recording_observability,
             recording_lifecycle,
             Duration::from_secs(config.runtime_idle_timeout_secs),
             config.public_gateway_url,

--- a/code/apps/bpane-gateway/src/main.rs
+++ b/code/apps/bpane-gateway/src/main.rs
@@ -3,6 +3,9 @@ mod auth;
 mod config;
 mod connect_ticket;
 mod idle_stop;
+mod recording_artifact_store;
+mod recording_lifecycle;
+mod recording_retention;
 mod relay;
 mod runtime_manager;
 mod session;
@@ -15,6 +18,7 @@ mod transport;
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use clap::Parser;
 use tracing::info;
 use tracing::warn;
@@ -24,6 +28,9 @@ use wtransport::Identity;
 use auth::{AuthValidator, OidcConfig};
 use config::Config;
 use connect_ticket::SessionConnectTicketManager;
+use recording_artifact_store::RecordingArtifactStore;
+use recording_lifecycle::{RecordingLifecycleManager, RecordingWorkerConfig};
+use recording_retention::RecordingRetentionManager;
 use session_control::{SessionOwnerMode, SessionStore};
 use session_manager::{SessionManager, SessionManagerConfig, SessionManagerDockerConfig};
 use session_registry::SessionRegistry;
@@ -193,6 +200,50 @@ async fn main() -> anyhow::Result<()> {
         .attach_session_store(session_store.clone())
         .await;
     session_manager.reconcile_persisted_state().await?;
+    let recording_worker_config = if let Some(bin) = config.recording_worker_bin.clone() {
+        Some(RecordingWorkerConfig {
+            bin,
+            args: config.recording_worker_args.clone(),
+            chrome_executable: config.recording_worker_chrome.clone().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--recording-worker-chrome is required when --recording-worker-bin is set"
+                )
+            })?,
+            gateway_api_url: config.recording_worker_api_url.clone(),
+            page_url: config.recording_worker_page_url.clone(),
+            output_root: config.recording_worker_output_root.clone(),
+            cert_spki: config.recording_worker_cert_spki.clone(),
+            headless: config.recording_worker_headless,
+            connect_timeout: Duration::from_secs(config.recording_worker_connect_timeout_secs),
+            poll_interval: Duration::from_millis(config.recording_worker_poll_interval_ms),
+            finalize_timeout: Duration::from_secs(config.recording_worker_finalize_timeout_secs),
+            bearer_token: config.recording_worker_bearer_token.clone(),
+            oidc_token_url: config.recording_worker_oidc_token_url.clone(),
+            oidc_client_id: config.recording_worker_oidc_client_id.clone(),
+            oidc_client_secret: config.recording_worker_oidc_client_secret.clone(),
+            oidc_scopes: config.recording_worker_oidc_scopes.clone(),
+        })
+    } else {
+        None
+    };
+    let recording_lifecycle = Arc::new(RecordingLifecycleManager::new(
+        recording_worker_config,
+        auth_validator.clone(),
+        session_store.clone(),
+    )?);
+    recording_lifecycle.reconcile_persisted_state().await?;
+    let recording_artifact_store = Arc::new(RecordingArtifactStore::local_fs(
+        config.recording_artifact_local_root.clone(),
+    ));
+    if config.recording_artifact_cleanup_interval_secs > 0 {
+        let recording_retention = Arc::new(RecordingRetentionManager::new(
+            session_store.clone(),
+            recording_artifact_store.clone(),
+            Duration::from_secs(config.recording_artifact_cleanup_interval_secs),
+        ));
+        recording_retention.run_cleanup_pass(Utc::now()).await?;
+        recording_retention.start();
+    }
 
     let server = TransportServer::new(
         bind_addr,
@@ -201,6 +252,7 @@ async fn main() -> anyhow::Result<()> {
         auth_validator.clone(),
         connect_ticket_manager.clone(),
         session_store.clone(),
+        recording_lifecycle.clone(),
         Duration::from_secs(config.runtime_idle_timeout_secs),
         Duration::from_secs(config.heartbeat_timeout_secs),
         registry.clone(),
@@ -225,6 +277,8 @@ async fn main() -> anyhow::Result<()> {
             connect_ticket_manager,
             session_store,
             session_manager,
+            recording_artifact_store,
+            recording_lifecycle,
             Duration::from_secs(config.runtime_idle_timeout_secs),
             config.public_gateway_url,
             if config.exclusive_browser_owner {

--- a/code/apps/bpane-gateway/src/recording_artifact_store.rs
+++ b/code/apps/bpane-gateway/src/recording_artifact_store.rs
@@ -1,0 +1,237 @@
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::session_control::SessionRecordingFormat;
+
+const LOCAL_FS_REF_PREFIX: &str = "local_fs:";
+
+#[derive(Debug, Clone)]
+pub struct FinalizeRecordingArtifactRequest {
+    pub session_id: Uuid,
+    pub recording_id: Uuid,
+    pub format: SessionRecordingFormat,
+    pub source_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredRecordingArtifact {
+    pub artifact_ref: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordingArtifactStoreError {
+    #[error("invalid artifact reference: {0}")]
+    InvalidReference(String),
+    #[error("invalid source path: {0}")]
+    InvalidSourcePath(String),
+    #[error("recording artifact backend failed: {0}")]
+    Backend(#[from] std::io::Error),
+}
+
+impl RecordingArtifactStoreError {
+    pub fn io_kind(&self) -> Option<std::io::ErrorKind> {
+        match self {
+            Self::Backend(error) => Some(error.kind()),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait]
+pub trait RecordingArtifactStoreBackend: Send + Sync {
+    async fn finalize(
+        &self,
+        request: FinalizeRecordingArtifactRequest,
+    ) -> Result<StoredRecordingArtifact, RecordingArtifactStoreError>;
+
+    async fn read(&self, artifact_ref: &str) -> Result<Vec<u8>, RecordingArtifactStoreError>;
+
+    async fn delete(&self, artifact_ref: &str) -> Result<(), RecordingArtifactStoreError>;
+}
+
+#[derive(Clone)]
+pub struct RecordingArtifactStore {
+    backend: Arc<dyn RecordingArtifactStoreBackend>,
+}
+
+impl RecordingArtifactStore {
+    pub fn new(backend: Arc<dyn RecordingArtifactStoreBackend>) -> Self {
+        Self { backend }
+    }
+
+    pub fn local_fs(root: PathBuf) -> Self {
+        Self::new(Arc::new(LocalFsRecordingArtifactStore { root }))
+    }
+
+    pub async fn finalize(
+        &self,
+        request: FinalizeRecordingArtifactRequest,
+    ) -> Result<StoredRecordingArtifact, RecordingArtifactStoreError> {
+        self.backend.finalize(request).await
+    }
+
+    pub async fn read(&self, artifact_ref: &str) -> Result<Vec<u8>, RecordingArtifactStoreError> {
+        self.backend.read(artifact_ref).await
+    }
+
+    pub async fn delete(&self, artifact_ref: &str) -> Result<(), RecordingArtifactStoreError> {
+        self.backend.delete(artifact_ref).await
+    }
+}
+
+#[derive(Debug)]
+pub struct LocalFsRecordingArtifactStore {
+    root: PathBuf,
+}
+
+#[async_trait]
+impl RecordingArtifactStoreBackend for LocalFsRecordingArtifactStore {
+    async fn finalize(
+        &self,
+        request: FinalizeRecordingArtifactRequest,
+    ) -> Result<StoredRecordingArtifact, RecordingArtifactStoreError> {
+        let source_path = validate_source_path(&request.source_path)?;
+        let relative =
+            relative_artifact_path(request.session_id, request.recording_id, request.format);
+        let destination = self.root.join(&relative);
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+
+        match fs::rename(&source_path, &destination).await {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::CrossesDevices => {
+                fs::copy(&source_path, &destination).await?;
+                fs::remove_file(&source_path).await?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        Ok(StoredRecordingArtifact {
+            artifact_ref: format!("{LOCAL_FS_REF_PREFIX}{}", relative.to_string_lossy()),
+        })
+    }
+
+    async fn read(&self, artifact_ref: &str) -> Result<Vec<u8>, RecordingArtifactStoreError> {
+        let path = self.resolve_path(artifact_ref)?;
+        Ok(fs::read(path).await?)
+    }
+
+    async fn delete(&self, artifact_ref: &str) -> Result<(), RecordingArtifactStoreError> {
+        let path = self.resolve_path(artifact_ref)?;
+        match fs::remove_file(path).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+impl LocalFsRecordingArtifactStore {
+    fn resolve_path(&self, artifact_ref: &str) -> Result<PathBuf, RecordingArtifactStoreError> {
+        let relative = artifact_ref
+            .strip_prefix(LOCAL_FS_REF_PREFIX)
+            .ok_or_else(|| {
+                RecordingArtifactStoreError::InvalidReference(artifact_ref.to_string())
+            })?;
+        let path = Path::new(relative);
+        if path.as_os_str().is_empty() {
+            return Err(RecordingArtifactStoreError::InvalidReference(
+                "artifact reference path must not be empty".to_string(),
+            ));
+        }
+        for component in path.components() {
+            match component {
+                Component::Normal(_) => {}
+                _ => {
+                    return Err(RecordingArtifactStoreError::InvalidReference(
+                        artifact_ref.to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(self.root.join(path))
+    }
+}
+
+fn validate_source_path(source_path: &str) -> Result<PathBuf, RecordingArtifactStoreError> {
+    let trimmed = source_path.trim();
+    if trimmed.is_empty() {
+        return Err(RecordingArtifactStoreError::InvalidSourcePath(
+            "source path must not be empty".to_string(),
+        ));
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.is_absolute() {
+        return Err(RecordingArtifactStoreError::InvalidSourcePath(
+            "source path must be absolute for local_fs storage".to_string(),
+        ));
+    }
+    Ok(path)
+}
+
+fn relative_artifact_path(
+    session_id: Uuid,
+    recording_id: Uuid,
+    format: SessionRecordingFormat,
+) -> PathBuf {
+    let extension = match format {
+        SessionRecordingFormat::Webm => "webm",
+    };
+    PathBuf::from(session_id.to_string()).join(format!("{recording_id}.{extension}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn local_fs_store_moves_source_file_into_managed_root() {
+        let temp_dir = tempdir().unwrap();
+        let source = temp_dir.path().join("source.webm");
+        std::fs::write(&source, b"artifact").unwrap();
+        let root = temp_dir.path().join("artifacts");
+        let store = RecordingArtifactStore::local_fs(root.clone());
+        let session_id = Uuid::now_v7();
+        let recording_id = Uuid::now_v7();
+
+        let artifact = store
+            .finalize(FinalizeRecordingArtifactRequest {
+                session_id,
+                recording_id,
+                format: SessionRecordingFormat::Webm,
+                source_path: source.to_string_lossy().to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert!(!source.exists());
+        assert_eq!(
+            artifact.artifact_ref,
+            format!("{LOCAL_FS_REF_PREFIX}{session_id}/{recording_id}.webm")
+        );
+        let bytes = store.read(&artifact.artifact_ref).await.unwrap();
+        assert_eq!(bytes.as_slice(), b"artifact");
+        assert!(root
+            .join(session_id.to_string())
+            .join(format!("{recording_id}.webm"))
+            .exists());
+    }
+
+    #[tokio::test]
+    async fn local_fs_store_rejects_invalid_references() {
+        let temp_dir = tempdir().unwrap();
+        let store = RecordingArtifactStore::local_fs(temp_dir.path().join("artifacts"));
+        let error = store.read("../../../etc/passwd").await.unwrap_err();
+        assert!(matches!(
+            error,
+            RecordingArtifactStoreError::InvalidReference(_)
+        ));
+    }
+}

--- a/code/apps/bpane-gateway/src/recording_lifecycle.rs
+++ b/code/apps/bpane-gateway/src/recording_lifecycle.rs
@@ -1,0 +1,785 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::time::{sleep, Instant};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::auth::AuthValidator;
+use crate::session_control::{
+    FailSessionRecordingRequest, PersistedSessionRecordingWorkerAssignment, SessionRecordingMode,
+    SessionRecordingTerminationReason, SessionRecordingWorkerAssignmentStatus, SessionStore,
+    SessionStoreError, StoredSession,
+};
+
+#[derive(Debug, Clone)]
+pub struct RecordingWorkerConfig {
+    pub bin: PathBuf,
+    pub args: Vec<String>,
+    pub chrome_executable: PathBuf,
+    pub gateway_api_url: String,
+    pub page_url: String,
+    pub output_root: PathBuf,
+    pub cert_spki: Option<String>,
+    pub headless: bool,
+    pub connect_timeout: Duration,
+    pub poll_interval: Duration,
+    pub finalize_timeout: Duration,
+    pub bearer_token: Option<String>,
+    pub oidc_token_url: Option<String>,
+    pub oidc_client_id: Option<String>,
+    pub oidc_client_secret: Option<String>,
+    pub oidc_scopes: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RecordingLifecycleError {
+    Disabled(String),
+    InvalidConfiguration(String),
+    LaunchFailed(String),
+    Store(String),
+}
+
+impl std::fmt::Display for RecordingLifecycleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Disabled(message)
+            | Self::InvalidConfiguration(message)
+            | Self::LaunchFailed(message)
+            | Self::Store(message) => write!(f, "{message}"),
+        }
+    }
+}
+
+impl std::error::Error for RecordingLifecycleError {}
+
+impl From<SessionStoreError> for RecordingLifecycleError {
+    fn from(value: SessionStoreError) -> Self {
+        Self::Store(value.to_string())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct RecordingLifecycleManager {
+    inner: Option<Arc<RecordingLifecycleInner>>,
+}
+
+struct RecordingLifecycleInner {
+    config: RecordingWorkerConfig,
+    auth_validator: Arc<AuthValidator>,
+    session_store: SessionStore,
+    launched: Mutex<HashMap<Uuid, LaunchedRecordingWorker>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LaunchedRecordingWorker {
+    recording_id: Uuid,
+}
+
+impl RecordingLifecycleManager {
+    pub fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    pub fn new(
+        config: Option<RecordingWorkerConfig>,
+        auth_validator: Arc<AuthValidator>,
+        session_store: SessionStore,
+    ) -> Result<Self, RecordingLifecycleError> {
+        let Some(config) = config else {
+            return Ok(Self::disabled());
+        };
+        validate_config(&config, &auth_validator)?;
+        Ok(Self {
+            inner: Some(Arc::new(RecordingLifecycleInner {
+                config,
+                auth_validator,
+                session_store,
+                launched: Mutex::new(HashMap::new()),
+            })),
+        })
+    }
+
+    pub fn validate_mode(&self, mode: SessionRecordingMode) -> Result<(), RecordingLifecycleError> {
+        if mode != SessionRecordingMode::Always {
+            return Ok(());
+        }
+        if self.inner.is_none() {
+            return Err(RecordingLifecycleError::Disabled(
+                "recording mode=always requires a configured recording worker".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub async fn reconcile_persisted_state(&self) -> Result<(), RecordingLifecycleError> {
+        let Some(inner) = &self.inner else {
+            return Ok(());
+        };
+
+        let assignments = inner
+            .session_store
+            .list_recording_worker_assignments()
+            .await?;
+        for assignment in assignments {
+            inner.reconcile_assignment(assignment).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn ensure_auto_recording(
+        &self,
+        session: &StoredSession,
+    ) -> Result<(), RecordingLifecycleError> {
+        self.validate_mode(session.recording.mode)?;
+        if session.recording.mode != SessionRecordingMode::Always {
+            return Ok(());
+        }
+        let Some(inner) = &self.inner else {
+            return Ok(());
+        };
+
+        {
+            let launched = inner.launched.lock().await;
+            if let Some(worker) = launched.get(&session.id) {
+                info!(
+                    session_id = %session.id,
+                    recording_id = %worker.recording_id,
+                    "recorder worker is already running for always-on session"
+                );
+                return Ok(());
+            }
+        }
+
+        if let Some(existing) = inner
+            .session_store
+            .get_latest_recording_for_session(session.id)
+            .await?
+        {
+            if existing.state.is_active() {
+                info!(
+                    session_id = %session.id,
+                    recording_id = %existing.id,
+                    "reusing existing active recording for always-on session"
+                );
+                return Ok(());
+            }
+        }
+
+        let recording = inner
+            .session_store
+            .create_recording_for_session(session.id, session.recording.format, None)
+            .await?;
+
+        inner.spawn_worker(session.id, recording.id).await?;
+        Ok(())
+    }
+
+    pub async fn request_stop_and_wait(
+        &self,
+        session_id: Uuid,
+        termination_reason: SessionRecordingTerminationReason,
+    ) -> Result<(), RecordingLifecycleError> {
+        let Some(inner) = &self.inner else {
+            return Ok(());
+        };
+
+        let Some(recording) = inner
+            .session_store
+            .get_latest_recording_for_session(session_id)
+            .await?
+        else {
+            let _ = inner
+                .session_store
+                .clear_recording_worker_assignment(session_id)
+                .await;
+            return Ok(());
+        };
+
+        if let Some(mut assignment) = inner
+            .session_store
+            .get_recording_worker_assignment(session_id)
+            .await?
+        {
+            assignment.status = SessionRecordingWorkerAssignmentStatus::Stopping;
+            let _ = inner
+                .session_store
+                .upsert_recording_worker_assignment(assignment)
+                .await;
+        }
+
+        if recording.state.is_active() {
+            inner
+                .session_store
+                .stop_recording_for_session(session_id, recording.id, termination_reason)
+                .await?;
+        } else if recording.state.is_terminal() {
+            let _ = inner
+                .session_store
+                .clear_recording_worker_assignment(session_id)
+                .await;
+            return Ok(());
+        }
+
+        let deadline = Instant::now() + inner.config.finalize_timeout;
+        loop {
+            let Some(current) = inner
+                .session_store
+                .get_recording_for_session(session_id, recording.id)
+                .await?
+            else {
+                let _ = inner
+                    .session_store
+                    .clear_recording_worker_assignment(session_id)
+                    .await;
+                return Ok(());
+            };
+            if current.state.is_terminal() {
+                let _ = inner
+                    .session_store
+                    .clear_recording_worker_assignment(session_id)
+                    .await;
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                warn!(
+                    session_id = %session_id,
+                    recording_id = %recording.id,
+                    "timed out waiting for recording finalization during session teardown"
+                );
+                return Ok(());
+            }
+            sleep(inner.config.poll_interval).await;
+        }
+    }
+}
+
+impl RecordingLifecycleInner {
+    async fn reconcile_assignment(
+        self: &Arc<Self>,
+        assignment: PersistedSessionRecordingWorkerAssignment,
+    ) -> Result<(), RecordingLifecycleError> {
+        info!(
+            session_id = %assignment.session_id,
+            recording_id = %assignment.recording_id,
+            "reconciling persisted recorder worker assignment after gateway restart"
+        );
+
+        let stale_recording = self
+            .session_store
+            .get_recording_for_session(assignment.session_id, assignment.recording_id)
+            .await?;
+        if let Some(recording) = &stale_recording {
+            if recording.state.is_active() {
+                let _ = self
+                    .session_store
+                    .fail_recording_for_session(
+                        assignment.session_id,
+                        assignment.recording_id,
+                        FailSessionRecordingRequest {
+                            error: "gateway restarted while recorder worker was active".to_string(),
+                            termination_reason: Some(
+                                SessionRecordingTerminationReason::GatewayRestart,
+                            ),
+                        },
+                    )
+                    .await?;
+            }
+        }
+
+        self.session_store
+            .clear_recording_worker_assignment(assignment.session_id)
+            .await?;
+
+        let Some(session) = self
+            .session_store
+            .get_session_by_id(assignment.session_id)
+            .await?
+        else {
+            return Ok(());
+        };
+        if session.recording.mode != SessionRecordingMode::Always
+            || !session.state.is_runtime_candidate()
+        {
+            return Ok(());
+        }
+
+        let recording = self
+            .session_store
+            .create_recording_for_session(
+                session.id,
+                session.recording.format,
+                stale_recording.as_ref().map(|recording| recording.id),
+            )
+            .await?;
+        self.spawn_worker(session.id, recording.id).await
+    }
+
+    async fn spawn_worker(
+        self: &Arc<Self>,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<(), RecordingLifecycleError> {
+        let mut command = Command::new(&self.config.bin);
+        command.args(&self.config.args);
+        command.stdin(Stdio::null());
+        command.stdout(Stdio::null());
+        command.stderr(Stdio::null());
+        command.env("BPANE_RECORDING_SESSION_ID", session_id.to_string());
+        command.env("BPANE_RECORDING_ID", recording_id.to_string());
+        command.env("BPANE_RECORDING_CHROME", &self.config.chrome_executable);
+        command.env("BPANE_GATEWAY_API_URL", &self.config.gateway_api_url);
+        command.env("BPANE_RECORDING_PAGE_URL", &self.config.page_url);
+        command.env("BPANE_RECORDING_OUTPUT_ROOT", &self.config.output_root);
+        command.env(
+            "BPANE_RECORDING_CONNECT_TIMEOUT_MS",
+            self.config.connect_timeout.as_millis().to_string(),
+        );
+        command.env(
+            "BPANE_RECORDING_POLL_INTERVAL_MS",
+            self.config.poll_interval.as_millis().to_string(),
+        );
+        command.env(
+            "BPANE_RECORDING_HEADLESS",
+            if self.config.headless {
+                "true"
+            } else {
+                "false"
+            },
+        );
+
+        if let Some(cert_spki) = &self.config.cert_spki {
+            command.env("BPANE_RECORDING_CERT_SPKI", cert_spki);
+        }
+        if let Some(bearer_token) = self.resolve_bearer_token() {
+            command.env("BPANE_RECORDING_BEARER_TOKEN", bearer_token);
+        }
+        if let Some(token_url) = &self.config.oidc_token_url {
+            command.env("BPANE_GATEWAY_OIDC_TOKEN_URL", token_url);
+        }
+        if let Some(client_id) = &self.config.oidc_client_id {
+            command.env("BPANE_GATEWAY_OIDC_CLIENT_ID", client_id);
+        }
+        if let Some(client_secret) = &self.config.oidc_client_secret {
+            command.env("BPANE_GATEWAY_OIDC_CLIENT_SECRET", client_secret);
+        }
+        if let Some(scopes) = &self.config.oidc_scopes {
+            command.env("BPANE_GATEWAY_OIDC_SCOPES", scopes);
+        }
+
+        let mut child = command.spawn().map_err(|error| {
+            RecordingLifecycleError::LaunchFailed(format!(
+                "failed to spawn recording worker for session {session_id}: {error}"
+            ))
+        })?;
+        let process_id = child.id();
+
+        if let Err(error) = self
+            .session_store
+            .upsert_recording_worker_assignment(PersistedSessionRecordingWorkerAssignment {
+                session_id,
+                recording_id,
+                status: SessionRecordingWorkerAssignmentStatus::Running,
+                process_id,
+            })
+            .await
+        {
+            let _ = child.start_kill();
+            return Err(error.into());
+        }
+
+        self.launched
+            .lock()
+            .await
+            .insert(session_id, LaunchedRecordingWorker { recording_id });
+
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let status = child.wait_with_output().await;
+            manager
+                .handle_worker_exit(session_id, recording_id, status)
+                .await;
+        });
+
+        info!(
+            session_id = %session_id,
+            recording_id = %recording_id,
+            "launched recorder worker for always-on session"
+        );
+        Ok(())
+    }
+
+    fn resolve_bearer_token(&self) -> Option<String> {
+        self.config
+            .bearer_token
+            .clone()
+            .or_else(|| self.auth_validator.generate_token())
+    }
+
+    async fn handle_worker_exit(
+        self: Arc<Self>,
+        session_id: Uuid,
+        recording_id: Uuid,
+        status: std::io::Result<std::process::Output>,
+    ) {
+        self.launched.lock().await.remove(&session_id);
+
+        let exit_message = match status {
+            Ok(output) if output.status.success() => {
+                format!("recording worker exited before finalizing recording {recording_id}")
+            }
+            Ok(output) => format!(
+                "recording worker exited with status {:?} before finalizing recording {recording_id}",
+                output.status.code()
+            ),
+            Err(error) => format!(
+                "recording worker failed while waiting for session {session_id}: {error}"
+            ),
+        };
+
+        let Ok(Some(recording)) = self
+            .session_store
+            .get_recording_for_session(session_id, recording_id)
+            .await
+        else {
+            let _ = self
+                .session_store
+                .clear_recording_worker_assignment(session_id)
+                .await;
+            return;
+        };
+        if recording.state.is_terminal() {
+            let _ = self
+                .session_store
+                .clear_recording_worker_assignment(session_id)
+                .await;
+            return;
+        }
+
+        warn!(
+            session_id = %session_id,
+            recording_id = %recording_id,
+            "{exit_message}"
+        );
+        let _ = self
+            .session_store
+            .fail_recording_for_session(
+                session_id,
+                recording_id,
+                FailSessionRecordingRequest {
+                    error: exit_message,
+                    termination_reason: Some(SessionRecordingTerminationReason::WorkerExit),
+                },
+            )
+            .await;
+        let _ = self
+            .session_store
+            .clear_recording_worker_assignment(session_id)
+            .await;
+    }
+}
+
+fn validate_config(
+    config: &RecordingWorkerConfig,
+    auth_validator: &AuthValidator,
+) -> Result<(), RecordingLifecycleError> {
+    if config.bin.as_os_str().is_empty() {
+        return Err(RecordingLifecycleError::InvalidConfiguration(
+            "recording worker binary path must not be empty".to_string(),
+        ));
+    }
+    if config.chrome_executable.as_os_str().is_empty() {
+        return Err(RecordingLifecycleError::InvalidConfiguration(
+            "recording worker chrome path must not be empty".to_string(),
+        ));
+    }
+    if auth_validator.is_oidc()
+        && config.bearer_token.is_none()
+        && (config.oidc_token_url.is_none()
+            || config.oidc_client_id.is_none()
+            || config.oidc_client_secret.is_none())
+    {
+        return Err(RecordingLifecycleError::InvalidConfiguration(
+            "recording worker auth is not configured for OIDC mode".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::auth::{AuthValidator, AuthenticatedPrincipal};
+    use crate::session_control::{
+        CreateSessionRequest, PersistCompletedSessionRecordingRequest, SessionOwnerMode,
+        SessionRecordingFormat, SessionRecordingPolicy,
+    };
+
+    fn test_principal() -> AuthenticatedPrincipal {
+        AuthenticatedPrincipal {
+            subject: "owner".to_string(),
+            issuer: "issuer".to_string(),
+            display_name: Some("Owner".to_string()),
+            client_id: None,
+        }
+    }
+
+    fn test_config(script: PathBuf, capture_file: PathBuf) -> RecordingWorkerConfig {
+        RecordingWorkerConfig {
+            bin: script,
+            args: vec![capture_file.to_string_lossy().to_string()],
+            chrome_executable: PathBuf::from("/tmp/google-chrome"),
+            gateway_api_url: "http://127.0.0.1:8932".to_string(),
+            page_url: "http://127.0.0.1:8080".to_string(),
+            output_root: PathBuf::from("/tmp/bpane-recordings"),
+            cert_spki: Some("spki".to_string()),
+            headless: true,
+            connect_timeout: Duration::from_secs(1),
+            poll_interval: Duration::from_millis(10),
+            finalize_timeout: Duration::from_millis(100),
+            bearer_token: Some("token".to_string()),
+            oidc_token_url: None,
+            oidc_client_id: None,
+            oidc_client_secret: None,
+            oidc_scopes: None,
+        }
+    }
+
+    async fn create_session_with_mode(
+        store: &SessionStore,
+        mode: SessionRecordingMode,
+    ) -> StoredSession {
+        store
+            .create_session(
+                &test_principal(),
+                CreateSessionRequest {
+                    template_id: None,
+                    owner_mode: None,
+                    viewport: None,
+                    idle_timeout_sec: None,
+                    labels: HashMap::new(),
+                    integration_context: None,
+                    recording: SessionRecordingPolicy {
+                        mode,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec: None,
+                    },
+                },
+                SessionOwnerMode::Collaborative,
+            )
+            .await
+            .unwrap()
+    }
+
+    fn create_capture_script(dir: &tempfile::TempDir) -> PathBuf {
+        let script_path = dir.path().join("capture-env.sh");
+        fs::write(
+            &script_path,
+            r#"#!/bin/sh
+echo "${BPANE_RECORDING_SESSION_ID} ${BPANE_RECORDING_ID}" > "$1"
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&script_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).unwrap();
+        script_path
+    }
+
+    #[tokio::test]
+    async fn always_mode_launches_worker_and_marks_unfinished_recording_failed() {
+        let temp_dir = tempdir().unwrap();
+        let capture_file = temp_dir.path().join("capture.txt");
+        let script = create_capture_script(&temp_dir);
+        let store = SessionStore::in_memory();
+        let auth = Arc::new(AuthValidator::from_hmac_secret(vec![9; 32]));
+        let manager = RecordingLifecycleManager::new(
+            Some(test_config(script, capture_file.clone())),
+            auth,
+            store.clone(),
+        )
+        .unwrap();
+        let session = create_session_with_mode(&store, SessionRecordingMode::Always).await;
+
+        manager.ensure_auto_recording(&session).await.unwrap();
+
+        for _ in 0..50 {
+            if capture_file.exists() {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        assert!(capture_file.exists());
+
+        let capture = fs::read_to_string(&capture_file).unwrap();
+        assert!(capture.contains(&session.id.to_string()));
+
+        let mut latest = None;
+        for _ in 0..50 {
+            latest = store
+                .get_latest_recording_for_session(session.id)
+                .await
+                .unwrap();
+            if latest
+                .as_ref()
+                .is_some_and(|recording| recording.state.is_terminal())
+            {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+
+        let recording = latest.expect("recording should exist");
+        assert!(matches!(
+            recording.state,
+            crate::session_control::SessionRecordingState::Failed
+        ));
+    }
+
+    #[tokio::test]
+    async fn request_stop_and_wait_observes_recording_completion() {
+        let store = SessionStore::in_memory();
+        let auth = Arc::new(AuthValidator::from_hmac_secret(vec![9; 32]));
+        let manager = RecordingLifecycleManager::new(
+            Some(RecordingWorkerConfig {
+                bin: PathBuf::from("/bin/sh"),
+                args: vec!["-c".to_string(), "exit 0".to_string()],
+                chrome_executable: PathBuf::from("/tmp/google-chrome"),
+                gateway_api_url: "http://127.0.0.1:8932".to_string(),
+                page_url: "http://127.0.0.1:8080".to_string(),
+                output_root: PathBuf::from("/tmp/bpane-recordings"),
+                cert_spki: None,
+                headless: true,
+                connect_timeout: Duration::from_secs(1),
+                poll_interval: Duration::from_millis(10),
+                finalize_timeout: Duration::from_secs(1),
+                bearer_token: Some("token".to_string()),
+                oidc_token_url: None,
+                oidc_client_id: None,
+                oidc_client_secret: None,
+                oidc_scopes: None,
+            }),
+            auth,
+            store.clone(),
+        )
+        .unwrap();
+        let session = create_session_with_mode(&store, SessionRecordingMode::Manual).await;
+        let recording = store
+            .create_recording_for_session(session.id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+
+        let completion_store = store.clone();
+        let session_id = session.id;
+        let recording_id = recording.id;
+        tokio::spawn(async move {
+            sleep(Duration::from_millis(20)).await;
+            let _ = completion_store
+                .complete_recording_for_session(
+                    session_id,
+                    recording_id,
+                    PersistCompletedSessionRecordingRequest {
+                        artifact_ref: "local_fs:session/recording.webm".to_string(),
+                        mime_type: Some("video/webm".to_string()),
+                        bytes: Some(42),
+                        duration_ms: Some(1000),
+                    },
+                )
+                .await;
+        });
+
+        manager
+            .request_stop_and_wait(session.id, SessionRecordingTerminationReason::SessionStop)
+            .await
+            .unwrap();
+
+        let completed = store
+            .get_recording_for_session(session.id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            completed.state,
+            crate::session_control::SessionRecordingState::Ready
+        ));
+        assert_eq!(
+            completed.termination_reason,
+            Some(SessionRecordingTerminationReason::SessionStop)
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_fails_stale_recording_and_starts_a_fresh_one() {
+        let temp_dir = tempdir().unwrap();
+        let capture_file = temp_dir.path().join("capture.txt");
+        let script = create_capture_script(&temp_dir);
+        let store = SessionStore::in_memory();
+        let auth = Arc::new(AuthValidator::from_hmac_secret(vec![9; 32]));
+        let manager = RecordingLifecycleManager::new(
+            Some(test_config(script, capture_file.clone())),
+            auth,
+            store.clone(),
+        )
+        .unwrap();
+        let session = create_session_with_mode(&store, SessionRecordingMode::Always).await;
+        let stale_recording = store
+            .create_recording_for_session(session.id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        store
+            .upsert_recording_worker_assignment(PersistedSessionRecordingWorkerAssignment {
+                session_id: session.id,
+                recording_id: stale_recording.id,
+                status: SessionRecordingWorkerAssignmentStatus::Running,
+                process_id: Some(7777),
+            })
+            .await
+            .unwrap();
+
+        manager.reconcile_persisted_state().await.unwrap();
+
+        for _ in 0..50 {
+            if capture_file.exists() {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+        assert!(capture_file.exists());
+
+        let stale = store
+            .get_recording_for_session(session.id, stale_recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            stale.state,
+            crate::session_control::SessionRecordingState::Failed
+        ));
+        assert_eq!(
+            stale.error.as_deref(),
+            Some("gateway restarted while recorder worker was active")
+        );
+        assert_eq!(
+            stale.termination_reason,
+            Some(SessionRecordingTerminationReason::GatewayRestart)
+        );
+
+        let listed = store.list_recordings_for_session(session.id).await.unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_ne!(listed[0].id, stale_recording.id);
+        assert_eq!(listed[0].previous_recording_id, Some(stale_recording.id));
+    }
+}

--- a/code/apps/bpane-gateway/src/recording_observability.rs
+++ b/code/apps/bpane-gateway/src/recording_observability.rs
@@ -1,0 +1,188 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+pub struct RecordingObservability {
+    artifact_finalize_requests_total: AtomicU64,
+    artifact_finalize_successes_total: AtomicU64,
+    artifact_finalize_failures_total: AtomicU64,
+    recording_failures_total: AtomicU64,
+    playback_manifest_requests_total: AtomicU64,
+    playback_export_requests_total: AtomicU64,
+    playback_export_successes_total: AtomicU64,
+    playback_export_failures_total: AtomicU64,
+    playback_export_bytes_total: AtomicU64,
+    retention_passes_total: AtomicU64,
+    retention_candidates_total: AtomicU64,
+    retention_deleted_artifacts_total: AtomicU64,
+    retention_failures_total: AtomicU64,
+    last_playback_export_at: Mutex<Option<DateTime<Utc>>>,
+    last_retention_pass_at: Mutex<Option<DateTime<Utc>>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RecordingObservabilitySnapshot {
+    pub artifact_finalize_requests_total: u64,
+    pub artifact_finalize_successes_total: u64,
+    pub artifact_finalize_failures_total: u64,
+    pub recording_failures_total: u64,
+    pub playback_manifest_requests_total: u64,
+    pub playback_export_requests_total: u64,
+    pub playback_export_successes_total: u64,
+    pub playback_export_failures_total: u64,
+    pub playback_export_bytes_total: u64,
+    pub retention_passes_total: u64,
+    pub retention_candidates_total: u64,
+    pub retention_deleted_artifacts_total: u64,
+    pub retention_failures_total: u64,
+    pub last_playback_export_at: Option<DateTime<Utc>>,
+    pub last_retention_pass_at: Option<DateTime<Utc>>,
+}
+
+impl RecordingObservability {
+    pub fn record_artifact_finalize_request(&self) {
+        self.artifact_finalize_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_artifact_finalize_success(&self) {
+        self.artifact_finalize_successes_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_artifact_finalize_failure(&self) {
+        self.artifact_finalize_failures_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_recording_failure(&self) {
+        self.recording_failures_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_playback_manifest_request(&self) {
+        self.playback_manifest_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_playback_export_request(&self) {
+        self.playback_export_requests_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub async fn record_playback_export_success(&self, bytes: u64, at: DateTime<Utc>) {
+        self.playback_export_successes_total
+            .fetch_add(1, Ordering::Relaxed);
+        self.playback_export_bytes_total
+            .fetch_add(bytes, Ordering::Relaxed);
+        *self.last_playback_export_at.lock().await = Some(at);
+    }
+
+    pub fn record_playback_export_failure(&self) {
+        self.playback_export_failures_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub async fn record_retention_pass(&self, at: DateTime<Utc>, candidate_count: usize) {
+        self.retention_passes_total.fetch_add(1, Ordering::Relaxed);
+        self.retention_candidates_total
+            .fetch_add(candidate_count as u64, Ordering::Relaxed);
+        *self.last_retention_pass_at.lock().await = Some(at);
+    }
+
+    pub fn record_retention_deleted_artifact(&self) {
+        self.retention_deleted_artifacts_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn record_retention_failure(&self) {
+        self.retention_failures_total
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub async fn snapshot(&self) -> RecordingObservabilitySnapshot {
+        RecordingObservabilitySnapshot {
+            artifact_finalize_requests_total: self
+                .artifact_finalize_requests_total
+                .load(Ordering::Relaxed),
+            artifact_finalize_successes_total: self
+                .artifact_finalize_successes_total
+                .load(Ordering::Relaxed),
+            artifact_finalize_failures_total: self
+                .artifact_finalize_failures_total
+                .load(Ordering::Relaxed),
+            recording_failures_total: self.recording_failures_total.load(Ordering::Relaxed),
+            playback_manifest_requests_total: self
+                .playback_manifest_requests_total
+                .load(Ordering::Relaxed),
+            playback_export_requests_total: self
+                .playback_export_requests_total
+                .load(Ordering::Relaxed),
+            playback_export_successes_total: self
+                .playback_export_successes_total
+                .load(Ordering::Relaxed),
+            playback_export_failures_total: self
+                .playback_export_failures_total
+                .load(Ordering::Relaxed),
+            playback_export_bytes_total: self.playback_export_bytes_total.load(Ordering::Relaxed),
+            retention_passes_total: self.retention_passes_total.load(Ordering::Relaxed),
+            retention_candidates_total: self.retention_candidates_total.load(Ordering::Relaxed),
+            retention_deleted_artifacts_total: self
+                .retention_deleted_artifacts_total
+                .load(Ordering::Relaxed),
+            retention_failures_total: self.retention_failures_total.load(Ordering::Relaxed),
+            last_playback_export_at: *self.last_playback_export_at.lock().await,
+            last_retention_pass_at: *self.last_retention_pass_at.lock().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn snapshot_tracks_recording_operations() {
+        let observability = RecordingObservability::default();
+        let now = Utc::now();
+
+        observability.record_artifact_finalize_request();
+        observability.record_artifact_finalize_success();
+        observability.record_artifact_finalize_failure();
+        observability.record_recording_failure();
+        observability.record_playback_manifest_request();
+        observability.record_playback_export_request();
+        observability.record_playback_export_failure();
+        observability
+            .record_playback_export_success(4096, now + TimeDelta::seconds(1))
+            .await;
+        observability.record_retention_deleted_artifact();
+        observability.record_retention_failure();
+        observability.record_retention_pass(now, 3).await;
+
+        let snapshot = observability.snapshot().await;
+        assert_eq!(snapshot.artifact_finalize_requests_total, 1);
+        assert_eq!(snapshot.artifact_finalize_successes_total, 1);
+        assert_eq!(snapshot.artifact_finalize_failures_total, 1);
+        assert_eq!(snapshot.recording_failures_total, 1);
+        assert_eq!(snapshot.playback_manifest_requests_total, 1);
+        assert_eq!(snapshot.playback_export_requests_total, 1);
+        assert_eq!(snapshot.playback_export_successes_total, 1);
+        assert_eq!(snapshot.playback_export_failures_total, 1);
+        assert_eq!(snapshot.playback_export_bytes_total, 4096);
+        assert_eq!(snapshot.retention_passes_total, 1);
+        assert_eq!(snapshot.retention_candidates_total, 3);
+        assert_eq!(snapshot.retention_deleted_artifacts_total, 1);
+        assert_eq!(snapshot.retention_failures_total, 1);
+        assert_eq!(snapshot.last_retention_pass_at, Some(now));
+        assert_eq!(
+            snapshot.last_playback_export_at,
+            Some(now + TimeDelta::seconds(1))
+        );
+    }
+}

--- a/code/apps/bpane-gateway/src/recording_playback.rs
+++ b/code/apps/bpane-gateway/src/recording_playback.rs
@@ -1,0 +1,510 @@
+use std::io::Write;
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+
+use crate::recording_artifact_store::{RecordingArtifactStore, RecordingArtifactStoreError};
+use crate::session_control::{
+    SessionRecordingFormat, SessionRecordingState, SessionRecordingTerminationReason,
+    StoredSessionRecording,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRecordingPlaybackState {
+    Empty,
+    Ready,
+    Partial,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRecordingPlaybackResource {
+    pub session_id: Uuid,
+    pub state: SessionRecordingPlaybackState,
+    pub segment_count: u32,
+    pub included_segment_count: u32,
+    pub failed_segment_count: u32,
+    pub active_segment_count: u32,
+    pub missing_artifact_segment_count: u32,
+    pub included_bytes: u64,
+    pub included_duration_ms: u64,
+    pub manifest_path: String,
+    pub export_path: String,
+    pub generated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRecordingPlaybackManifest {
+    pub format_version: &'static str,
+    pub session_id: Uuid,
+    pub state: SessionRecordingPlaybackState,
+    pub segment_count: u32,
+    pub included_segment_count: u32,
+    pub failed_segment_count: u32,
+    pub active_segment_count: u32,
+    pub missing_artifact_segment_count: u32,
+    pub included_bytes: u64,
+    pub included_duration_ms: u64,
+    pub generated_at: DateTime<Utc>,
+    pub segments: Vec<SessionRecordingPlaybackSegment>,
+    pub omitted_segments: Vec<SessionRecordingPlaybackOmittedSegment>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRecordingPlaybackSegment {
+    pub sequence: u32,
+    pub recording_id: Uuid,
+    pub previous_recording_id: Option<Uuid>,
+    pub file_name: String,
+    pub content_path: String,
+    pub mime_type: String,
+    pub bytes: Option<u64>,
+    pub duration_ms: Option<u64>,
+    pub termination_reason: Option<SessionRecordingTerminationReason>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionRecordingPlaybackOmittedSegment {
+    pub recording_id: Uuid,
+    pub previous_recording_id: Option<Uuid>,
+    pub state: SessionRecordingState,
+    pub artifact_available: bool,
+    pub omitted_reason: String,
+    pub termination_reason: Option<SessionRecordingTerminationReason>,
+    pub error: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RecordingPlaybackError {
+    #[error("recording playback export is empty")]
+    Empty,
+    #[error("failed to encode playback manifest: {0}")]
+    ManifestEncode(#[from] serde_json::Error),
+    #[error("failed to write playback export: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("failed to load recording artifact for playback export: {0}")]
+    Artifact(#[from] RecordingArtifactStoreError),
+    #[error("failed to package playback export: {0}")]
+    Package(#[from] zip::result::ZipError),
+}
+
+#[derive(Debug, Clone)]
+struct PreparedPlaybackSegmentArtifact {
+    file_name: String,
+    artifact_ref: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PreparedSessionRecordingPlayback {
+    pub resource: SessionRecordingPlaybackResource,
+    pub manifest: SessionRecordingPlaybackManifest,
+    segment_artifacts: Vec<PreparedPlaybackSegmentArtifact>,
+}
+
+impl PreparedSessionRecordingPlayback {
+    pub async fn export_bundle(
+        &self,
+        artifact_store: &RecordingArtifactStore,
+    ) -> Result<Vec<u8>, RecordingPlaybackError> {
+        if self.segment_artifacts.is_empty() {
+            return Err(RecordingPlaybackError::Empty);
+        }
+
+        let manifest_json = serde_json::to_vec_pretty(&self.manifest)?;
+        let player_html = build_player_html(&self.manifest)?;
+        let cursor = std::io::Cursor::new(Vec::new());
+        let mut zip = zip::ZipWriter::new(cursor);
+        let file_options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+
+        zip.start_file("manifest.json", file_options)?;
+        zip.write_all(&manifest_json)?;
+        zip.start_file("player.html", file_options)?;
+        zip.write_all(player_html.as_bytes())?;
+
+        for segment in &self.segment_artifacts {
+            let bytes = artifact_store.read(&segment.artifact_ref).await?;
+            zip.start_file(&segment.file_name, file_options)?;
+            zip.write_all(&bytes)?;
+        }
+
+        let cursor = zip.finish()?;
+        Ok(cursor.into_inner())
+    }
+}
+
+pub fn prepare_session_recording_playback(
+    session_id: Uuid,
+    recordings: &[StoredSessionRecording],
+    generated_at: DateTime<Utc>,
+) -> PreparedSessionRecordingPlayback {
+    let manifest_path = format!("/api/v1/sessions/{session_id}/recording-playback/manifest");
+    let export_path = format!("/api/v1/sessions/{session_id}/recording-playback/export");
+    let mut ordered = recordings.to_vec();
+    ordered.sort_by(|left, right| {
+        left.started_at
+            .cmp(&right.started_at)
+            .then_with(|| left.created_at.cmp(&right.created_at))
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    let mut included_bytes = 0_u64;
+    let mut included_duration_ms = 0_u64;
+    let mut included_segments = Vec::new();
+    let mut omitted_segments = Vec::new();
+    let mut segment_artifacts = Vec::new();
+    let mut failed_segment_count = 0_u32;
+    let mut active_segment_count = 0_u32;
+    let mut missing_artifact_segment_count = 0_u32;
+
+    for recording in ordered {
+        let artifact_available = recording.artifact_ref.is_some();
+        match recording.state {
+            SessionRecordingState::Ready if artifact_available => {
+                let sequence = included_segments.len() as u32 + 1;
+                let file_name = format!(
+                    "segments/{sequence:04}-{}.{}",
+                    recording.id,
+                    recording_extension(recording.format)
+                );
+                included_bytes = included_bytes.saturating_add(recording.bytes.unwrap_or(0));
+                included_duration_ms =
+                    included_duration_ms.saturating_add(recording.duration_ms.unwrap_or(0));
+                included_segments.push(SessionRecordingPlaybackSegment {
+                    sequence,
+                    recording_id: recording.id,
+                    previous_recording_id: recording.previous_recording_id,
+                    file_name: file_name.clone(),
+                    content_path: format!(
+                        "/api/v1/sessions/{}/recordings/{}/content",
+                        recording.session_id, recording.id
+                    ),
+                    mime_type: recording
+                        .mime_type
+                        .clone()
+                        .unwrap_or_else(|| recording_mime_type(recording.format).to_string()),
+                    bytes: recording.bytes,
+                    duration_ms: recording.duration_ms,
+                    termination_reason: recording.termination_reason,
+                    started_at: recording.started_at,
+                    completed_at: recording.completed_at,
+                });
+                segment_artifacts.push(PreparedPlaybackSegmentArtifact {
+                    file_name,
+                    artifact_ref: recording.artifact_ref.unwrap_or_default(),
+                });
+            }
+            SessionRecordingState::Ready => {
+                missing_artifact_segment_count += 1;
+                omitted_segments.push(omitted_segment(recording, "artifact_missing"));
+            }
+            SessionRecordingState::Failed => {
+                failed_segment_count += 1;
+                omitted_segments.push(omitted_segment(recording, "failed"));
+            }
+            _ => {
+                active_segment_count += 1;
+                omitted_segments.push(omitted_segment(recording, "in_progress"));
+            }
+        }
+    }
+
+    let segment_count = (included_segments.len() + omitted_segments.len()) as u32;
+    let state = if segment_count == 0 {
+        SessionRecordingPlaybackState::Empty
+    } else if omitted_segments.is_empty() {
+        SessionRecordingPlaybackState::Ready
+    } else {
+        SessionRecordingPlaybackState::Partial
+    };
+    let manifest = SessionRecordingPlaybackManifest {
+        format_version: "browserpane_recording_playback_v1",
+        session_id,
+        state,
+        segment_count,
+        included_segment_count: included_segments.len() as u32,
+        failed_segment_count,
+        active_segment_count,
+        missing_artifact_segment_count,
+        included_bytes,
+        included_duration_ms,
+        generated_at,
+        segments: included_segments,
+        omitted_segments,
+    };
+    let resource = SessionRecordingPlaybackResource {
+        session_id,
+        state,
+        segment_count,
+        included_segment_count: manifest.included_segment_count,
+        failed_segment_count,
+        active_segment_count,
+        missing_artifact_segment_count,
+        included_bytes,
+        included_duration_ms,
+        manifest_path,
+        export_path,
+        generated_at,
+    };
+
+    PreparedSessionRecordingPlayback {
+        resource,
+        manifest,
+        segment_artifacts,
+    }
+}
+
+fn recording_extension(format: SessionRecordingFormat) -> &'static str {
+    match format {
+        SessionRecordingFormat::Webm => "webm",
+    }
+}
+
+fn recording_mime_type(format: SessionRecordingFormat) -> &'static str {
+    match format {
+        SessionRecordingFormat::Webm => "video/webm",
+    }
+}
+
+fn omitted_segment(
+    recording: StoredSessionRecording,
+    omitted_reason: &str,
+) -> SessionRecordingPlaybackOmittedSegment {
+    SessionRecordingPlaybackOmittedSegment {
+        recording_id: recording.id,
+        previous_recording_id: recording.previous_recording_id,
+        state: recording.state,
+        artifact_available: recording.artifact_ref.is_some(),
+        omitted_reason: omitted_reason.to_string(),
+        termination_reason: recording.termination_reason,
+        error: recording.error,
+        started_at: recording.started_at,
+        completed_at: recording.completed_at,
+    }
+}
+
+fn build_player_html(
+    manifest: &SessionRecordingPlaybackManifest,
+) -> Result<String, RecordingPlaybackError> {
+    let manifest_json = serde_json::to_string(manifest)?;
+    Ok(format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>BrowserPane Recording Playback</title>
+  <style>
+    :root {{
+      color-scheme: light;
+      font-family: "SF Mono", "Menlo", monospace;
+      background: linear-gradient(160deg, #f2efe7, #ddd7cb);
+      color: #1b1a17;
+    }}
+    body {{
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 32px;
+    }}
+    main {{
+      width: min(960px, 100%);
+      background: rgba(255, 255, 255, 0.82);
+      backdrop-filter: blur(12px);
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      border-radius: 24px;
+      box-shadow: 0 28px 80px rgba(38, 32, 21, 0.14);
+      padding: 24px;
+    }}
+    h1 {{
+      margin-top: 0;
+      font-size: 20px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }}
+    video {{
+      width: 100%;
+      border-radius: 16px;
+      background: #111;
+    }}
+    .meta {{
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin: 16px 0;
+      font-size: 13px;
+    }}
+    .meta span {{
+      padding: 6px 10px;
+      background: rgba(0, 0, 0, 0.05);
+      border-radius: 999px;
+    }}
+    ol {{
+      padding-left: 20px;
+      margin: 0;
+      display: grid;
+      gap: 6px;
+      font-size: 13px;
+    }}
+    button {{
+      margin-right: 8px;
+    }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>BrowserPane Recording Playback</h1>
+    <video id="player" controls autoplay></video>
+    <div class="meta" id="summary"></div>
+    <p>
+      <button id="prev">Previous</button>
+      <button id="next">Next</button>
+    </p>
+    <ol id="segments"></ol>
+  </main>
+  <script>
+    const manifest = {manifest_json};
+    const player = document.getElementById('player');
+    const summary = document.getElementById('summary');
+    const segmentList = document.getElementById('segments');
+    const prev = document.getElementById('prev');
+    const next = document.getElementById('next');
+    let index = 0;
+
+    function renderSummary() {{
+      summary.innerHTML = '';
+      [
+        `state: ${{manifest.state}}`,
+        `segments: ${{manifest.included_segment_count}} / ${{manifest.segment_count}}`,
+        `duration_ms: ${{manifest.included_duration_ms}}`,
+        `bytes: ${{manifest.included_bytes}}`
+      ].forEach((value) => {{
+        const node = document.createElement('span');
+        node.textContent = value;
+        summary.appendChild(node);
+      }});
+    }}
+
+    function renderSegments() {{
+      segmentList.innerHTML = '';
+      manifest.segments.forEach((segment, segmentIndex) => {{
+        const item = document.createElement('li');
+        item.textContent = `${{segment.sequence}}. ${{segment.recording_id}}`;
+        if (segmentIndex === index) {{
+          item.style.fontWeight = '700';
+        }}
+        segmentList.appendChild(item);
+      }});
+    }}
+
+    function loadSegment(segmentIndex) {{
+      if (!manifest.segments.length) {{
+        return;
+      }}
+      index = Math.max(0, Math.min(segmentIndex, manifest.segments.length - 1));
+      player.src = manifest.segments[index].file_name;
+      renderSegments();
+    }}
+
+    player.addEventListener('ended', () => {{
+      if (index + 1 < manifest.segments.length) {{
+        loadSegment(index + 1);
+        player.play().catch(() => {{}});
+      }}
+    }});
+    prev.addEventListener('click', () => loadSegment(index - 1));
+    next.addEventListener('click', () => loadSegment(index + 1));
+
+    renderSummary();
+    renderSegments();
+    loadSegment(0);
+  </script>
+</body>
+</html>
+"#
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::*;
+
+    fn ready_recording(
+        session_id: Uuid,
+        recording_id: Uuid,
+        previous_recording_id: Option<Uuid>,
+        started_at: DateTime<Utc>,
+    ) -> StoredSessionRecording {
+        StoredSessionRecording {
+            id: recording_id,
+            session_id,
+            previous_recording_id,
+            state: SessionRecordingState::Ready,
+            format: SessionRecordingFormat::Webm,
+            mime_type: Some("video/webm".to_string()),
+            bytes: Some(1024),
+            duration_ms: Some(500),
+            error: None,
+            termination_reason: Some(SessionRecordingTerminationReason::ManualStop),
+            artifact_ref: Some(format!("local_fs:{session_id}/{recording_id}.webm")),
+            started_at,
+            completed_at: Some(started_at + TimeDelta::milliseconds(500)),
+            created_at: started_at,
+            updated_at: started_at + TimeDelta::milliseconds(500),
+        }
+    }
+
+    #[test]
+    fn prepare_playback_marks_partial_when_segments_are_missing() {
+        let session_id = Uuid::now_v7();
+        let first_id = Uuid::now_v7();
+        let second_id = Uuid::now_v7();
+        let now = Utc::now();
+        let ready = ready_recording(session_id, first_id, None, now);
+        let failed = StoredSessionRecording {
+            id: second_id,
+            session_id,
+            previous_recording_id: Some(first_id),
+            state: SessionRecordingState::Failed,
+            format: SessionRecordingFormat::Webm,
+            mime_type: Some("video/webm".to_string()),
+            bytes: None,
+            duration_ms: None,
+            error: Some("worker exited".to_string()),
+            termination_reason: Some(SessionRecordingTerminationReason::WorkerExit),
+            artifact_ref: None,
+            started_at: now + TimeDelta::seconds(1),
+            completed_at: Some(now + TimeDelta::seconds(2)),
+            created_at: now + TimeDelta::seconds(1),
+            updated_at: now + TimeDelta::seconds(2),
+        };
+
+        let playback =
+            prepare_session_recording_playback(session_id, &[failed, ready.clone()], now);
+
+        assert_eq!(
+            playback.resource.state,
+            SessionRecordingPlaybackState::Partial
+        );
+        assert_eq!(playback.resource.segment_count, 2);
+        assert_eq!(playback.resource.included_segment_count, 1);
+        assert_eq!(playback.resource.failed_segment_count, 1);
+        assert_eq!(playback.resource.missing_artifact_segment_count, 0);
+        assert_eq!(playback.manifest.segments.len(), 1);
+        assert_eq!(playback.manifest.segments[0].recording_id, ready.id);
+        assert_eq!(playback.manifest.omitted_segments.len(), 1);
+        assert_eq!(
+            playback.manifest.omitted_segments[0].omitted_reason,
+            "failed"
+        );
+    }
+}

--- a/code/apps/bpane-gateway/src/recording_retention.rs
+++ b/code/apps/bpane-gateway/src/recording_retention.rs
@@ -6,6 +6,7 @@ use tokio::time::sleep;
 use tracing::{info, warn};
 
 use crate::recording_artifact_store::RecordingArtifactStore;
+use crate::recording_observability::RecordingObservability;
 use crate::session_control::{
     RecordingArtifactRetentionCandidate, SessionStore, SessionStoreError,
 };
@@ -13,6 +14,7 @@ use crate::session_control::{
 #[derive(Clone)]
 pub struct RecordingRetentionManager {
     artifact_store: Arc<RecordingArtifactStore>,
+    observability: Arc<RecordingObservability>,
     session_store: SessionStore,
     interval: Duration,
 }
@@ -21,10 +23,12 @@ impl RecordingRetentionManager {
     pub fn new(
         session_store: SessionStore,
         artifact_store: Arc<RecordingArtifactStore>,
+        observability: Arc<RecordingObservability>,
         interval: Duration,
     ) -> Self {
         Self {
             artifact_store,
+            observability,
             session_store,
             interval,
         }
@@ -46,6 +50,9 @@ impl RecordingRetentionManager {
             .session_store
             .list_recording_artifact_retention_candidates(now)
             .await?;
+        self.observability
+            .record_retention_pass(now, candidates.len())
+            .await;
         for candidate in candidates {
             self.cleanup_candidate(candidate).await;
         }
@@ -56,6 +63,7 @@ impl RecordingRetentionManager {
         match self.artifact_store.delete(&candidate.artifact_ref).await {
             Ok(()) => {}
             Err(error) => {
+                self.observability.record_retention_failure();
                 warn!(
                     session_id = %candidate.session_id,
                     recording_id = %candidate.recording_id,
@@ -72,6 +80,7 @@ impl RecordingRetentionManager {
             .await
         {
             Ok(Some(_)) => {
+                self.observability.record_retention_deleted_artifact();
                 info!(
                     session_id = %candidate.session_id,
                     recording_id = %candidate.recording_id,
@@ -81,6 +90,7 @@ impl RecordingRetentionManager {
             }
             Ok(None) => {}
             Err(error) => {
+                self.observability.record_retention_failure();
                 warn!(
                     session_id = %candidate.session_id,
                     recording_id = %candidate.recording_id,
@@ -105,6 +115,7 @@ mod tests {
     use crate::recording_artifact_store::{
         FinalizeRecordingArtifactRequest, RecordingArtifactStore,
     };
+    use crate::recording_observability::RecordingObservability;
     use crate::session_control::{
         CreateSessionRequest, PersistCompletedSessionRecordingRequest, SessionOwnerMode,
         SessionRecordingFormat, SessionRecordingMode, SessionRecordingPolicy,
@@ -191,6 +202,7 @@ mod tests {
         let manager = Arc::new(RecordingRetentionManager::new(
             store.clone(),
             artifact_store.clone(),
+            Arc::new(RecordingObservability::default()),
             Duration::from_secs(60),
         ));
 
@@ -260,6 +272,7 @@ mod tests {
         let manager = Arc::new(RecordingRetentionManager::new(
             store.clone(),
             artifact_store.clone(),
+            Arc::new(RecordingObservability::default()),
             Duration::from_secs(60),
         ));
 
@@ -282,5 +295,66 @@ mod tests {
             reloaded.artifact_ref.as_deref(),
             Some(stored_artifact.artifact_ref.as_str())
         );
+    }
+
+    #[tokio::test]
+    async fn cleanup_pass_updates_observability_counters() {
+        let store = SessionStore::in_memory();
+        let session_id = create_manual_recording_session(&store, Some(60)).await;
+        let temp_dir = tempdir().unwrap();
+        let source_path = temp_dir.path().join("recording.webm");
+        std::fs::write(&source_path, b"artifact").unwrap();
+        let artifact_root = temp_dir.path().join("artifacts");
+        let artifact_store = Arc::new(RecordingArtifactStore::local_fs(artifact_root.clone()));
+        let observability = Arc::new(RecordingObservability::default());
+
+        let recording = store
+            .create_recording_for_session(session_id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        let stored_artifact = artifact_store
+            .finalize(FinalizeRecordingArtifactRequest {
+                session_id,
+                recording_id: recording.id,
+                format: SessionRecordingFormat::Webm,
+                source_path: source_path.to_string_lossy().to_string(),
+            })
+            .await
+            .unwrap();
+        store
+            .complete_recording_for_session(
+                session_id,
+                recording.id,
+                PersistCompletedSessionRecordingRequest {
+                    artifact_ref: stored_artifact.artifact_ref.clone(),
+                    mime_type: Some("video/webm".to_string()),
+                    bytes: Some(8),
+                    duration_ms: Some(500),
+                },
+            )
+            .await
+            .unwrap();
+        let completed = store
+            .get_recording_for_session(session_id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let manager = Arc::new(RecordingRetentionManager::new(
+            store.clone(),
+            artifact_store,
+            observability.clone(),
+            Duration::from_secs(60),
+        ));
+
+        manager
+            .run_cleanup_pass(completed.completed_at.unwrap() + ChronoDuration::seconds(61))
+            .await
+            .unwrap();
+
+        let snapshot = observability.snapshot().await;
+        assert_eq!(snapshot.retention_passes_total, 1);
+        assert_eq!(snapshot.retention_candidates_total, 1);
+        assert_eq!(snapshot.retention_deleted_artifacts_total, 1);
+        assert_eq!(snapshot.retention_failures_total, 0);
     }
 }

--- a/code/apps/bpane-gateway/src/recording_retention.rs
+++ b/code/apps/bpane-gateway/src/recording_retention.rs
@@ -1,0 +1,286 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use tokio::time::sleep;
+use tracing::{info, warn};
+
+use crate::recording_artifact_store::RecordingArtifactStore;
+use crate::session_control::{
+    RecordingArtifactRetentionCandidate, SessionStore, SessionStoreError,
+};
+
+#[derive(Clone)]
+pub struct RecordingRetentionManager {
+    artifact_store: Arc<RecordingArtifactStore>,
+    session_store: SessionStore,
+    interval: Duration,
+}
+
+impl RecordingRetentionManager {
+    pub fn new(
+        session_store: SessionStore,
+        artifact_store: Arc<RecordingArtifactStore>,
+        interval: Duration,
+    ) -> Self {
+        Self {
+            artifact_store,
+            session_store,
+            interval,
+        }
+    }
+
+    pub fn start(self: Arc<Self>) {
+        tokio::spawn(async move {
+            loop {
+                sleep(self.interval).await;
+                if let Err(error) = self.run_cleanup_pass(Utc::now()).await {
+                    warn!("recording artifact cleanup pass failed: {error}");
+                }
+            }
+        });
+    }
+
+    pub async fn run_cleanup_pass(&self, now: DateTime<Utc>) -> Result<(), SessionStoreError> {
+        let candidates = self
+            .session_store
+            .list_recording_artifact_retention_candidates(now)
+            .await?;
+        for candidate in candidates {
+            self.cleanup_candidate(candidate).await;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_candidate(&self, candidate: RecordingArtifactRetentionCandidate) {
+        match self.artifact_store.delete(&candidate.artifact_ref).await {
+            Ok(()) => {}
+            Err(error) => {
+                warn!(
+                    session_id = %candidate.session_id,
+                    recording_id = %candidate.recording_id,
+                    artifact_ref = %candidate.artifact_ref,
+                    "failed to remove expired recording artifact: {error}"
+                );
+                return;
+            }
+        }
+
+        match self
+            .session_store
+            .clear_recording_artifact_path(candidate.session_id, candidate.recording_id)
+            .await
+        {
+            Ok(Some(_)) => {
+                info!(
+                    session_id = %candidate.session_id,
+                    recording_id = %candidate.recording_id,
+                    expired_at = %candidate.expires_at,
+                    "cleared retained recording artifact after expiration"
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                warn!(
+                    session_id = %candidate.session_id,
+                    recording_id = %candidate.recording_id,
+                    "failed to clear expired recording artifact metadata: {error}"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use chrono::Duration as ChronoDuration;
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::auth::AuthenticatedPrincipal;
+    use crate::recording_artifact_store::{
+        FinalizeRecordingArtifactRequest, RecordingArtifactStore,
+    };
+    use crate::session_control::{
+        CreateSessionRequest, PersistCompletedSessionRecordingRequest, SessionOwnerMode,
+        SessionRecordingFormat, SessionRecordingMode, SessionRecordingPolicy,
+    };
+
+    fn owner() -> AuthenticatedPrincipal {
+        AuthenticatedPrincipal {
+            subject: "owner".to_string(),
+            issuer: "issuer".to_string(),
+            display_name: Some("Owner".to_string()),
+            client_id: None,
+        }
+    }
+
+    async fn create_manual_recording_session(
+        store: &SessionStore,
+        retention_sec: Option<u32>,
+    ) -> uuid::Uuid {
+        let session = store
+            .create_session(
+                &owner(),
+                CreateSessionRequest {
+                    template_id: None,
+                    owner_mode: None,
+                    viewport: None,
+                    idle_timeout_sec: None,
+                    labels: HashMap::new(),
+                    integration_context: None,
+                    recording: SessionRecordingPolicy {
+                        mode: SessionRecordingMode::Manual,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec,
+                    },
+                },
+                SessionOwnerMode::Collaborative,
+            )
+            .await
+            .unwrap();
+        session.id
+    }
+
+    #[tokio::test]
+    async fn cleanup_pass_removes_expired_ready_artifacts() {
+        let store = SessionStore::in_memory();
+        let session_id = create_manual_recording_session(&store, Some(60)).await;
+        let temp_dir = tempdir().unwrap();
+        let source_path = temp_dir.path().join("recording.webm");
+        std::fs::write(&source_path, b"artifact").unwrap();
+        let artifact_root = temp_dir.path().join("artifacts");
+        let artifact_store = Arc::new(RecordingArtifactStore::local_fs(artifact_root.clone()));
+
+        let recording = store
+            .create_recording_for_session(session_id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        let stored_artifact = artifact_store
+            .finalize(FinalizeRecordingArtifactRequest {
+                session_id,
+                recording_id: recording.id,
+                format: SessionRecordingFormat::Webm,
+                source_path: source_path.to_string_lossy().to_string(),
+            })
+            .await
+            .unwrap();
+        store
+            .complete_recording_for_session(
+                session_id,
+                recording.id,
+                PersistCompletedSessionRecordingRequest {
+                    artifact_ref: stored_artifact.artifact_ref.clone(),
+                    mime_type: Some("video/webm".to_string()),
+                    bytes: Some(8),
+                    duration_ms: Some(500),
+                },
+            )
+            .await
+            .unwrap();
+
+        let completed = store
+            .get_recording_for_session(session_id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let manager = Arc::new(RecordingRetentionManager::new(
+            store.clone(),
+            artifact_store.clone(),
+            Duration::from_secs(60),
+        ));
+
+        manager
+            .run_cleanup_pass(completed.completed_at.unwrap() + ChronoDuration::seconds(61))
+            .await
+            .unwrap();
+
+        assert!(artifact_store
+            .read(&stored_artifact.artifact_ref)
+            .await
+            .is_err());
+        let reloaded = store
+            .get_recording_for_session(session_id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(reloaded.artifact_ref.is_none());
+        assert_eq!(
+            reloaded.state,
+            crate::session_control::SessionRecordingState::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_pass_keeps_unexpired_ready_artifacts() {
+        let store = SessionStore::in_memory();
+        let session_id = create_manual_recording_session(&store, Some(60)).await;
+        let temp_dir = tempdir().unwrap();
+        let source_path = temp_dir.path().join("recording.webm");
+        std::fs::write(&source_path, b"artifact").unwrap();
+        let artifact_root = temp_dir.path().join("artifacts");
+        let artifact_store = Arc::new(RecordingArtifactStore::local_fs(artifact_root.clone()));
+
+        let recording = store
+            .create_recording_for_session(session_id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        let stored_artifact = artifact_store
+            .finalize(FinalizeRecordingArtifactRequest {
+                session_id,
+                recording_id: recording.id,
+                format: SessionRecordingFormat::Webm,
+                source_path: source_path.to_string_lossy().to_string(),
+            })
+            .await
+            .unwrap();
+        store
+            .complete_recording_for_session(
+                session_id,
+                recording.id,
+                PersistCompletedSessionRecordingRequest {
+                    artifact_ref: stored_artifact.artifact_ref.clone(),
+                    mime_type: Some("video/webm".to_string()),
+                    bytes: Some(8),
+                    duration_ms: Some(500),
+                },
+            )
+            .await
+            .unwrap();
+
+        let completed = store
+            .get_recording_for_session(session_id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let manager = Arc::new(RecordingRetentionManager::new(
+            store.clone(),
+            artifact_store.clone(),
+            Duration::from_secs(60),
+        ));
+
+        manager
+            .run_cleanup_pass(completed.completed_at.unwrap() + ChronoDuration::seconds(59))
+            .await
+            .unwrap();
+
+        let bytes = artifact_store
+            .read(&stored_artifact.artifact_ref)
+            .await
+            .unwrap();
+        assert_eq!(bytes.as_slice(), b"artifact");
+        let reloaded = store
+            .get_recording_for_session(session_id, recording.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            reloaded.artifact_ref.as_deref(),
+            Some(stored_artifact.artifact_ref.as_str())
+        );
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control.rs
+++ b/code/apps/bpane-gateway/src/session_control.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::Context;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value};
 use tokio::sync::Mutex;
@@ -119,6 +119,143 @@ impl Default for SessionViewport {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRecordingMode {
+    #[default]
+    Disabled,
+    Manual,
+    Always,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRecordingFormat {
+    #[default]
+    Webm,
+}
+
+impl SessionRecordingFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Webm => "webm",
+        }
+    }
+}
+
+impl FromStr for SessionRecordingFormat {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "webm" => Ok(Self::Webm),
+            _ => Err("unknown session recording format"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRecordingPolicy {
+    #[serde(default)]
+    pub mode: SessionRecordingMode,
+    #[serde(default)]
+    pub format: SessionRecordingFormat,
+    #[serde(default)]
+    pub retention_sec: Option<u32>,
+}
+
+impl Default for SessionRecordingPolicy {
+    fn default() -> Self {
+        Self {
+            mode: SessionRecordingMode::Disabled,
+            format: SessionRecordingFormat::Webm,
+            retention_sec: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRecordingState {
+    Starting,
+    Recording,
+    Finalizing,
+    Ready,
+    Failed,
+}
+
+impl SessionRecordingState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Recording => "recording",
+            Self::Finalizing => "finalizing",
+            Self::Ready => "ready",
+            Self::Failed => "failed",
+        }
+    }
+
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Starting | Self::Recording | Self::Finalizing)
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Ready | Self::Failed)
+    }
+}
+
+impl FromStr for SessionRecordingState {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "starting" => Ok(Self::Starting),
+            "recording" => Ok(Self::Recording),
+            "finalizing" => Ok(Self::Finalizing),
+            "ready" => Ok(Self::Ready),
+            "failed" => Ok(Self::Failed),
+            _ => Err("unknown session recording state"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRecordingTerminationReason {
+    ManualStop,
+    SessionStop,
+    IdleStop,
+    GatewayRestart,
+    WorkerExit,
+}
+
+impl SessionRecordingTerminationReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ManualStop => "manual_stop",
+            Self::SessionStop => "session_stop",
+            Self::IdleStop => "idle_stop",
+            Self::GatewayRestart => "gateway_restart",
+            Self::WorkerExit => "worker_exit",
+        }
+    }
+}
+
+impl FromStr for SessionRecordingTerminationReason {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "manual_stop" => Ok(Self::ManualStop),
+            "session_stop" => Ok(Self::SessionStop),
+            "idle_stop" => Ok(Self::IdleStop),
+            "gateway_restart" => Ok(Self::GatewayRestart),
+            "worker_exit" => Ok(Self::WorkerExit),
+            _ => Err("unknown session recording termination reason"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionOwner {
     pub subject: String,
@@ -197,11 +334,37 @@ pub struct SessionResource {
     pub idle_timeout_sec: Option<u32>,
     pub labels: HashMap<String, String>,
     pub integration_context: Option<Value>,
+    pub recording: SessionRecordingPolicy,
     pub connect: SessionConnectInfo,
     pub runtime: SessionRuntimeInfo,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub stopped_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SessionRecordingResource {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub previous_recording_id: Option<Uuid>,
+    pub state: SessionRecordingState,
+    pub format: SessionRecordingFormat,
+    pub mime_type: Option<String>,
+    pub bytes: Option<u64>,
+    pub duration_ms: Option<u64>,
+    pub error: Option<String>,
+    pub termination_reason: Option<SessionRecordingTerminationReason>,
+    pub artifact_available: bool,
+    pub content_path: String,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionRecordingListResponse {
+    pub recordings: Vec<SessionRecordingResource>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -218,6 +381,8 @@ pub struct CreateSessionRequest {
     pub labels: HashMap<String, String>,
     #[serde(default)]
     pub integration_context: Option<Value>,
+    #[serde(default)]
+    pub recording: SessionRecordingPolicy,
 }
 
 #[derive(Debug, Deserialize)]
@@ -227,6 +392,33 @@ pub struct SetAutomationDelegateRequest {
     pub issuer: Option<String>,
     #[serde(default)]
     pub display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CompleteSessionRecordingRequest {
+    #[serde(alias = "artifact_path")]
+    pub source_path: String,
+    #[serde(default)]
+    pub mime_type: Option<String>,
+    #[serde(default)]
+    pub bytes: Option<u64>,
+    #[serde(default)]
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistCompletedSessionRecordingRequest {
+    pub artifact_ref: String,
+    pub mime_type: Option<String>,
+    pub bytes: Option<u64>,
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FailSessionRecordingRequest {
+    pub error: String,
+    #[serde(default)]
+    pub termination_reason: Option<SessionRecordingTerminationReason>,
 }
 
 #[derive(Debug, Serialize)]
@@ -246,9 +438,75 @@ pub struct StoredSession {
     pub idle_timeout_sec: Option<u32>,
     pub labels: HashMap<String, String>,
     pub integration_context: Option<Value>,
+    pub recording: SessionRecordingPolicy,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub stopped_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredSessionRecording {
+    pub id: Uuid,
+    pub session_id: Uuid,
+    pub previous_recording_id: Option<Uuid>,
+    pub state: SessionRecordingState,
+    pub format: SessionRecordingFormat,
+    pub mime_type: Option<String>,
+    pub bytes: Option<u64>,
+    pub duration_ms: Option<u64>,
+    pub error: Option<String>,
+    pub termination_reason: Option<SessionRecordingTerminationReason>,
+    pub artifact_ref: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordingArtifactRetentionCandidate {
+    pub session_id: Uuid,
+    pub recording_id: Uuid,
+    pub artifact_ref: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRecordingWorkerAssignmentStatus {
+    Starting,
+    Running,
+    Stopping,
+}
+
+impl SessionRecordingWorkerAssignmentStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Stopping => "stopping",
+        }
+    }
+}
+
+impl FromStr for SessionRecordingWorkerAssignmentStatus {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "starting" => Ok(Self::Starting),
+            "running" => Ok(Self::Running),
+            "stopping" => Ok(Self::Stopping),
+            _ => Err("unknown session recording worker assignment status"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PersistedSessionRecordingWorkerAssignment {
+    pub session_id: Uuid,
+    pub recording_id: Uuid,
+    pub status: SessionRecordingWorkerAssignmentStatus,
+    pub process_id: Option<u32>,
 }
 
 impl StoredSession {
@@ -270,6 +528,7 @@ impl StoredSession {
             idle_timeout_sec: self.idle_timeout_sec,
             labels: self.labels.clone(),
             integration_context: self.integration_context.clone(),
+            recording: self.recording.clone(),
             connect: SessionConnectInfo {
                 gateway_url: public_gateway_url.to_string(),
                 transport_path: "/session".to_string(),
@@ -285,9 +544,36 @@ impl StoredSession {
     }
 }
 
+impl StoredSessionRecording {
+    pub fn to_resource(&self) -> SessionRecordingResource {
+        SessionRecordingResource {
+            id: self.id,
+            session_id: self.session_id,
+            previous_recording_id: self.previous_recording_id,
+            state: self.state,
+            format: self.format,
+            mime_type: self.mime_type.clone(),
+            bytes: self.bytes,
+            duration_ms: self.duration_ms,
+            error: self.error.clone(),
+            termination_reason: self.termination_reason,
+            artifact_available: self.artifact_ref.is_some(),
+            content_path: format!(
+                "/api/v1/sessions/{}/recordings/{}/content",
+                self.session_id, self.id
+            ),
+            started_at: self.started_at,
+            completed_at: self.completed_at,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum SessionStoreError {
     ActiveSessionConflict { max_runtime_sessions: usize },
+    Conflict(String),
     InvalidRequest(String),
     Backend(String),
 }
@@ -305,6 +591,7 @@ impl std::fmt::Display for SessionStoreError {
                     if *max_runtime_sessions == 1 { "" } else { "s" }
                 )
             }
+            Self::Conflict(message) => write!(f, "{message}"),
             Self::InvalidRequest(message) => write!(f, "{message}"),
             Self::Backend(message) => write!(f, "{message}"),
         }
@@ -359,7 +646,9 @@ impl SessionStore {
         Self {
             backend: SessionStoreBackend::InMemory(Arc::new(InMemorySessionStore {
                 sessions: Mutex::new(Vec::new()),
+                recordings: Mutex::new(Vec::new()),
                 runtime_assignments: Mutex::new(HashMap::new()),
+                recording_worker_assignments: Mutex::new(HashMap::new()),
                 config: SessionStoreConfig::from(runtime_profile),
             })),
         }
@@ -586,10 +875,227 @@ impl SessionStore {
         }
     }
 
+    pub async fn create_recording_for_session(
+        &self,
+        session_id: Uuid,
+        format: SessionRecordingFormat,
+        previous_recording_id: Option<Uuid>,
+    ) -> Result<StoredSessionRecording, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .create_recording_for_session(session_id, format, previous_recording_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .create_recording_for_session(session_id, format, previous_recording_id)
+                    .await
+            }
+        }
+    }
+
+    pub async fn list_recordings_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<StoredSessionRecording>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.list_recordings_for_session(session_id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.list_recordings_for_session(session_id).await
+            }
+        }
+    }
+
+    pub async fn get_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .get_recording_for_session(session_id, recording_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .get_recording_for_session(session_id, recording_id)
+                    .await
+            }
+        }
+    }
+
+    pub async fn get_latest_recording_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.get_latest_recording_for_session(session_id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.get_latest_recording_for_session(session_id).await
+            }
+        }
+    }
+
+    pub async fn list_recording_artifact_retention_candidates(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<RecordingArtifactRetentionCandidate>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .list_recording_artifact_retention_candidates(now)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .list_recording_artifact_retention_candidates(now)
+                    .await
+            }
+        }
+    }
+
+    pub async fn stop_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        termination_reason: SessionRecordingTerminationReason,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .stop_recording_for_session(session_id, recording_id, termination_reason)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .stop_recording_for_session(session_id, recording_id, termination_reason)
+                    .await
+            }
+        }
+    }
+
+    pub async fn clear_recording_artifact_path(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .clear_recording_artifact_path(session_id, recording_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .clear_recording_artifact_path(session_id, recording_id)
+                    .await
+            }
+        }
+    }
+
+    pub async fn complete_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: PersistCompletedSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        validate_persist_completed_recording_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .complete_recording_for_session(session_id, recording_id, request)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .complete_recording_for_session(session_id, recording_id, request)
+                    .await
+            }
+        }
+    }
+
+    pub async fn fail_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: FailSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        validate_fail_recording_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .fail_recording_for_session(session_id, recording_id, request)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .fail_recording_for_session(session_id, recording_id, request)
+                    .await
+            }
+        }
+    }
+
     pub async fn clear_runtime_assignment(&self, id: Uuid) -> Result<(), SessionStoreError> {
         match &self.backend {
             SessionStoreBackend::InMemory(store) => store.clear_runtime_assignment(id).await,
             SessionStoreBackend::Postgres(store) => store.clear_runtime_assignment(id).await,
+        }
+    }
+
+    pub async fn upsert_recording_worker_assignment(
+        &self,
+        assignment: PersistedSessionRecordingWorkerAssignment,
+    ) -> Result<(), SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.upsert_recording_worker_assignment(assignment).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.upsert_recording_worker_assignment(assignment).await
+            }
+        }
+    }
+
+    pub async fn clear_recording_worker_assignment(
+        &self,
+        session_id: Uuid,
+    ) -> Result<(), SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.clear_recording_worker_assignment(session_id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.clear_recording_worker_assignment(session_id).await
+            }
+        }
+    }
+
+    pub async fn get_recording_worker_assignment(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Option<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.get_recording_worker_assignment(session_id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.get_recording_worker_assignment(session_id).await
+            }
+        }
+    }
+
+    pub async fn list_recording_worker_assignments(
+        &self,
+    ) -> Result<Vec<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => store.list_recording_worker_assignments().await,
+            SessionStoreBackend::Postgres(store) => store.list_recording_worker_assignments().await,
         }
     }
 
@@ -666,6 +1172,13 @@ fn validate_create_request(request: &CreateSessionRequest) -> Result<(), Session
             ));
         }
     }
+    if let Some(retention_sec) = request.recording.retention_sec {
+        if retention_sec == 0 {
+            return Err(SessionStoreError::InvalidRequest(
+                "recording.retention_sec must be greater than zero when provided".to_string(),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -687,9 +1200,58 @@ fn validate_automation_delegate_request(
     Ok(())
 }
 
+fn validate_complete_recording_request(
+    request: &CompleteSessionRecordingRequest,
+) -> Result<(), SessionStoreError> {
+    if request.source_path.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "source_path must not be empty".to_string(),
+        ));
+    }
+    if let Some(mime_type) = &request.mime_type {
+        if mime_type.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "mime_type must not be empty when provided".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_persist_completed_recording_request(
+    request: &PersistCompletedSessionRecordingRequest,
+) -> Result<(), SessionStoreError> {
+    if request.artifact_ref.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "artifact_ref must not be empty".to_string(),
+        ));
+    }
+    if let Some(mime_type) = &request.mime_type {
+        if mime_type.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "mime_type must not be empty when provided".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_fail_recording_request(
+    request: &FailSessionRecordingRequest,
+) -> Result<(), SessionStoreError> {
+    if request.error.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "error must not be empty".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 struct InMemorySessionStore {
     sessions: Mutex<Vec<StoredSession>>,
+    recordings: Mutex<Vec<StoredSessionRecording>>,
     runtime_assignments: Mutex<HashMap<Uuid, PersistedSessionRuntimeAssignment>>,
+    recording_worker_assignments: Mutex<HashMap<Uuid, PersistedSessionRecordingWorkerAssignment>>,
     config: SessionStoreConfig,
 }
 
@@ -741,6 +1303,7 @@ impl InMemorySessionStore {
             idle_timeout_sec: request.idle_timeout_sec,
             labels: request.labels,
             integration_context: request.integration_context,
+            recording: request.recording,
             created_at: now,
             updated_at: now,
             stopped_at: None,
@@ -956,6 +1519,241 @@ impl InMemorySessionStore {
         Ok(Some(session.clone()))
     }
 
+    async fn create_recording_for_session(
+        &self,
+        session_id: Uuid,
+        format: SessionRecordingFormat,
+        previous_recording_id: Option<Uuid>,
+    ) -> Result<StoredSessionRecording, SessionStoreError> {
+        let mut recordings = self.recordings.lock().await;
+        if let Some(active) = recordings
+            .iter()
+            .find(|recording| recording.session_id == session_id && recording.state.is_active())
+        {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {session_id} already has active recording {}",
+                active.id
+            )));
+        }
+
+        let now = Utc::now();
+        let recording = StoredSessionRecording {
+            id: Uuid::now_v7(),
+            session_id,
+            previous_recording_id,
+            state: SessionRecordingState::Recording,
+            format,
+            mime_type: Some(recording_mime_type(format).to_string()),
+            bytes: None,
+            duration_ms: None,
+            error: None,
+            termination_reason: None,
+            artifact_ref: None,
+            started_at: now,
+            completed_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        recordings.push(recording.clone());
+        Ok(recording)
+    }
+
+    async fn list_recordings_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<StoredSessionRecording>, SessionStoreError> {
+        let mut recordings = self
+            .recordings
+            .lock()
+            .await
+            .iter()
+            .filter(|recording| recording.session_id == session_id)
+            .cloned()
+            .collect::<Vec<_>>();
+        recordings.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(recordings)
+    }
+
+    async fn get_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        Ok(self
+            .recordings
+            .lock()
+            .await
+            .iter()
+            .find(|recording| recording.session_id == session_id && recording.id == recording_id)
+            .cloned())
+    }
+
+    async fn get_latest_recording_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        Ok(self
+            .recordings
+            .lock()
+            .await
+            .iter()
+            .filter(|recording| recording.session_id == session_id)
+            .max_by(|left, right| {
+                left.updated_at
+                    .cmp(&right.updated_at)
+                    .then_with(|| left.created_at.cmp(&right.created_at))
+            })
+            .cloned())
+    }
+
+    async fn list_recording_artifact_retention_candidates(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<RecordingArtifactRetentionCandidate>, SessionStoreError> {
+        let sessions = self.sessions.lock().await;
+        let session_retention = sessions
+            .iter()
+            .filter_map(|session| {
+                session
+                    .recording
+                    .retention_sec
+                    .map(|retention| (session.id, retention))
+            })
+            .collect::<HashMap<_, _>>();
+        let recordings = self.recordings.lock().await;
+        let mut candidates = recordings
+            .iter()
+            .filter_map(|recording| {
+                if recording.state != SessionRecordingState::Ready {
+                    return None;
+                }
+                let artifact_ref = recording.artifact_ref.clone()?;
+                let completed_at = recording.completed_at?;
+                let retention_sec = *session_retention.get(&recording.session_id)?;
+                let expires_at = completed_at + ChronoDuration::seconds(i64::from(retention_sec));
+                if expires_at > now {
+                    return None;
+                }
+                Some(RecordingArtifactRetentionCandidate {
+                    session_id: recording.session_id,
+                    recording_id: recording.id,
+                    artifact_ref,
+                    expires_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| left.expires_at.cmp(&right.expires_at));
+        Ok(candidates)
+    }
+
+    async fn stop_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        termination_reason: SessionRecordingTerminationReason,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let mut recordings = self.recordings.lock().await;
+        let Some(recording) = recordings
+            .iter_mut()
+            .find(|recording| recording.session_id == session_id && recording.id == recording_id)
+        else {
+            return Ok(None);
+        };
+
+        if !recording.state.is_active() {
+            return Err(SessionStoreError::Conflict(format!(
+                "recording {recording_id} is not active"
+            )));
+        }
+
+        recording.state = SessionRecordingState::Finalizing;
+        recording.termination_reason = Some(termination_reason);
+        recording.updated_at = Utc::now();
+        Ok(Some(recording.clone()))
+    }
+
+    async fn complete_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: PersistCompletedSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let mut recordings = self.recordings.lock().await;
+        let Some(recording) = recordings
+            .iter_mut()
+            .find(|recording| recording.session_id == session_id && recording.id == recording_id)
+        else {
+            return Ok(None);
+        };
+
+        if !recording.state.is_active() {
+            return Err(SessionStoreError::Conflict(format!(
+                "recording {recording_id} is not active"
+            )));
+        }
+
+        let now = Utc::now();
+        recording.state = SessionRecordingState::Ready;
+        recording.artifact_ref = Some(request.artifact_ref);
+        recording.mime_type = request
+            .mime_type
+            .or_else(|| recording.mime_type.clone())
+            .or_else(|| Some(recording_mime_type(recording.format).to_string()));
+        recording.bytes = request.bytes;
+        recording.duration_ms = request.duration_ms;
+        recording.error = None;
+        recording.completed_at = Some(now);
+        recording.updated_at = now;
+        Ok(Some(recording.clone()))
+    }
+
+    async fn clear_recording_artifact_path(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let mut recordings = self.recordings.lock().await;
+        let Some(recording) = recordings
+            .iter_mut()
+            .find(|recording| recording.session_id == session_id && recording.id == recording_id)
+        else {
+            return Ok(None);
+        };
+
+        recording.artifact_ref = None;
+        recording.updated_at = Utc::now();
+        Ok(Some(recording.clone()))
+    }
+
+    async fn fail_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: FailSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let mut recordings = self.recordings.lock().await;
+        let Some(recording) = recordings
+            .iter_mut()
+            .find(|recording| recording.session_id == session_id && recording.id == recording_id)
+        else {
+            return Ok(None);
+        };
+
+        if matches!(recording.state, SessionRecordingState::Ready) {
+            return Err(SessionStoreError::Conflict(format!(
+                "recording {recording_id} is already complete"
+            )));
+        }
+
+        let now = Utc::now();
+        recording.state = SessionRecordingState::Failed;
+        recording.error = Some(request.error);
+        recording.termination_reason = request.termination_reason;
+        recording.completed_at = Some(now);
+        recording.updated_at = now;
+        Ok(Some(recording.clone()))
+    }
+
     async fn upsert_runtime_assignment(
         &self,
         assignment: PersistedSessionRuntimeAssignment,
@@ -970,6 +1768,43 @@ impl InMemorySessionStore {
     async fn clear_runtime_assignment(&self, id: Uuid) -> Result<(), SessionStoreError> {
         self.runtime_assignments.lock().await.remove(&id);
         Ok(())
+    }
+
+    async fn upsert_recording_worker_assignment(
+        &self,
+        assignment: PersistedSessionRecordingWorkerAssignment,
+    ) -> Result<(), SessionStoreError> {
+        self.recording_worker_assignments
+            .lock()
+            .await
+            .insert(assignment.session_id, assignment);
+        Ok(())
+    }
+
+    async fn clear_recording_worker_assignment(&self, id: Uuid) -> Result<(), SessionStoreError> {
+        self.recording_worker_assignments.lock().await.remove(&id);
+        Ok(())
+    }
+
+    async fn get_recording_worker_assignment(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        Ok(self
+            .recording_worker_assignments
+            .lock()
+            .await
+            .get(&id)
+            .cloned())
+    }
+
+    async fn list_recording_worker_assignments(
+        &self,
+    ) -> Result<Vec<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        let assignments = self.recording_worker_assignments.lock().await;
+        let mut values = assignments.values().cloned().collect::<Vec<_>>();
+        values.sort_by_key(|assignment| assignment.session_id);
+        Ok(values)
     }
 
     async fn list_runtime_assignments(
@@ -1032,6 +1867,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec INTEGER NULL CHECK (idle_timeout_sec IS NULL OR idle_timeout_sec > 0),
                     labels JSONB NOT NULL DEFAULT '{}'::jsonb,
                     integration_context JSONB NULL,
+                    recording JSONB NOT NULL DEFAULT '{"mode":"disabled","format":"webm","retention_sec":null}'::jsonb,
                     runtime_binding TEXT NOT NULL DEFAULT 'legacy_single_session',
                     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -1058,12 +1894,51 @@ impl PostgresSessionStore {
                 CREATE INDEX IF NOT EXISTS idx_control_session_runtimes_binding_updated
                     ON control_session_runtimes (runtime_binding, updated_at DESC);
 
+                CREATE TABLE IF NOT EXISTS control_session_recordings (
+                    id UUID PRIMARY KEY,
+                    session_id UUID NOT NULL REFERENCES control_sessions(id) ON DELETE CASCADE,
+                    previous_recording_id UUID NULL REFERENCES control_session_recordings(id) ON DELETE SET NULL,
+                    state TEXT NOT NULL,
+                    format TEXT NOT NULL,
+                    mime_type TEXT NULL,
+                    byte_count BIGINT NULL CHECK (byte_count IS NULL OR byte_count >= 0),
+                    duration_ms BIGINT NULL CHECK (duration_ms IS NULL OR duration_ms >= 0),
+                    error TEXT NULL,
+                    termination_reason TEXT NULL,
+                    artifact_path TEXT NULL,
+                    started_at TIMESTAMPTZ NOT NULL,
+                    completed_at TIMESTAMPTZ NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_control_session_recordings_session_created
+                    ON control_session_recordings (session_id, created_at DESC);
+
+                CREATE TABLE IF NOT EXISTS control_session_recording_workers (
+                    session_id UUID PRIMARY KEY REFERENCES control_sessions(id) ON DELETE CASCADE,
+                    recording_id UUID NOT NULL REFERENCES control_session_recordings(id) ON DELETE CASCADE,
+                    status TEXT NOT NULL,
+                    process_id BIGINT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_control_session_recording_workers_updated
+                    ON control_session_recording_workers (updated_at DESC);
+
                 ALTER TABLE control_sessions
                     ADD COLUMN IF NOT EXISTS automation_owner_client_id TEXT NULL;
                 ALTER TABLE control_sessions
                     ADD COLUMN IF NOT EXISTS automation_owner_issuer TEXT NULL;
                 ALTER TABLE control_sessions
                     ADD COLUMN IF NOT EXISTS automation_owner_display_name TEXT NULL;
+                ALTER TABLE control_sessions
+                    ADD COLUMN IF NOT EXISTS recording JSONB NOT NULL DEFAULT '{"mode":"disabled","format":"webm","retention_sec":null}'::jsonb;
+                ALTER TABLE control_session_recordings
+                    ADD COLUMN IF NOT EXISTS previous_recording_id UUID NULL REFERENCES control_session_recordings(id) ON DELETE SET NULL;
+                ALTER TABLE control_session_recordings
+                    ADD COLUMN IF NOT EXISTS termination_reason TEXT NULL;
                 "#,
             )
             .await
@@ -1108,6 +1983,7 @@ impl PostgresSessionStore {
         let viewport = request.viewport.unwrap_or_default();
         let now = Utc::now();
         let labels_value = json_labels(&request.labels);
+        let recording_value = json_recording_policy(&request.recording)?;
         let session_id = Uuid::now_v7();
         let row = transaction
             .query_one(
@@ -1125,11 +2001,12 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     runtime_binding,
                     created_at,
                     updated_at
                 )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13, $14, $14)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, $12::jsonb, $13::jsonb, $14, $15, $15)
                 RETURNING
                     id,
                     owner_subject,
@@ -1146,6 +2023,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1163,6 +2041,7 @@ impl PostgresSessionStore {
                     &request.idle_timeout_sec.map(|value| value as i32),
                     &labels_value,
                     &request.integration_context,
+                    &recording_value,
                     &self.config.runtime_binding,
                     &now,
                 ],
@@ -1203,6 +2082,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1247,6 +2127,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1288,6 +2169,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1330,6 +2212,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1383,6 +2266,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1438,6 +2322,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1484,6 +2369,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1530,6 +2416,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1571,6 +2458,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1650,6 +2538,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1708,6 +2597,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1764,6 +2654,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1775,6 +2666,523 @@ impl PostgresSessionStore {
                 SessionStoreError::Backend(format!("failed to clear automation delegate: {error}"))
             })?;
         row.as_ref().map(row_to_stored_session).transpose()
+    }
+
+    async fn create_recording_for_session(
+        &self,
+        session_id: Uuid,
+        format: SessionRecordingFormat,
+        previous_recording_id: Option<Uuid>,
+    ) -> Result<StoredSessionRecording, SessionStoreError> {
+        let mut client = self.client.lock().await;
+        let transaction = client.build_transaction().start().await.map_err(|error| {
+            SessionStoreError::Backend(format!("failed to start transaction: {error}"))
+        })?;
+
+        let active = transaction
+            .query_opt(
+                r#"
+                SELECT id
+                FROM control_session_recordings
+                WHERE session_id = $1
+                  AND state IN ('starting', 'recording', 'finalizing')
+                ORDER BY updated_at DESC, created_at DESC
+                LIMIT 1
+                FOR UPDATE
+                "#,
+                &[&session_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to check active recordings: {error}"))
+            })?;
+        if let Some(active) = active {
+            let active_id: Uuid = active.get("id");
+            return Err(SessionStoreError::Conflict(format!(
+                "session {session_id} already has active recording {active_id}"
+            )));
+        }
+
+        let now = Utc::now();
+        let recording_id = Uuid::now_v7();
+        let row = transaction
+            .query_one(
+                r#"
+                INSERT INTO control_session_recordings (
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    started_at,
+                    created_at,
+                    updated_at
+                )
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $7, $7)
+                RETURNING
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                "#,
+                &[
+                    &recording_id,
+                    &session_id,
+                    &previous_recording_id,
+                    &SessionRecordingState::Recording.as_str(),
+                    &format.as_str(),
+                    &recording_mime_type(format),
+                    &now,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to insert recording: {error}"))
+            })?;
+
+        transaction.commit().await.map_err(|error| {
+            SessionStoreError::Backend(format!("failed to commit transaction: {error}"))
+        })?;
+
+        row_to_stored_session_recording(&row)
+    }
+
+    async fn list_recordings_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Vec<StoredSessionRecording>, SessionStoreError> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                FROM control_session_recordings
+                WHERE session_id = $1
+                ORDER BY created_at DESC, updated_at DESC
+                "#,
+                &[&session_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to list session recordings: {error}"))
+            })?;
+
+        rows.iter().map(row_to_stored_session_recording).collect()
+    }
+
+    async fn get_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                SELECT
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                FROM control_session_recordings
+                WHERE session_id = $1 AND id = $2
+                "#,
+                &[&session_id, &recording_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to load session recording: {error}"))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_session_recording)
+            .transpose()
+    }
+
+    async fn get_latest_recording_for_session(
+        &self,
+        session_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                SELECT
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                FROM control_session_recordings
+                WHERE session_id = $1
+                ORDER BY updated_at DESC, created_at DESC
+                LIMIT 1
+                "#,
+                &[&session_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to load latest recording: {error}"))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_session_recording)
+            .transpose()
+    }
+
+    async fn list_recording_artifact_retention_candidates(
+        &self,
+        now: DateTime<Utc>,
+    ) -> Result<Vec<RecordingArtifactRetentionCandidate>, SessionStoreError> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT
+                    r.session_id,
+                    r.id AS recording_id,
+                    r.artifact_path AS artifact_ref,
+                    r.completed_at,
+                    ((s.recording ->> 'retention_sec')::INTEGER) AS retention_sec
+                FROM control_session_recordings r
+                INNER JOIN control_sessions s
+                    ON s.id = r.session_id
+                WHERE r.state = 'ready'
+                  AND r.artifact_path IS NOT NULL
+                  AND r.completed_at IS NOT NULL
+                  AND (s.recording ->> 'retention_sec') IS NOT NULL
+                ORDER BY r.completed_at ASC, r.created_at ASC
+                "#,
+                &[],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to list recording artifact retention candidates: {error}"
+                ))
+            })?;
+
+        let mut candidates = rows
+            .iter()
+            .filter_map(|row| {
+                let completed_at = row.get::<_, DateTime<Utc>>("completed_at");
+                let retention_sec = row.get::<_, i32>("retention_sec");
+                let expires_at = completed_at + ChronoDuration::seconds(i64::from(retention_sec));
+                if expires_at > now {
+                    return None;
+                }
+                Some(RecordingArtifactRetentionCandidate {
+                    session_id: row.get("session_id"),
+                    recording_id: row.get("recording_id"),
+                    artifact_ref: row.get("artifact_ref"),
+                    expires_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_by(|left, right| left.expires_at.cmp(&right.expires_at));
+        Ok(candidates)
+    }
+
+    async fn stop_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        termination_reason: SessionRecordingTerminationReason,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                UPDATE control_session_recordings
+                SET
+                    state = 'finalizing',
+                    termination_reason = $3,
+                    updated_at = NOW()
+                WHERE session_id = $1
+                  AND id = $2
+                  AND state IN ('starting', 'recording', 'finalizing')
+                RETURNING
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                "#,
+                &[&session_id, &recording_id, &termination_reason.as_str()],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to stop recording: {error}"))
+            })?;
+        if let Some(row) = row {
+            return row_to_stored_session_recording(&row).map(Some);
+        }
+
+        let existing = self
+            .get_recording_for_session(session_id, recording_id)
+            .await?;
+        if existing.is_some() {
+            return Err(SessionStoreError::Conflict(format!(
+                "recording {recording_id} is not active"
+            )));
+        }
+        Ok(None)
+    }
+
+    async fn complete_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: PersistCompletedSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                UPDATE control_session_recordings
+                SET
+                    state = 'ready',
+                    artifact_path = $3,
+                    mime_type = COALESCE($4, mime_type),
+                    byte_count = $5,
+                    duration_ms = $6,
+                    error = NULL,
+                    completed_at = NOW(),
+                    updated_at = NOW()
+                WHERE session_id = $1
+                  AND id = $2
+                  AND state IN ('starting', 'recording', 'finalizing')
+                RETURNING
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                "#,
+                &[
+                    &session_id,
+                    &recording_id,
+                    &request.artifact_ref,
+                    &request.mime_type,
+                    &request.bytes.map(|value| value as i64),
+                    &request.duration_ms.map(|value| value as i64),
+                ],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to complete recording: {error}"))
+            })?;
+        if let Some(row) = row {
+            return row_to_stored_session_recording(&row).map(Some);
+        }
+
+        let existing = self
+            .get_recording_for_session(session_id, recording_id)
+            .await?;
+        if existing.is_some() {
+            return Err(SessionStoreError::Conflict(format!(
+                "recording {recording_id} is not active"
+            )));
+        }
+        Ok(None)
+    }
+
+    async fn clear_recording_artifact_path(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                UPDATE control_session_recordings
+                SET
+                    artifact_path = NULL,
+                    updated_at = NOW()
+                WHERE session_id = $1
+                  AND id = $2
+                RETURNING
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                "#,
+                &[&session_id, &recording_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to clear recording artifact path: {error}"
+                ))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_session_recording)
+            .transpose()
+    }
+
+    async fn fail_recording_for_session(
+        &self,
+        session_id: Uuid,
+        recording_id: Uuid,
+        request: FailSessionRecordingRequest,
+    ) -> Result<Option<StoredSessionRecording>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                UPDATE control_session_recordings
+                SET
+                    state = 'failed',
+                    error = $3,
+                    termination_reason = $4,
+                    completed_at = NOW(),
+                    updated_at = NOW()
+                WHERE session_id = $1
+                  AND id = $2
+                  AND state IN ('starting', 'recording', 'finalizing', 'failed')
+                RETURNING
+                    id,
+                    session_id,
+                    previous_recording_id,
+                    state,
+                    format,
+                    mime_type,
+                    byte_count,
+                    duration_ms,
+                    error,
+                    termination_reason,
+                    artifact_path AS artifact_ref,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                "#,
+                &[
+                    &session_id,
+                    &recording_id,
+                    &request.error,
+                    &request
+                        .termination_reason
+                        .map(|reason| reason.as_str().to_string()),
+                ],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to fail recording: {error}"))
+            })?;
+        if let Some(row) = row {
+            return row_to_stored_session_recording(&row).map(Some);
+        }
+
+        let existing = self
+            .get_recording_for_session(session_id, recording_id)
+            .await?;
+        if let Some(existing) = existing {
+            if matches!(existing.state, SessionRecordingState::Ready) {
+                return Err(SessionStoreError::Conflict(format!(
+                    "recording {recording_id} is already complete"
+                )));
+            }
+        } else {
+            return Ok(None);
+        }
+
+        self.get_recording_for_session(session_id, recording_id)
+            .await
     }
 
     async fn upsert_runtime_assignment(
@@ -1835,6 +3243,127 @@ impl PostgresSessionStore {
                 SessionStoreError::Backend(format!("failed to clear runtime assignment: {error}"))
             })?;
         Ok(())
+    }
+
+    async fn upsert_recording_worker_assignment(
+        &self,
+        assignment: PersistedSessionRecordingWorkerAssignment,
+    ) -> Result<(), SessionStoreError> {
+        let process_id = assignment.process_id.map(i64::from);
+        self.client
+            .lock()
+            .await
+            .execute(
+                r#"
+                INSERT INTO control_session_recording_workers (
+                    session_id,
+                    recording_id,
+                    status,
+                    process_id,
+                    created_at,
+                    updated_at
+                )
+                VALUES ($1, $2, $3, $4, NOW(), NOW())
+                ON CONFLICT (session_id)
+                DO UPDATE SET
+                    recording_id = EXCLUDED.recording_id,
+                    status = EXCLUDED.status,
+                    process_id = EXCLUDED.process_id,
+                    updated_at = NOW()
+                "#,
+                &[
+                    &assignment.session_id,
+                    &assignment.recording_id,
+                    &assignment.status.as_str(),
+                    &process_id,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to upsert recording worker assignment: {error}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn clear_recording_worker_assignment(&self, id: Uuid) -> Result<(), SessionStoreError> {
+        self.client
+            .lock()
+            .await
+            .execute(
+                "DELETE FROM control_session_recording_workers WHERE session_id = $1",
+                &[&id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to clear recording worker assignment: {error}"
+                ))
+            })?;
+        Ok(())
+    }
+
+    async fn get_recording_worker_assignment(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        let row = self
+            .client
+            .lock()
+            .await
+            .query_opt(
+                r#"
+                SELECT
+                    session_id,
+                    recording_id,
+                    status,
+                    process_id
+                FROM control_session_recording_workers
+                WHERE session_id = $1
+                "#,
+                &[&id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to load recording worker assignment: {error}"
+                ))
+            })?;
+        row.as_ref()
+            .map(row_to_recording_worker_assignment)
+            .transpose()
+    }
+
+    async fn list_recording_worker_assignments(
+        &self,
+    ) -> Result<Vec<PersistedSessionRecordingWorkerAssignment>, SessionStoreError> {
+        let rows = self
+            .client
+            .lock()
+            .await
+            .query(
+                r#"
+                SELECT
+                    session_id,
+                    recording_id,
+                    status,
+                    process_id
+                FROM control_session_recording_workers
+                ORDER BY updated_at DESC, created_at DESC
+                "#,
+                &[],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to list recording worker assignments: {error}"
+                ))
+            })?;
+
+        rows.iter()
+            .map(row_to_recording_worker_assignment)
+            .collect()
     }
 
     async fn list_runtime_assignments(
@@ -1900,6 +3429,7 @@ impl PostgresSessionStore {
                     idle_timeout_sec,
                     labels,
                     integration_context,
+                    recording,
                     created_at,
                     updated_at,
                     stopped_at
@@ -1922,6 +3452,18 @@ fn json_labels(labels: &HashMap<String, String>) -> Value {
         object.insert(key.clone(), Value::String(value.clone()));
     }
     Value::Object(object)
+}
+
+fn recording_mime_type(format: SessionRecordingFormat) -> &'static str {
+    match format {
+        SessionRecordingFormat::Webm => "video/webm",
+    }
+}
+
+fn json_recording_policy(recording: &SessionRecordingPolicy) -> Result<Value, SessionStoreError> {
+    serde_json::to_value(recording).map_err(|error| {
+        SessionStoreError::Backend(format!("failed to encode recording policy: {error}"))
+    })
 }
 
 fn session_visible_to_principal(
@@ -1966,6 +3508,10 @@ fn row_to_stored_session(row: &Row) -> Result<StoredSession, SessionStoreError> 
             ))
         })
         .collect::<Result<HashMap<_, _>, SessionStoreError>>()?;
+    let recording = serde_json::from_value::<SessionRecordingPolicy>(row.get("recording"))
+        .map_err(|error| {
+            SessionStoreError::Backend(format!("failed to decode recording policy: {error}"))
+        })?;
 
     let width = row.get::<_, i32>("viewport_width");
     let height = row.get::<_, i32>("viewport_height");
@@ -1999,9 +3545,51 @@ fn row_to_stored_session(row: &Row) -> Result<StoredSession, SessionStoreError> 
             .map(|value| value as u32),
         labels,
         integration_context: row.get("integration_context"),
+        recording,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         stopped_at: row.get("stopped_at"),
+    })
+}
+
+fn row_to_stored_session_recording(row: &Row) -> Result<StoredSessionRecording, SessionStoreError> {
+    let state = row
+        .get::<_, String>("state")
+        .parse::<SessionRecordingState>()
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
+    let format = row
+        .get::<_, String>("format")
+        .parse::<SessionRecordingFormat>()
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
+    let termination_reason = row
+        .get::<_, Option<String>>("termination_reason")
+        .map(|value| {
+            value
+                .parse::<SessionRecordingTerminationReason>()
+                .map_err(|error| SessionStoreError::Backend(error.to_string()))
+        })
+        .transpose()?;
+
+    Ok(StoredSessionRecording {
+        id: row.get("id"),
+        session_id: row.get("session_id"),
+        previous_recording_id: row.get("previous_recording_id"),
+        state,
+        format,
+        mime_type: row.get("mime_type"),
+        bytes: row
+            .get::<_, Option<i64>>("byte_count")
+            .map(|value| value as u64),
+        duration_ms: row
+            .get::<_, Option<i64>>("duration_ms")
+            .map(|value| value as u64),
+        error: row.get("error"),
+        termination_reason,
+        artifact_ref: row.get("artifact_ref"),
+        started_at: row.get("started_at"),
+        completed_at: row.get("completed_at"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
     })
 }
 
@@ -2019,6 +3607,30 @@ fn row_to_runtime_assignment(
         agent_socket_path: row.get("agent_socket_path"),
         container_name: row.get("container_name"),
         cdp_endpoint: row.get("cdp_endpoint"),
+    })
+}
+
+fn row_to_recording_worker_assignment(
+    row: &Row,
+) -> Result<PersistedSessionRecordingWorkerAssignment, SessionStoreError> {
+    let status = row
+        .get::<_, String>("status")
+        .parse::<SessionRecordingWorkerAssignmentStatus>()
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
+    let process_id = row
+        .get::<_, Option<i64>>("process_id")
+        .map(|value| u32::try_from(value))
+        .transpose()
+        .map_err(|error| {
+            SessionStoreError::Backend(format!(
+                "recording worker process_id is out of range: {error}"
+            ))
+        })?;
+    Ok(PersistedSessionRecordingWorkerAssignment {
+        session_id: row.get("session_id"),
+        recording_id: row.get("recording_id"),
+        status,
+        process_id,
     })
 }
 
@@ -2063,6 +3675,11 @@ mod tests {
                     idle_timeout_sec: Some(600),
                     labels: HashMap::from([("suite".to_string(), "smoke".to_string())]),
                     integration_context: Some(serde_json::json!({ "ticket": "BPANE-6" })),
+                    recording: SessionRecordingPolicy {
+                        mode: SessionRecordingMode::Manual,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec: Some(86_400),
+                    },
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2072,6 +3689,10 @@ mod tests {
         let alpha_sessions = store.list_sessions_for_owner(&alpha).await.unwrap();
         assert_eq!(alpha_sessions.len(), 1);
         assert_eq!(alpha_sessions[0].id, created.id);
+        assert_eq!(alpha_sessions[0].recording, created.recording);
+        assert_eq!(created.recording.mode, SessionRecordingMode::Manual);
+        assert_eq!(created.recording.format, SessionRecordingFormat::Webm);
+        assert_eq!(created.recording.retention_sec, Some(86_400));
 
         let bravo_sessions = store.list_sessions_for_owner(&bravo).await.unwrap();
         assert!(bravo_sessions.is_empty());
@@ -2097,6 +3718,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2113,6 +3735,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2148,6 +3771,7 @@ mod tests {
                         idle_timeout_sec: None,
                         labels: HashMap::new(),
                         integration_context: None,
+                        recording: SessionRecordingPolicy::default(),
                     },
                     SessionOwnerMode::Collaborative,
                 )
@@ -2165,6 +3789,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2195,6 +3820,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2241,6 +3867,7 @@ mod tests {
                     idle_timeout_sec: Some(300),
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2264,6 +3891,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2309,6 +3937,7 @@ mod tests {
                     idle_timeout_sec: Some(300),
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2351,6 +3980,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2375,6 +4005,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2413,6 +4044,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2451,6 +4083,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn in_memory_store_persists_recording_worker_assignments() {
+        let store = SessionStore::in_memory();
+        let owner = principal("owner");
+        let session = store
+            .create_session(
+                &owner,
+                CreateSessionRequest {
+                    template_id: None,
+                    owner_mode: None,
+                    viewport: None,
+                    idle_timeout_sec: None,
+                    labels: HashMap::new(),
+                    integration_context: None,
+                    recording: SessionRecordingPolicy {
+                        mode: SessionRecordingMode::Always,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec: None,
+                    },
+                },
+                SessionOwnerMode::Collaborative,
+            )
+            .await
+            .unwrap();
+        let recording = store
+            .create_recording_for_session(session.id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+
+        store
+            .upsert_recording_worker_assignment(PersistedSessionRecordingWorkerAssignment {
+                session_id: session.id,
+                recording_id: recording.id,
+                status: SessionRecordingWorkerAssignmentStatus::Running,
+                process_id: Some(4242),
+            })
+            .await
+            .unwrap();
+
+        let loaded = store
+            .get_recording_worker_assignment(session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.recording_id, recording.id);
+        assert_eq!(
+            loaded.status,
+            SessionRecordingWorkerAssignmentStatus::Running
+        );
+        assert_eq!(loaded.process_id, Some(4242));
+
+        let listed = store.list_recording_worker_assignments().await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].session_id, session.id);
+
+        store
+            .clear_recording_worker_assignment(session.id)
+            .await
+            .unwrap();
+        assert!(store
+            .list_recording_worker_assignments()
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn in_memory_store_can_restore_runtime_candidate_to_ready_after_runtime_loss() {
         let store = SessionStore::in_memory();
         let owner = principal("owner");
@@ -2464,6 +4162,7 @@ mod tests {
                     idle_timeout_sec: None,
                     labels: HashMap::new(),
                     integration_context: None,
+                    recording: SessionRecordingPolicy::default(),
                 },
                 SessionOwnerMode::Collaborative,
             )
@@ -2485,6 +4184,196 @@ mod tests {
         assert_eq!(restored.state, SessionLifecycleState::Ready);
     }
 
+    #[tokio::test]
+    async fn in_memory_store_creates_and_stops_recording_metadata() {
+        let store = SessionStore::in_memory();
+        let owner = principal("owner");
+        let session = store
+            .create_session(
+                &owner,
+                CreateSessionRequest {
+                    template_id: None,
+                    owner_mode: None,
+                    viewport: None,
+                    idle_timeout_sec: None,
+                    labels: HashMap::new(),
+                    integration_context: None,
+                    recording: SessionRecordingPolicy {
+                        mode: SessionRecordingMode::Manual,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec: None,
+                    },
+                },
+                SessionOwnerMode::Collaborative,
+            )
+            .await
+            .unwrap();
+
+        let created = store
+            .create_recording_for_session(session.id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        assert_eq!(created.session_id, session.id);
+        assert_eq!(created.previous_recording_id, None);
+        assert_eq!(created.state, SessionRecordingState::Recording);
+        assert_eq!(created.mime_type.as_deref(), Some("video/webm"));
+
+        let listed = store.list_recordings_for_session(session.id).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, created.id);
+
+        let stopped = store
+            .stop_recording_for_session(
+                session.id,
+                created.id,
+                SessionRecordingTerminationReason::ManualStop,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stopped.state, SessionRecordingState::Finalizing);
+        assert_eq!(
+            stopped.termination_reason,
+            Some(SessionRecordingTerminationReason::ManualStop)
+        );
+
+        let latest = store
+            .get_latest_recording_for_session(session.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(latest.id, created.id);
+        assert_eq!(latest.state, SessionRecordingState::Finalizing);
+        assert_eq!(
+            latest.termination_reason,
+            Some(SessionRecordingTerminationReason::ManualStop)
+        );
+
+        let completed = store
+            .complete_recording_for_session(
+                session.id,
+                created.id,
+                PersistCompletedSessionRecordingRequest {
+                    artifact_ref: "local_fs:session/recording.webm".to_string(),
+                    mime_type: Some("video/webm".to_string()),
+                    bytes: Some(123),
+                    duration_ms: Some(456),
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.state, SessionRecordingState::Ready);
+        assert_eq!(
+            completed.artifact_ref.as_deref(),
+            Some("local_fs:session/recording.webm")
+        );
+        assert_eq!(completed.bytes, Some(123));
+        assert_eq!(completed.duration_ms, Some(456));
+
+        let failed = store
+            .create_recording_for_session(
+                session.id,
+                SessionRecordingFormat::Webm,
+                Some(created.id),
+            )
+            .await
+            .unwrap();
+        let failed = store
+            .fail_recording_for_session(
+                session.id,
+                failed.id,
+                FailSessionRecordingRequest {
+                    error: "boom".to_string(),
+                    termination_reason: Some(SessionRecordingTerminationReason::WorkerExit),
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(failed.state, SessionRecordingState::Failed);
+        assert_eq!(failed.previous_recording_id, Some(created.id));
+        assert_eq!(failed.error.as_deref(), Some("boom"));
+        assert_eq!(
+            failed.termination_reason,
+            Some(SessionRecordingTerminationReason::WorkerExit)
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_lists_and_clears_expired_recording_artifacts() {
+        let store = SessionStore::in_memory();
+        let owner = principal("owner");
+        let session = store
+            .create_session(
+                &owner,
+                CreateSessionRequest {
+                    template_id: None,
+                    owner_mode: None,
+                    viewport: None,
+                    idle_timeout_sec: None,
+                    labels: HashMap::new(),
+                    integration_context: None,
+                    recording: SessionRecordingPolicy {
+                        mode: SessionRecordingMode::Manual,
+                        format: SessionRecordingFormat::Webm,
+                        retention_sec: Some(60),
+                    },
+                },
+                SessionOwnerMode::Collaborative,
+            )
+            .await
+            .unwrap();
+
+        let created = store
+            .create_recording_for_session(session.id, SessionRecordingFormat::Webm, None)
+            .await
+            .unwrap();
+        let completed = store
+            .complete_recording_for_session(
+                session.id,
+                created.id,
+                PersistCompletedSessionRecordingRequest {
+                    artifact_ref: "local_fs:session/recording.webm".to_string(),
+                    mime_type: Some("video/webm".to_string()),
+                    bytes: Some(123),
+                    duration_ms: Some(456),
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let candidates = store
+            .list_recording_artifact_retention_candidates(
+                completed.completed_at.unwrap() + chrono::Duration::seconds(61),
+            )
+            .await
+            .unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].session_id, session.id);
+        assert_eq!(candidates[0].recording_id, created.id);
+        assert_eq!(
+            candidates[0].artifact_ref,
+            "local_fs:session/recording.webm"
+        );
+
+        let cleared = store
+            .clear_recording_artifact_path(session.id, created.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(cleared.artifact_ref.is_none());
+
+        let candidates = store
+            .list_recording_artifact_retention_candidates(
+                completed.completed_at.unwrap() + chrono::Duration::seconds(61),
+            )
+            .await
+            .unwrap();
+        assert!(candidates.is_empty());
+    }
+
     #[test]
     fn rejects_non_object_integration_context() {
         let error = validate_create_request(&CreateSessionRequest {
@@ -2494,6 +4383,51 @@ mod tests {
             idle_timeout_sec: None,
             labels: HashMap::new(),
             integration_context: Some(Value::String("bad".to_string())),
+            recording: SessionRecordingPolicy::default(),
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, SessionStoreError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn rejects_zero_recording_retention() {
+        let error = validate_create_request(&CreateSessionRequest {
+            template_id: None,
+            owner_mode: None,
+            viewport: None,
+            idle_timeout_sec: None,
+            labels: HashMap::new(),
+            integration_context: None,
+            recording: SessionRecordingPolicy {
+                mode: SessionRecordingMode::Manual,
+                format: SessionRecordingFormat::Webm,
+                retention_sec: Some(0),
+            },
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, SessionStoreError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn rejects_empty_recording_source_path() {
+        let error = validate_complete_recording_request(&CompleteSessionRecordingRequest {
+            source_path: "   ".to_string(),
+            mime_type: None,
+            bytes: None,
+            duration_ms: None,
+        })
+        .unwrap_err();
+
+        assert!(matches!(error, SessionStoreError::InvalidRequest(_)));
+    }
+
+    #[test]
+    fn rejects_empty_recording_failure_message() {
+        let error = validate_fail_recording_request(&FailSessionRecordingRequest {
+            error: "".to_string(),
+            termination_reason: None,
         })
         .unwrap_err();
 

--- a/code/apps/bpane-gateway/src/session_hub.rs
+++ b/code/apps/bpane-gateway/src/session_hub.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::RwLock;
 use tokio::sync::{broadcast, mpsc, Mutex};
 
 use bpane_protocol::frame::Frame;
@@ -16,7 +17,7 @@ mod telemetry;
 mod types;
 
 pub use self::telemetry::SessionTelemetrySnapshot;
-pub use self::types::{ClientHandle, ResizeResult, SubscribeError};
+pub use self::types::{BrowserClientRole, ClientHandle, ResizeResult, SubscribeError};
 
 /// Broadcast channel capacity. At 30fps, 1024 frames is ~34 seconds of buffer.
 const BROADCAST_CAPACITY: usize = 1024;
@@ -33,6 +34,7 @@ pub struct SessionHub {
     exclusive_browser_owner: bool,
     current_resolution: Arc<Mutex<(u16, u16)>>,
     connected_clients: Mutex<Vec<u64>>,
+    client_roles: RwLock<HashMap<u64, BrowserClientRole>>,
     client_control_txs: Mutex<HashMap<u64, mpsc::Sender<ControlMessage>>>,
     client_counter: AtomicU64,
     client_count: AtomicU32,
@@ -100,6 +102,7 @@ impl SessionHub {
             exclusive_browser_owner,
             current_resolution,
             connected_clients: Mutex::new(Vec::new()),
+            client_roles: RwLock::new(HashMap::new()),
             client_control_txs: Mutex::new(HashMap::new()),
             client_counter: AtomicU64::new(0),
             client_count: AtomicU32::new(0),
@@ -132,7 +135,15 @@ impl SessionHub {
     /// Subscribe a new client to the hub.
     /// The first subscriber becomes the session owner.
     pub async fn subscribe(&self) -> Result<ClientHandle, SubscribeError> {
-        membership::subscribe(self).await
+        membership::subscribe(self, BrowserClientRole::Interactive).await
+    }
+
+    /// Subscribe a new client with an explicit runtime role.
+    pub async fn subscribe_with_role(
+        &self,
+        client_role: BrowserClientRole,
+    ) -> Result<ClientHandle, SubscribeError> {
+        membership::subscribe(self, client_role).await
     }
 
     /// Called when a client disconnects.
@@ -189,6 +200,10 @@ impl SessionHub {
 
     pub fn viewer_count(&self) -> u32 {
         policy::viewer_count(self)
+    }
+
+    pub fn recorder_count(&self) -> u32 {
+        policy::recorder_count(self)
     }
 
     pub async fn telemetry_snapshot(&self) -> SessionTelemetrySnapshot {

--- a/code/apps/bpane-gateway/src/session_hub/membership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/membership.rs
@@ -7,9 +7,12 @@ use bpane_protocol::ControlMessage;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use super::{ClientHandle, SessionHub, SubscribeError};
+use super::{BrowserClientRole, ClientHandle, SessionHub, SubscribeError};
 
-pub(super) async fn subscribe(hub: &SessionHub) -> Result<ClientHandle, SubscribeError> {
+pub(super) async fn subscribe(
+    hub: &SessionHub,
+    client_role: BrowserClientRole,
+) -> Result<ClientHandle, SubscribeError> {
     let join_started = Instant::now();
     let client_id = hub.client_counter.fetch_add(1, Ordering::Relaxed) + 1;
     let mcp_is_owner = hub.mcp_is_owner.load(Ordering::Relaxed);
@@ -17,10 +20,11 @@ pub(super) async fn subscribe(hub: &SessionHub) -> Result<ClientHandle, Subscrib
     let prev_count = connected_clients.len() as u32;
     let current_owner_id = hub.owner_id.load(Ordering::Relaxed);
     let exclusive_browser_owner = hub.exclusive_browser_owner;
-    let is_resize_owner = !mcp_is_owner && current_owner_id == 0;
+    let is_resize_owner =
+        client_role == BrowserClientRole::Interactive && !mcp_is_owner && current_owner_id == 0;
     let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(8);
 
-    let is_owner = if mcp_is_owner {
+    let is_owner = if client_role == BrowserClientRole::Recorder || mcp_is_owner {
         false
     } else if !exclusive_browser_owner {
         true
@@ -28,12 +32,19 @@ pub(super) async fn subscribe(hub: &SessionHub) -> Result<ClientHandle, Subscrib
         current_owner_id == 0
     };
 
-    if !is_owner {
+    if client_role == BrowserClientRole::Interactive && !is_owner {
         let owner_connected = !mcp_is_owner && current_owner_id != 0 && prev_count > 0;
+        let current_viewers = {
+            let roles = hub.client_roles.read().unwrap();
+            connected_clients
+                .iter()
+                .filter(|id| roles.get(id) == Some(&BrowserClientRole::Interactive))
+                .count() as u32
+        };
         let current_viewers = if owner_connected {
-            prev_count.saturating_sub(1)
+            current_viewers.saturating_sub(1)
         } else {
-            prev_count
+            current_viewers
         };
         if current_viewers >= hub.max_viewers {
             hub.joins_rejected_viewer_cap
@@ -51,6 +62,11 @@ pub(super) async fn subscribe(hub: &SessionHub) -> Result<ClientHandle, Subscrib
     hub.client_count
         .store(connected_clients.len() as u32, Ordering::Relaxed);
     drop(connected_clients);
+
+    hub.client_roles
+        .write()
+        .unwrap()
+        .insert(client_id, client_role);
 
     hub.client_control_txs
         .lock()
@@ -75,6 +91,7 @@ pub(super) async fn subscribe(hub: &SessionHub) -> Result<ClientHandle, Subscrib
         to_host: hub.to_agent.clone(),
         client_id,
         is_owner,
+        client_role,
         initial_frames,
         initial_access_state,
         control_rx,
@@ -88,12 +105,17 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
         .store(connected_clients.len() as u32, Ordering::Relaxed);
 
     let remaining_clients = connected_clients.clone();
+    let next_owner = if hub.mcp_is_owner.load(Ordering::Relaxed) {
+        0
+    } else {
+        let roles = hub.client_roles.read().unwrap();
+        connected_clients
+            .iter()
+            .copied()
+            .find(|id| roles.get(id) == Some(&BrowserClientRole::Interactive))
+            .unwrap_or(0)
+    };
     if hub.owner_id.load(Ordering::Relaxed) == client_id {
-        let next_owner = if hub.mcp_is_owner.load(Ordering::Relaxed) {
-            0
-        } else {
-            connected_clients.first().copied().unwrap_or(0)
-        };
         hub.owner_id.store(next_owner, Ordering::Relaxed);
         if next_owner != 0 {
             debug!(
@@ -103,13 +125,14 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
         }
     } else if hub.owner_id.load(Ordering::Relaxed) == 0 && !hub.mcp_is_owner.load(Ordering::Relaxed)
     {
-        if let Some(next_owner) = connected_clients.first().copied() {
+        if next_owner != 0 {
             hub.owner_id.store(next_owner, Ordering::Relaxed);
             debug!(client_id, next_owner, "restored missing session owner");
         }
     }
     drop(connected_clients);
 
+    hub.client_roles.write().unwrap().remove(&client_id);
     hub.client_control_txs.lock().await.remove(&client_id);
     super::policy::notify_client_access_states(hub, &remaining_clients, None).await;
 }

--- a/code/apps/bpane-gateway/src/session_hub/policy.rs
+++ b/code/apps/bpane-gateway/src/session_hub/policy.rs
@@ -3,9 +3,21 @@ use std::sync::atomic::Ordering;
 use bpane_protocol::{ClientAccessFlags, ControlMessage};
 use tracing::{info, warn};
 
-use super::{ResizeResult, SessionHub};
+use super::{BrowserClientRole, ResizeResult, SessionHub};
+
+fn client_role(hub: &SessionHub, client_id: u64) -> BrowserClientRole {
+    hub.client_roles
+        .read()
+        .unwrap()
+        .get(&client_id)
+        .copied()
+        .unwrap_or(BrowserClientRole::Interactive)
+}
 
 pub(super) fn is_browser_owner(hub: &SessionHub, client_id: u64) -> bool {
+    if client_role(hub, client_id) == BrowserClientRole::Recorder {
+        return false;
+    }
     if hub.mcp_is_owner() {
         return false;
     }
@@ -17,6 +29,9 @@ pub(super) fn is_browser_owner(hub: &SessionHub, client_id: u64) -> bool {
 }
 
 pub(super) fn is_resize_owner(hub: &SessionHub, client_id: u64) -> bool {
+    if client_role(hub, client_id) == BrowserClientRole::Recorder {
+        return false;
+    }
     if hub.mcp_is_owner() {
         return false;
     }
@@ -90,19 +105,21 @@ pub(super) async fn clear_mcp_owner(hub: &SessionHub) {
 }
 
 pub(super) fn viewer_count(hub: &SessionHub) -> u32 {
-    let clients = hub.client_count();
-    if hub.mcp_is_owner() {
-        clients
-    } else if hub.exclusive_browser_owner
-        && hub.owner_id.load(Ordering::Relaxed) != 0
-        && clients > 0
-    {
-        clients.saturating_sub(1)
-    } else if hub.exclusive_browser_owner {
-        clients
-    } else {
-        0
-    }
+    let roles = hub.client_roles.read().unwrap();
+    roles
+        .iter()
+        .filter(|(_, role)| **role == BrowserClientRole::Interactive)
+        .filter(|(client_id, _)| !is_browser_owner(hub, **client_id))
+        .count() as u32
+}
+
+pub(super) fn recorder_count(hub: &SessionHub) -> u32 {
+    hub.client_roles
+        .read()
+        .unwrap()
+        .values()
+        .filter(|role| **role == BrowserClientRole::Recorder)
+        .count() as u32
 }
 
 async fn forward_resize_request(

--- a/code/apps/bpane-gateway/src/session_hub/telemetry.rs
+++ b/code/apps/bpane-gateway/src/session_hub/telemetry.rs
@@ -7,6 +7,7 @@ use super::SessionHub;
 pub struct SessionTelemetrySnapshot {
     pub browser_clients: u32,
     pub viewer_clients: u32,
+    pub recorder_clients: u32,
     pub max_viewers: u32,
     pub viewer_slots_remaining: u32,
     pub exclusive_browser_owner: bool,
@@ -32,6 +33,7 @@ pub struct SessionTelemetrySnapshot {
 pub(super) fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelemetrySnapshot {
     let browser_clients = hub.client_count();
     let viewer_clients = hub.viewer_count();
+    let recorder_clients = hub.recorder_count();
     let joins_accepted = hub.joins_accepted.load(Ordering::Relaxed);
     let total_join_latency_ms = hub.total_join_latency_ms.load(Ordering::Relaxed);
     let egress_send_stream_lock_acquires_total = hub
@@ -44,6 +46,7 @@ pub(super) fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelem
     SessionTelemetrySnapshot {
         browser_clients,
         viewer_clients,
+        recorder_clients,
         max_viewers: hub.max_viewers,
         viewer_slots_remaining: hub.max_viewers.saturating_sub(viewer_clients),
         exclusive_browser_owner: hub.exclusive_browser_owner,

--- a/code/apps/bpane-gateway/src/session_hub/tests/ownership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/ownership.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
+use crate::session_hub::BrowserClientRole;
 
 #[tokio::test]
 async fn first_subscriber_is_owner() {
@@ -179,5 +180,52 @@ async fn viewer_cap_blocks_extra_viewers() {
     let snapshot = hub.telemetry_snapshot().await;
     assert_eq!(snapshot.viewer_clients, 1);
     assert_eq!(snapshot.joins_rejected_viewer_cap, 1);
+    assert_eq!(snapshot.viewer_slots_remaining, 0);
+}
+
+#[tokio::test]
+async fn recorder_clients_stay_passive_and_do_not_consume_viewer_slots() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = Arc::new(SessionHub::new(sock_str, 1, true).await.unwrap());
+
+    let owner = hub.subscribe().await.unwrap();
+    assert!(matches!(
+        hub.request_resize(owner.client_id, 1600, 900).await,
+        ResizeResult::Applied
+    ));
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let recorder = hub
+        .subscribe_with_role(BrowserClientRole::Recorder)
+        .await
+        .unwrap();
+    assert!(!recorder.is_owner);
+    assert_eq!(recorder.client_role, BrowserClientRole::Recorder);
+    assert!(!hub.is_browser_owner(recorder.client_id));
+    assert_eq!(
+        recorder.initial_access_state,
+        Some(ControlMessage::ClientAccessState {
+            flags: ClientAccessFlags::VIEW_ONLY | ClientAccessFlags::RESIZE_LOCKED,
+            width: 1600,
+            height: 900,
+        })
+    );
+
+    let viewer = hub.subscribe().await.unwrap();
+    assert!(!viewer.is_owner);
+
+    let err = hub.subscribe().await.unwrap_err();
+    assert_eq!(err, SubscribeError::ViewerLimitReached { max_viewers: 1 });
+
+    let snapshot = hub.telemetry_snapshot().await;
+    assert_eq!(snapshot.browser_clients, 3);
+    assert_eq!(snapshot.viewer_clients, 1);
+    assert_eq!(snapshot.recorder_clients, 1);
     assert_eq!(snapshot.viewer_slots_remaining, 0);
 }

--- a/code/apps/bpane-gateway/src/session_hub/tests/telemetry.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/telemetry.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
+use crate::session_hub::BrowserClientRole;
 
 #[tokio::test]
 async fn telemetry_tracks_join_latency_and_refresh_bursts() {
@@ -32,10 +33,35 @@ async fn telemetry_tracks_join_latency_and_refresh_bursts() {
     let snapshot = hub.telemetry_snapshot().await;
     assert_eq!(snapshot.browser_clients, 2);
     assert_eq!(snapshot.viewer_clients, 1);
+    assert_eq!(snapshot.recorder_clients, 0);
     assert_eq!(snapshot.joins_accepted, 2);
     assert!(snapshot.max_join_latency_ms >= snapshot.last_join_latency_ms);
     assert_eq!(snapshot.full_refresh_requests, 1);
     assert_eq!(snapshot.full_refresh_tiles_requested, 6);
     assert_eq!(snapshot.last_full_refresh_tiles, 6);
     assert_eq!(snapshot.max_full_refresh_tiles, 6);
+}
+
+#[tokio::test]
+async fn telemetry_reports_recorder_clients_separately() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = SessionHub::new(sock_str, 10, true).await.unwrap();
+
+    let _owner = hub.subscribe().await.unwrap();
+    let _recorder = hub
+        .subscribe_with_role(BrowserClientRole::Recorder)
+        .await
+        .unwrap();
+
+    let snapshot = hub.telemetry_snapshot().await;
+    assert_eq!(snapshot.browser_clients, 2);
+    assert_eq!(snapshot.viewer_clients, 0);
+    assert_eq!(snapshot.recorder_clients, 1);
+    assert_eq!(snapshot.viewer_slots_remaining, 10);
 }

--- a/code/apps/bpane-gateway/src/session_hub/types.rs
+++ b/code/apps/bpane-gateway/src/session_hub/types.rs
@@ -5,6 +5,18 @@ use bpane_protocol::ControlMessage;
 use tokio::sync::{broadcast, mpsc};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowserClientRole {
+    Interactive,
+    Recorder,
+}
+
+impl BrowserClientRole {
+    pub fn allows_bitrate_feedback(self) -> bool {
+        matches!(self, Self::Interactive)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SubscribeError {
     ViewerLimitReached { max_viewers: u32 },
 }
@@ -33,6 +45,8 @@ pub struct ClientHandle {
     /// Whether this client is the session owner (first to connect).
     /// In collaborative mode this stays `true` for interactive late joiners.
     pub is_owner: bool,
+    /// Browser client role for policy and telemetry decisions.
+    pub client_role: BrowserClientRole,
     /// Frames to send immediately on connect (cached SessionReady + last keyframe).
     pub initial_frames: Vec<Arc<Frame>>,
     /// Optional gateway-managed access state to send immediately on connect.

--- a/code/apps/bpane-gateway/src/session_registry.rs
+++ b/code/apps/bpane-gateway/src/session_registry.rs
@@ -6,7 +6,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::session_hub::SessionTelemetrySnapshot;
-use crate::session_hub::{ClientHandle, SessionHub};
+use crate::session_hub::{BrowserClientRole, ClientHandle, SessionHub};
 
 /// Maps agent socket paths to active SessionHubs.
 ///
@@ -106,10 +106,27 @@ impl SessionRegistry {
         session_id: Uuid,
         agent_socket_path: &str,
     ) -> anyhow::Result<(ClientHandle, Arc<SessionHub>)> {
+        self.join_with_role(
+            session_id,
+            agent_socket_path,
+            BrowserClientRole::Interactive,
+        )
+        .await
+    }
+
+    pub async fn join_with_role(
+        &self,
+        session_id: Uuid,
+        agent_socket_path: &str,
+        client_role: BrowserClientRole,
+    ) -> anyhow::Result<(ClientHandle, Arc<SessionHub>)> {
         let (hub, created) = self
             .get_or_create_hub(session_id, agent_socket_path)
             .await?;
-        let handle = hub.subscribe().await.map_err(anyhow::Error::from)?;
+        let handle = hub
+            .subscribe_with_role(client_role)
+            .await
+            .map_err(anyhow::Error::from)?;
 
         if created {
             debug!(
@@ -120,6 +137,7 @@ impl SessionRegistry {
             debug!(
                 client_id = handle.client_id,
                 is_owner = handle.is_owner,
+                ?client_role,
                 clients = hub.client_count(),
                 "client joined existing session"
             );

--- a/code/apps/bpane-gateway/src/session_registry/tests.rs
+++ b/code/apps/bpane-gateway/src/session_registry/tests.rs
@@ -6,6 +6,7 @@ use tokio::net::UnixListener;
 use uuid::Uuid;
 
 use super::SessionRegistry;
+use crate::session_hub::BrowserClientRole;
 
 fn session_id() -> Uuid {
     Uuid::now_v7()
@@ -75,6 +76,30 @@ async fn exclusive_owner_mode_marks_late_joiner_as_viewer() {
     let (c2, _) = registry.join(session_id, sock_str).await.unwrap();
     assert!(c1.is_owner);
     assert!(!c2.is_owner);
+}
+
+#[tokio::test]
+async fn recorder_role_joins_without_becoming_owner() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let registry = SessionRegistry::new(10, true);
+    let session_id = session_id();
+
+    let (owner, _) = registry.join(session_id, sock_str).await.unwrap();
+    let (recorder, _) = registry
+        .join_with_role(session_id, sock_str, BrowserClientRole::Recorder)
+        .await
+        .unwrap();
+
+    assert!(owner.is_owner);
+    assert_eq!(owner.client_role, BrowserClientRole::Interactive);
+    assert!(!recorder.is_owner);
+    assert_eq!(recorder.client_role, BrowserClientRole::Recorder);
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/src/transport.rs
+++ b/code/apps/bpane-gateway/src/transport.rs
@@ -22,6 +22,7 @@ use self::request::{validate_request_path, RequestValidationError};
 use self::session_task::handle_session;
 use crate::auth::AuthValidator;
 use crate::connect_ticket::SessionConnectTicketManager;
+use crate::recording_lifecycle::RecordingLifecycleManager;
 use crate::session_control::SessionStore;
 use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
@@ -33,6 +34,7 @@ pub struct TransportServer {
     auth_validator: Arc<AuthValidator>,
     connect_ticket_manager: Arc<SessionConnectTicketManager>,
     session_store: SessionStore,
+    recording_lifecycle: Arc<RecordingLifecycleManager>,
     idle_stop_timeout: Duration,
     heartbeat_timeout: Duration,
     registry: Arc<SessionRegistry>,
@@ -46,6 +48,7 @@ impl TransportServer {
         auth_validator: Arc<AuthValidator>,
         connect_ticket_manager: Arc<SessionConnectTicketManager>,
         session_store: SessionStore,
+        recording_lifecycle: Arc<RecordingLifecycleManager>,
         idle_stop_timeout: Duration,
         heartbeat_timeout: Duration,
         registry: Arc<SessionRegistry>,
@@ -57,6 +60,7 @@ impl TransportServer {
             auth_validator,
             connect_ticket_manager,
             session_store,
+            recording_lifecycle,
             idle_stop_timeout,
             heartbeat_timeout,
             registry,
@@ -180,6 +184,7 @@ impl TransportServer {
             let registry = self.registry.clone();
             let session_manager = self.session_manager.clone();
             let session_store = self.session_store.clone();
+            let recording_lifecycle = self.recording_lifecycle.clone();
             let idle_stop_timeout = self.idle_stop_timeout;
             active_sessions.fetch_add(1, Ordering::Relaxed);
 
@@ -200,6 +205,7 @@ impl TransportServer {
                     &agent_path,
                     heartbeat_timeout,
                     registry.clone(),
+                    recording_lifecycle,
                 )
                 .await
                 {

--- a/code/apps/bpane-gateway/src/transport/request.rs
+++ b/code/apps/bpane-gateway/src/transport/request.rs
@@ -3,6 +3,7 @@ use uuid::Uuid;
 use crate::auth::{AuthError, AuthValidator, AuthenticatedPrincipal};
 use crate::connect_ticket::{SessionConnectTicketError, SessionConnectTicketManager};
 use crate::session_control::SessionStore;
+use crate::session_hub::BrowserClientRole;
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum RequestValidationError {
@@ -17,6 +18,7 @@ pub(super) enum RequestValidationError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct ValidatedConnectRequest {
     pub session_id: Uuid,
+    pub client_role: BrowserClientRole,
 }
 
 pub(super) async fn validate_request_path(
@@ -25,6 +27,7 @@ pub(super) async fn validate_request_path(
     connect_ticket_manager: &SessionConnectTicketManager,
     session_store: &SessionStore,
 ) -> Result<ValidatedConnectRequest, RequestValidationError> {
+    let client_role = parsed_client_role(path);
     match extract_connect_request(path)? {
         ConnectRequest::SessionTicket { ticket } => {
             let claims = connect_ticket_manager
@@ -48,6 +51,7 @@ pub(super) async fn validate_request_path(
             }
             Ok(ValidatedConnectRequest {
                 session_id: claims.session_id,
+                client_role,
             })
         }
         ConnectRequest::BearerToken { token, session_id } => {
@@ -65,7 +69,10 @@ pub(super) async fn validate_request_path(
             {
                 return Err(RequestValidationError::SessionNotVisible);
             }
-            Ok(ValidatedConnectRequest { session_id })
+            Ok(ValidatedConnectRequest {
+                session_id,
+                client_role,
+            })
         }
     }
 }
@@ -109,6 +116,22 @@ fn extract_connect_request(path: &str) -> Result<ConnectRequest, RequestValidati
     let token = bearer_token.ok_or(RequestValidationError::MissingCredential)?;
     let session_id = session_id.ok_or(RequestValidationError::MissingSessionId)?;
     Ok(ConnectRequest::BearerToken { token, session_id })
+}
+
+fn parsed_client_role(path: &str) -> BrowserClientRole {
+    let Some(query) = path.split('?').nth(1) else {
+        return BrowserClientRole::Interactive;
+    };
+
+    for param in query.split('&') {
+        if let Some(value) = param.strip_prefix("client_role=") {
+            if value.eq_ignore_ascii_case("recorder") {
+                return BrowserClientRole::Recorder;
+            }
+        }
+    }
+
+    BrowserClientRole::Interactive
 }
 
 #[cfg(test)]

--- a/code/apps/bpane-gateway/src/transport/session_task.rs
+++ b/code/apps/bpane-gateway/src/transport/session_task.rs
@@ -13,6 +13,7 @@ use super::tasks::{
     spawn_gateway_pinger,
 };
 use crate::idle_stop::schedule_idle_session_stop;
+use crate::recording_lifecycle::RecordingLifecycleManager;
 use crate::session::Session;
 use crate::session_control::SessionStore;
 use crate::session_manager::SessionManager;
@@ -28,6 +29,7 @@ pub(super) async fn handle_session(
     agent_socket_path: &str,
     heartbeat_timeout: Duration,
     registry: Arc<SessionRegistry>,
+    recording_lifecycle: Arc<RecordingLifecycleManager>,
 ) -> anyhow::Result<()> {
     let routed_session_id = connect_request.session_id;
     let (client_handle, hub) = registry
@@ -136,6 +138,7 @@ pub(super) async fn handle_session(
                 registry.clone(),
                 session_store.clone(),
                 session_manager.clone(),
+                recording_lifecycle.clone(),
             );
         }
     } else {
@@ -147,6 +150,7 @@ pub(super) async fn handle_session(
             registry.clone(),
             session_store,
             session_manager.clone(),
+            recording_lifecycle,
         );
     }
 

--- a/code/apps/bpane-gateway/src/transport/session_task.rs
+++ b/code/apps/bpane-gateway/src/transport/session_task.rs
@@ -8,7 +8,10 @@ use super::bootstrap::send_initial_frames;
 use super::egress::{spawn_agent_to_browser_task, EgressTaskContext};
 use super::ingress::spawn_browser_to_agent_task;
 use super::request::ValidatedConnectRequest;
-use super::tasks::{spawn_bitrate_hint_task, spawn_direct_control_task, spawn_gateway_pinger};
+use super::tasks::{
+    recorder_role_suppresses_bitrate_feedback, spawn_bitrate_hint_task, spawn_direct_control_task,
+    spawn_gateway_pinger,
+};
 use crate::idle_stop::schedule_idle_session_stop;
 use crate::session::Session;
 use crate::session_control::SessionStore;
@@ -27,9 +30,16 @@ pub(super) async fn handle_session(
     registry: Arc<SessionRegistry>,
 ) -> anyhow::Result<()> {
     let routed_session_id = connect_request.session_id;
-    let (client_handle, hub) = registry.join(routed_session_id, agent_socket_path).await?;
+    let (client_handle, hub) = registry
+        .join_with_role(
+            routed_session_id,
+            agent_socket_path,
+            connect_request.client_role,
+        )
+        .await?;
     let client_id = client_handle.client_id;
     let joined_as_owner = client_handle.is_owner;
+    let client_role = client_handle.client_role;
     let initial_access_state = client_handle.initial_access_state;
     let control_rx = client_handle.control_rx;
     let from_host = client_handle.from_host;
@@ -77,14 +87,6 @@ pub(super) async fn handle_session(
         from_host,
     );
 
-    let bitrate_hint_task = spawn_bitrate_hint_task(
-        session_id,
-        client_id,
-        session.clone(),
-        dgram_stats.clone(),
-        send_stream.clone(),
-    );
-
     let browser_to_agent = spawn_browser_to_agent_task(
         session.clone(),
         hub.clone(),
@@ -98,12 +100,28 @@ pub(super) async fn handle_session(
 
     let gateway_pinger = spawn_gateway_pinger(session.clone(), send_stream.clone());
 
-    tokio::select! {
-        _ = agent_to_browser => {}
-        _ = browser_to_agent => {}
-        _ = direct_control_task => {}
-        _ = gateway_pinger => {}
-        _ = bitrate_hint_task => {}
+    if recorder_role_suppresses_bitrate_feedback(client_role) {
+        tokio::select! {
+            _ = agent_to_browser => {}
+            _ = browser_to_agent => {}
+            _ = direct_control_task => {}
+            _ = gateway_pinger => {}
+        }
+    } else {
+        let bitrate_hint_task = spawn_bitrate_hint_task(
+            session_id,
+            client_id,
+            session.clone(),
+            dgram_stats.clone(),
+            send_stream.clone(),
+        );
+        tokio::select! {
+            _ = agent_to_browser => {}
+            _ = browser_to_agent => {}
+            _ = direct_control_task => {}
+            _ = gateway_pinger => {}
+            _ = bitrate_hint_task => {}
+        }
     }
 
     session.deactivate();

--- a/code/apps/bpane-gateway/src/transport/tasks.rs
+++ b/code/apps/bpane-gateway/src/transport/tasks.rs
@@ -9,6 +9,11 @@ use tracing::debug;
 
 use super::bitrate::{compute_adapted_bitrate, DatagramStats};
 use crate::session::Session;
+use crate::session_hub::BrowserClientRole;
+
+pub(super) fn recorder_role_suppresses_bitrate_feedback(client_role: BrowserClientRole) -> bool {
+    !client_role.allows_bitrate_feedback()
+}
 
 pub(super) fn spawn_bitrate_hint_task<S>(
     session_id: u64,
@@ -67,6 +72,22 @@ where
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::recorder_role_suppresses_bitrate_feedback;
+    use crate::session_hub::BrowserClientRole;
+
+    #[test]
+    fn recorder_role_disables_bitrate_feedback() {
+        assert!(!recorder_role_suppresses_bitrate_feedback(
+            BrowserClientRole::Interactive
+        ));
+        assert!(recorder_role_suppresses_bitrate_feedback(
+            BrowserClientRole::Recorder
+        ));
+    }
 }
 
 pub(super) fn spawn_gateway_pinger<S>(

--- a/code/apps/bpane-gateway/src/transport/tests/request.rs
+++ b/code/apps/bpane-gateway/src/transport/tests/request.rs
@@ -6,7 +6,9 @@ use uuid::Uuid;
 
 use crate::auth::AuthenticatedPrincipal;
 use crate::connect_ticket::{SessionConnectTicketError, SessionConnectTicketManager};
-use crate::session_control::{CreateSessionRequest, SessionOwnerMode, SessionStore};
+use crate::session_control::{
+    CreateSessionRequest, SessionOwnerMode, SessionRecordingPolicy, SessionStore,
+};
 use crate::session_hub::BrowserClientRole;
 
 fn empty_request() -> CreateSessionRequest {
@@ -17,6 +19,7 @@ fn empty_request() -> CreateSessionRequest {
         idle_timeout_sec: None,
         labels: HashMap::new(),
         integration_context: None,
+        recording: SessionRecordingPolicy::default(),
     }
 }
 

--- a/code/apps/bpane-gateway/src/transport/tests/request.rs
+++ b/code/apps/bpane-gateway/src/transport/tests/request.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 use crate::auth::AuthenticatedPrincipal;
 use crate::connect_ticket::{SessionConnectTicketError, SessionConnectTicketManager};
 use crate::session_control::{CreateSessionRequest, SessionOwnerMode, SessionStore};
+use crate::session_hub::BrowserClientRole;
 
 fn empty_request() -> CreateSessionRequest {
     CreateSessionRequest {
@@ -62,7 +63,36 @@ async fn validate_request_path_accepts_valid_token() {
     assert_eq!(
         validate_request_path(&path, &validator, &ticket_manager, &store).await,
         Ok(ValidatedConnectRequest {
-            session_id: session.id
+            session_id: session.id,
+            client_role: BrowserClientRole::Interactive,
+        })
+    );
+}
+
+#[tokio::test]
+async fn validate_request_path_accepts_recorder_client_role() {
+    let validator = AuthValidator::from_hmac_secret(b"transport-request-secret".to_vec());
+    let ticket_manager = SessionConnectTicketManager::new(
+        b"transport-request-secret".to_vec(),
+        Duration::from_secs(300),
+    );
+    let token = validator.generate_token().unwrap();
+    let store = SessionStore::in_memory();
+    let principal = validator.authenticate(&token).await.unwrap();
+    let session = store
+        .create_session(&principal, empty_request(), SessionOwnerMode::Collaborative)
+        .await
+        .unwrap();
+    let path = format!(
+        "/session?token={token}&session_id={}&client_role=recorder",
+        session.id
+    );
+
+    assert_eq!(
+        validate_request_path(&path, &validator, &ticket_manager, &store).await,
+        Ok(ValidatedConnectRequest {
+            session_id: session.id,
+            client_role: BrowserClientRole::Recorder,
         })
     );
 }
@@ -94,7 +124,8 @@ async fn validate_request_path_accepts_valid_session_ticket() {
     assert_eq!(
         validate_request_path(&path, &validator, &ticket_manager, &store).await,
         Ok(ValidatedConnectRequest {
-            session_id: session.id
+            session_id: session.id,
+            client_role: BrowserClientRole::Interactive,
         })
     );
 }

--- a/code/integrations/recording-worker/package-lock.json
+++ b/code/integrations/recording-worker/package-lock.json
@@ -1,0 +1,605 @@
+{
+  "name": "bpane-recording-worker",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bpane-recording-worker",
+      "version": "0.1.0",
+      "dependencies": {
+        "playwright-core": "^1.59.1"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsx": "^4.19.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/code/integrations/recording-worker/package.json
+++ b/code/integrations/recording-worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bpane-recording-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts",
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts"
+  },
+  "dependencies": {
+    "playwright-core": "^1.59.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/code/integrations/recording-worker/src/gateway-token-manager.ts
+++ b/code/integrations/recording-worker/src/gateway-token-manager.ts
@@ -1,0 +1,82 @@
+type GatewayTokenManagerOptions = {
+  staticBearerToken: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string;
+};
+
+export class GatewayTokenManager {
+  private readonly staticBearerToken: string;
+  private readonly tokenUrl: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly scopes: string;
+  private accessToken: string | null = null;
+  private expiresAtMs = 0;
+
+  constructor(options: GatewayTokenManagerOptions) {
+    this.staticBearerToken = options.staticBearerToken.trim();
+    this.tokenUrl = options.tokenUrl.trim();
+    this.clientId = options.clientId.trim();
+    this.clientSecret = options.clientSecret.trim();
+    this.scopes = options.scopes.trim();
+  }
+
+  async getAuthHeaders(
+    extraHeaders: Record<string, string> = {},
+  ): Promise<Record<string, string>> {
+    const token = await this.getAccessToken();
+    if (!token) {
+      return extraHeaders;
+    }
+    return {
+      ...extraHeaders,
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  private async getAccessToken(): Promise<string | null> {
+    if (this.staticBearerToken) {
+      return this.staticBearerToken;
+    }
+    if (!this.tokenUrl || !this.clientId || !this.clientSecret) {
+      return null;
+    }
+
+    const now = Date.now();
+    if (this.accessToken && now < this.expiresAtMs - 30_000) {
+      return this.accessToken;
+    }
+
+    const body = new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+    });
+    if (this.scopes) {
+      body.set("scope", this.scopes);
+    }
+
+    const response = await fetch(this.tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    if (!response.ok) {
+      throw new Error(`token endpoint returned ${response.status}`);
+    }
+
+    const payload = (await response.json()) as {
+      access_token?: string;
+      expires_in?: number;
+    };
+    if (!payload.access_token) {
+      throw new Error("token endpoint returned no access_token");
+    }
+
+    this.accessToken = payload.access_token;
+    this.expiresAtMs = now + Math.max(30, payload.expires_in ?? 60) * 1000;
+    return this.accessToken;
+  }
+}

--- a/code/integrations/recording-worker/src/index.ts
+++ b/code/integrations/recording-worker/src/index.ts
@@ -1,0 +1,49 @@
+import { GatewayTokenManager } from "./gateway-token-manager.js";
+import { RecorderPageRuntime } from "./recorder-page-runtime.js";
+import { RecordingControlClient } from "./recording-control-client.js";
+import { RecordingWorkerService } from "./recording-worker-service.js";
+
+function requiredEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function main(): Promise<void> {
+  const tokenManager = new GatewayTokenManager({
+    staticBearerToken: process.env.BPANE_RECORDING_BEARER_TOKEN ?? "",
+    tokenUrl: process.env.BPANE_GATEWAY_OIDC_TOKEN_URL ?? "",
+    clientId: process.env.BPANE_GATEWAY_OIDC_CLIENT_ID ?? "",
+    clientSecret: process.env.BPANE_GATEWAY_OIDC_CLIENT_SECRET ?? "",
+    scopes: process.env.BPANE_GATEWAY_OIDC_SCOPES ?? "",
+  });
+  const controlClient = new RecordingControlClient({
+    gatewayApiUrl: process.env.BPANE_GATEWAY_API_URL ?? "http://localhost:8932",
+    getHeaders: (extraHeaders) => tokenManager.getAuthHeaders(extraHeaders),
+  });
+  const pageRuntime = new RecorderPageRuntime({
+    pageUrl: process.env.BPANE_RECORDING_PAGE_URL ?? "http://localhost:8080",
+    certSpki: process.env.BPANE_RECORDING_CERT_SPKI ?? process.env.BPANE_BENCHMARK_CERT_SPKI ?? "",
+    chromeExecutablePath: requiredEnv("BPANE_RECORDING_CHROME"),
+    connectTimeoutMs: Number.parseInt(process.env.BPANE_RECORDING_CONNECT_TIMEOUT_MS ?? "30000", 10),
+    headless: (process.env.BPANE_RECORDING_HEADLESS ?? "true").trim().toLowerCase() !== "false",
+  });
+  const service = new RecordingWorkerService({
+    sessionId: requiredEnv("BPANE_RECORDING_SESSION_ID"),
+    recordingId: process.env.BPANE_RECORDING_ID ?? "",
+    outputRoot: process.env.BPANE_RECORDING_OUTPUT_ROOT ?? "/tmp/bpane-recordings",
+    pollIntervalMs: Number.parseInt(process.env.BPANE_RECORDING_POLL_INTERVAL_MS ?? "2000", 10),
+    controlClient,
+    pageRuntime,
+  });
+
+  await service.run();
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(`[recording-worker] ${message}`);
+  process.exitCode = 1;
+});

--- a/code/integrations/recording-worker/src/page-globals.d.ts
+++ b/code/integrations/recording-worker/src/page-globals.d.ts
@@ -1,0 +1,40 @@
+export {};
+
+type BpaneExampleUser = {
+  username: string;
+  password: string;
+};
+
+type BpaneAuthApi = {
+  isConfigured?: () => boolean;
+  isAuthenticated?: () => boolean;
+  getExampleUser?: () => BpaneExampleUser | null;
+};
+
+type BpaneControlApi = {
+  refreshSessions: (options?: {
+    preserveSelection?: boolean;
+    silent?: boolean;
+  }) => Promise<unknown>;
+  selectSession: (sessionId: string) => Promise<unknown>;
+  connectSelected: (options?: { clientRole?: "interactive" | "recorder" }) => Promise<unknown>;
+  disconnect: () => Promise<void>;
+  getState?: () => {
+    connected?: boolean;
+  };
+};
+
+type BpaneRecordingApi = {
+  start: () => Promise<unknown>;
+  stop: () => Promise<Blob>;
+  downloadLast: () => void;
+  setAutoDownload: (enabled: boolean) => boolean;
+};
+
+declare global {
+  interface Window {
+    __bpaneAuth?: BpaneAuthApi;
+    __bpaneControl?: BpaneControlApi;
+    __bpaneRecording?: BpaneRecordingApi;
+  }
+}

--- a/code/integrations/recording-worker/src/recorder-page-runtime.ts
+++ b/code/integrations/recording-worker/src/recorder-page-runtime.ts
@@ -1,0 +1,199 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright-core";
+
+type RecorderPageRuntimeOptions = {
+  pageUrl: string;
+  certSpki: string;
+  chromeExecutablePath: string;
+  connectTimeoutMs: number;
+  headless: boolean;
+};
+
+type RecordingArtifact = {
+  outputPath: string;
+  bytes: number;
+  mimeType: string;
+  durationMs: number;
+};
+
+export class RecorderPageRuntime {
+  private readonly pageUrl: string;
+  private readonly certSpki: string;
+  private readonly chromeExecutablePath: string;
+  private readonly connectTimeoutMs: number;
+  private readonly headless: boolean;
+  private browser: Browser | null = null;
+  private context: BrowserContext | null = null;
+  private page: Page | null = null;
+  private startedAtMs = 0;
+
+  constructor(options: RecorderPageRuntimeOptions) {
+    this.pageUrl = options.pageUrl;
+    this.certSpki = options.certSpki.trim();
+    this.chromeExecutablePath = options.chromeExecutablePath;
+    this.connectTimeoutMs = options.connectTimeoutMs;
+    this.headless = options.headless;
+  }
+
+  async start(sessionId: string): Promise<void> {
+    const browser = await chromium.launch({
+      headless: this.headless,
+      executablePath: this.chromeExecutablePath,
+      args: this.buildChromeArgs(),
+    });
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 960 },
+      deviceScaleFactor: 1,
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
+
+    this.browser = browser;
+    this.context = context;
+    this.page = page;
+
+    await page.goto(this.pageUrl, { waitUntil: "networkidle" });
+    await page.waitForFunction(
+      () => Boolean(window.__bpaneAuth && window.__bpaneControl && window.__bpaneRecording),
+      { timeout: this.connectTimeoutMs },
+    );
+    await this.ensureLoggedIn(page);
+    await page.goto(this.buildRecorderPageUrl(), { waitUntil: "networkidle" });
+    await page.waitForFunction(
+      () => Boolean(window.__bpaneAuth && window.__bpaneControl && window.__bpaneRecording),
+      { timeout: this.connectTimeoutMs },
+    );
+    await page.evaluate(
+      async (selectedSessionId) => {
+        const control = window.__bpaneControl;
+        if (!control) {
+          throw new Error("BrowserPane control API is not available");
+        }
+        await control.refreshSessions({ preserveSelection: true, silent: true });
+        await control.selectSession(selectedSessionId);
+        await control.connectSelected({ clientRole: "recorder" });
+      },
+      sessionId,
+    );
+    await page.waitForFunction(
+      () => window.__bpaneControl?.getState?.()?.connected === true,
+      { timeout: this.connectTimeoutMs },
+    );
+    await page.waitForSelector("#desktop-container canvas", { timeout: this.connectTimeoutMs });
+    await page.evaluate(() => {
+      const recording = window.__bpaneRecording;
+      if (!recording) {
+        throw new Error("BrowserPane recording API is not available");
+      }
+      recording.setAutoDownload(false);
+      return recording.start();
+    });
+    this.startedAtMs = Date.now();
+  }
+
+  async stopAndDownload(outputPath: string): Promise<RecordingArtifact> {
+    const page = this.requirePage();
+    const stopResult = await page.evaluate(async () => {
+      const recording = window.__bpaneRecording;
+      if (!recording) {
+        throw new Error("BrowserPane recording API is not available");
+      }
+      const blob = await recording.stop();
+      return { size: blob?.size ?? 0, type: blob?.type ?? "" };
+    });
+    if (!stopResult.size) {
+      throw new Error("recording finalized without any media bytes");
+    }
+
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.evaluate(() => {
+        const recording = window.__bpaneRecording;
+        if (!recording) {
+          throw new Error("BrowserPane recording API is not available");
+        }
+        recording.downloadLast();
+      }),
+    ]);
+    await download.saveAs(outputPath);
+    const stats = await fs.stat(outputPath);
+    return {
+      outputPath,
+      bytes: stats.size,
+      mimeType: stopResult.type || "video/webm",
+      durationMs: Math.max(0, Date.now() - this.startedAtMs),
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.page) {
+      await this.page
+        .evaluate(async () => {
+          if (window.__bpaneControl?.getState?.()?.connected) {
+            await window.__bpaneControl.disconnect();
+          }
+        })
+        .catch(() => {});
+    }
+    await this.context?.close().catch(() => {});
+    await this.browser?.close().catch(() => {});
+    this.page = null;
+    this.context = null;
+    this.browser = null;
+  }
+
+  private buildChromeArgs(): string[] {
+    const args = [
+      "--origin-to-force-quic-on=localhost:4433",
+      "--disable-background-timer-throttling",
+      "--disable-renderer-backgrounding",
+      "--disable-backgrounding-occluded-windows",
+    ];
+    if (this.certSpki) {
+      args.push(`--ignore-certificate-errors-spki-list=${this.certSpki}`);
+    }
+    return args;
+  }
+
+  private buildRecorderPageUrl(): string {
+    const url = new URL(this.pageUrl);
+    url.searchParams.set("layout", "browser-only");
+    url.searchParams.set("client_role", "recorder");
+    return url.toString();
+  }
+
+  private async ensureLoggedIn(page: Page): Promise<void> {
+    const state = await page.evaluate(() => ({
+      configured: window.__bpaneAuth?.isConfigured?.() ?? false,
+      authenticated: window.__bpaneAuth?.isAuthenticated?.() ?? false,
+      exampleUser: window.__bpaneAuth?.getExampleUser?.() ?? null,
+    }));
+    if (!state.configured || state.authenticated) {
+      return;
+    }
+    if (!state.exampleUser?.username || !state.exampleUser?.password) {
+      throw new Error("OIDC auth is enabled, but no example user is configured");
+    }
+
+    await page.click("#btn-login");
+    const username = page.locator('input[name="username"], #username').first();
+    const password = page.locator('input[name="password"], #password').first();
+    await username.waitFor({ state: "visible", timeout: this.connectTimeoutMs });
+    await password.waitFor({ state: "visible", timeout: this.connectTimeoutMs });
+    await username.fill(state.exampleUser.username);
+    await password.fill(state.exampleUser.password);
+    await page.locator('input[type="submit"], #kc-login').click();
+    await page.waitForFunction(() => window.__bpaneAuth?.isAuthenticated?.() === true, {
+      timeout: this.connectTimeoutMs,
+    });
+  }
+
+  private requirePage(): Page {
+    if (!this.page) {
+      throw new Error("recorder page is not active");
+    }
+    return this.page;
+  }
+}

--- a/code/integrations/recording-worker/src/recording-control-client.ts
+++ b/code/integrations/recording-worker/src/recording-control-client.ts
@@ -1,0 +1,120 @@
+import type {
+  GatewayRecordingResource,
+  GatewayRecordingTerminationReason,
+  GatewaySessionResource,
+} from "./types.js";
+
+type RecordingControlClientOptions = {
+  gatewayApiUrl: string;
+  getHeaders: (extraHeaders?: Record<string, string>) => Promise<Record<string, string>>;
+};
+
+export class RecordingControlClient {
+  private readonly gatewayApiUrl: string;
+  private readonly getHeaders: (
+    extraHeaders?: Record<string, string>,
+  ) => Promise<Record<string, string>>;
+
+  constructor(options: RecordingControlClientOptions) {
+    this.gatewayApiUrl = options.gatewayApiUrl.replace(/\/$/, "");
+    this.getHeaders = options.getHeaders;
+  }
+
+  async getSession(sessionId: string): Promise<GatewaySessionResource> {
+    return this.fetchJson<GatewaySessionResource>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}`,
+    );
+  }
+
+  async createRecording(sessionId: string): Promise<GatewayRecordingResource> {
+    return this.fetchJson<GatewayRecordingResource>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/recordings`,
+      { method: "POST" },
+    );
+  }
+
+  async getRecording(sessionId: string, recordingId: string): Promise<GatewayRecordingResource> {
+    return this.fetchJson<GatewayRecordingResource>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/recordings/${encodeURIComponent(recordingId)}`,
+    );
+  }
+
+  async completeRecording(
+    sessionId: string,
+    recordingId: string,
+    sourcePath: string,
+    mimeType: string,
+    bytes: number,
+    durationMs: number,
+  ): Promise<GatewayRecordingResource> {
+    return this.fetchJson<GatewayRecordingResource>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/recordings/${encodeURIComponent(recordingId)}/complete`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source_path: sourcePath,
+          mime_type: mimeType,
+          bytes,
+          duration_ms: durationMs,
+        }),
+      },
+    );
+  }
+
+  async failRecording(
+    sessionId: string,
+    recordingId: string,
+    error: string,
+    terminationReason?: GatewayRecordingTerminationReason,
+  ): Promise<GatewayRecordingResource> {
+    const body: { error: string; termination_reason?: GatewayRecordingTerminationReason } = {
+      error,
+    };
+    if (terminationReason) {
+      body.termination_reason = terminationReason;
+    }
+    return this.fetchJson<GatewayRecordingResource>(
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/recordings/${encodeURIComponent(recordingId)}/fail`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+  }
+
+  private async fetchJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const headers = await this.getHeaders({
+      Accept: "application/json",
+      ...(init.headers as Record<string, string> | undefined),
+    });
+    const response = await fetch(`${this.gatewayApiUrl}${path}`, {
+      ...init,
+      headers,
+    });
+    if (!response.ok) {
+      let message = `${response.status} ${response.statusText}`.trim();
+      try {
+        const payload = (await response.json()) as { error?: string };
+        if (payload?.error) {
+          message = payload.error;
+        }
+      } catch {
+        // Ignore malformed error bodies.
+      }
+      throw new RecordingControlClientError(message, response.status);
+    }
+    return (await response.json()) as T;
+  }
+}
+
+export class RecordingControlClientError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "RecordingControlClientError";
+    this.status = status;
+  }
+}

--- a/code/integrations/recording-worker/src/recording-worker-service.ts
+++ b/code/integrations/recording-worker/src/recording-worker-service.ts
@@ -1,0 +1,110 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { RecordingControlClient } from "./recording-control-client.js";
+import { RecorderPageRuntime } from "./recorder-page-runtime.js";
+import type { GatewayRecordingResource } from "./types.js";
+
+type RecordingWorkerServiceOptions = {
+  sessionId: string;
+  recordingId: string;
+  outputRoot: string;
+  pollIntervalMs: number;
+  controlClient: RecordingControlClient;
+  pageRuntime: RecorderPageRuntime;
+};
+
+export class RecordingWorkerService {
+  private readonly sessionId: string;
+  private readonly recordingId: string;
+  private readonly outputRoot: string;
+  private readonly pollIntervalMs: number;
+  private readonly controlClient: RecordingControlClient;
+  private readonly pageRuntime: RecorderPageRuntime;
+
+  constructor(options: RecordingWorkerServiceOptions) {
+    this.sessionId = options.sessionId;
+    this.recordingId = options.recordingId.trim();
+    this.outputRoot = options.outputRoot;
+    this.pollIntervalMs = options.pollIntervalMs;
+    this.controlClient = options.controlClient;
+    this.pageRuntime = options.pageRuntime;
+  }
+
+  async run(): Promise<void> {
+    const session = await this.controlClient.getSession(this.sessionId);
+    if (session.recording.mode === "disabled") {
+      throw new Error(`recording is disabled for session ${this.sessionId}`);
+    }
+
+    const recording = this.recordingId
+      ? await this.controlClient.getRecording(this.sessionId, this.recordingId)
+      : await this.controlClient.createRecording(this.sessionId);
+    let artifactDownloaded = false;
+    console.log(
+      `[recording-worker] using recording ${recording.id} for session ${this.sessionId}`,
+    );
+
+    try {
+      await this.pageRuntime.start(this.sessionId);
+      console.log(
+        `[recording-worker] recorder client connected for session ${this.sessionId}`,
+      );
+      const finalizationTarget = await this.waitForFinalize(recording.id);
+      if (finalizationTarget.state === "ready") {
+        console.log(
+          `[recording-worker] recording ${recording.id} was already finalized elsewhere`,
+        );
+        return;
+      }
+      const outputPath = this.resolveArtifactPath(recording.id);
+      const artifact = await this.pageRuntime.stopAndDownload(outputPath);
+      artifactDownloaded = true;
+      await this.controlClient.completeRecording(
+        this.sessionId,
+        recording.id,
+        artifact.outputPath,
+        artifact.mimeType,
+        artifact.bytes,
+        artifact.durationMs,
+      );
+      console.log(
+        `[recording-worker] finalized recording ${recording.id} to ${artifact.outputPath}`,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!artifactDownloaded) {
+        await fs.rm(this.resolveArtifactPath(recording.id), { force: true }).catch(() => {});
+      }
+      await this.controlClient
+        .failRecording(this.sessionId, recording.id, message, "worker_exit")
+        .catch(() => {});
+      throw error;
+    } finally {
+      await this.pageRuntime.close();
+    }
+  }
+
+  private async waitForFinalize(recordingId: string): Promise<GatewayRecordingResource> {
+    for (;;) {
+      const recording = await this.controlClient.getRecording(this.sessionId, recordingId);
+      if (recording.state === "finalizing") {
+        return recording;
+      }
+      if (recording.state === "ready") {
+        return recording;
+      }
+      if (recording.state === "failed") {
+        throw new Error(`recording ${recordingId} entered failed state`);
+      }
+      await this.sleep(this.pollIntervalMs);
+    }
+  }
+
+  private resolveArtifactPath(recordingId: string): string {
+    return path.join(this.outputRoot, this.sessionId, `${recordingId}.webm`);
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/code/integrations/recording-worker/src/types.ts
+++ b/code/integrations/recording-worker/src/types.ts
@@ -1,0 +1,54 @@
+export type GatewaySessionState =
+  | "pending"
+  | "starting"
+  | "ready"
+  | "active"
+  | "idle"
+  | "stopping"
+  | "stopped"
+  | "failed"
+  | "expired";
+
+export type GatewayRecordingMode = "disabled" | "manual" | "always";
+export type GatewayRecordingFormat = "webm";
+export type GatewayRecordingState =
+  | "starting"
+  | "recording"
+  | "finalizing"
+  | "ready"
+  | "failed";
+export type GatewayRecordingTerminationReason =
+  | "manual_stop"
+  | "session_stop"
+  | "idle_stop"
+  | "gateway_restart"
+  | "worker_exit";
+
+export type GatewaySessionResource = {
+  id: string;
+  state: GatewaySessionState;
+  recording: {
+    mode: GatewayRecordingMode;
+    format: GatewayRecordingFormat;
+    retention_sec: number | null;
+  };
+};
+
+export type GatewayRecordingResource = {
+  id: string;
+  session_id: string;
+  previous_recording_id: string | null;
+  state: GatewayRecordingState;
+  format: GatewayRecordingFormat;
+  mime_type: string | null;
+  bytes: number | null;
+  duration_ms: number | null;
+  error: string | null;
+  termination_reason: GatewayRecordingTerminationReason | null;
+  artifact_available: boolean;
+  content_path: string;
+  started_at: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/code/integrations/recording-worker/tsconfig.json
+++ b/code/integrations/recording-worker/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/code/web/bpane-client/js/__tests__/audio-playback-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/audio-playback-runtime.test.ts
@@ -37,6 +37,9 @@ class MockAudioContext {
     }),
   };
   readonly destination = {} as AudioDestinationNode;
+  readonly createMediaStreamDestination = vi.fn(() => ({
+    stream: { id: 'recording-audio-stream' } as unknown as MediaStream,
+  }) as MediaStreamAudioDestinationNode);
   readonly resume = vi.fn(async () => {});
   readonly close = vi.fn(async () => {});
   state: AudioContextState;
@@ -81,7 +84,13 @@ describe('AudioPlaybackRuntime', () => {
     );
     expect(MockAudioWorkletNode.instances).toHaveLength(1);
     expect(MockAudioWorkletNode.instances[0].connect).toHaveBeenCalledWith(MockAudioContext.instances[0].destination);
+    expect(MockAudioWorkletNode.instances[0].connect).toHaveBeenCalledWith(
+      expect.objectContaining({ stream: expect.anything() }),
+    );
     expect(runtime.ensureStarted()).toBe(true);
+    await expect(runtime.ensureRecordingStream()).resolves.toEqual(
+      expect.objectContaining({ id: 'recording-audio-stream' }),
+    );
 
     runtime.enqueueSamples(new Float32Array([0.25, -0.25, 0.5, -0.5]));
 

--- a/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
@@ -141,6 +141,34 @@ describe('SessionRecordingRuntime', () => {
     expect(MockMediaRecorder.instances[0].stream.getAudioTracks()).toHaveLength(0);
   });
 
+  it('uses a compressed default recording profile when no explicit options are provided', async () => {
+    const isTypeSupported = vi.fn((mimeType: string) => mimeType === 'video/webm;codecs=vp9,opus');
+    (globalThis as any).MediaRecorder = Object.assign(
+      class {},
+      { isTypeSupported },
+    );
+
+    const runtime = new SessionRecordingRuntime({
+      createVideoStream: vi.fn(() => new MockMediaStream([new MockTrack('video')]) as unknown as MediaStream),
+      getAudioStream: vi.fn(async () => new MockMediaStream([new MockTrack('audio')]) as unknown as MediaStream),
+      stopVideoStream: vi.fn(),
+      mediaRecorderFactory: (stream, options) => new MockMediaRecorder(
+        stream as unknown as MockMediaStream,
+        options,
+      ) as unknown as MediaRecorder,
+      mediaStreamFactory: (tracks) => new MockMediaStream(tracks as any[]) as unknown as MediaStream,
+    });
+
+    await runtime.start();
+
+    expect(MockMediaRecorder.instances[0].options).toEqual(expect.objectContaining({
+      mimeType: 'video/webm;codecs=vp9,opus',
+      videoBitsPerSecond: 3_000_000,
+      audioBitsPerSecond: 96_000,
+    }));
+    expect(isTypeSupported).toHaveBeenCalled();
+  });
+
   it('stops the recording tracks during destroy cleanup', async () => {
     const videoTrack = new MockTrack('video');
     const audioTrack = new MockTrack('audio');

--- a/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionRecordingRuntime } from '../session-recording-runtime.js';
+
+class MockTrack {
+  readonly kind: string;
+  readonly stop = vi.fn();
+
+  constructor(kind: string) {
+    this.kind = kind;
+  }
+}
+
+class MockMediaStream {
+  private readonly tracks: any[];
+
+  constructor(tracks: any[] = []) {
+    this.tracks = [...tracks];
+  }
+
+  addTrack(track: any): void {
+    this.tracks.push(track);
+  }
+
+  getTracks(): any[] {
+    return [...this.tracks];
+  }
+
+  getAudioTracks(): any[] {
+    return this.tracks.filter((track) => track.kind === 'audio');
+  }
+
+  getVideoTracks(): any[] {
+    return this.tracks.filter((track) => track.kind === 'video');
+  }
+}
+
+class MockBlobEvent extends Event {
+  readonly data: Blob;
+
+  constructor(type: string, data: Blob) {
+    super(type);
+    this.data = data;
+  }
+}
+
+class MockMediaRecorder extends EventTarget {
+  static instances: MockMediaRecorder[] = [];
+
+  readonly stream: MockMediaStream;
+  readonly options?: MediaRecorderOptions;
+  readonly start = vi.fn();
+  readonly stop = vi.fn();
+  readonly requestData = vi.fn();
+  state: RecordingState = 'inactive';
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: ((event: Event) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+
+  constructor(stream: MockMediaStream, options?: MediaRecorderOptions) {
+    super();
+    this.stream = stream;
+    this.options = options;
+    MockMediaRecorder.instances.push(this);
+  }
+
+  emitData(bytes: number[]): void {
+    const event = new MockBlobEvent(
+      'dataavailable',
+      new Blob([new Uint8Array(bytes)], { type: this.options?.mimeType ?? 'video/webm' }),
+    ) as unknown as BlobEvent;
+    this.ondataavailable?.(event);
+    this.dispatchEvent(event);
+  }
+
+  emitStop(): void {
+    this.state = 'inactive';
+    const event = new Event('stop');
+    this.onstop?.(event);
+    this.dispatchEvent(event);
+  }
+}
+
+describe('SessionRecordingRuntime', () => {
+  beforeEach(() => {
+    MockMediaRecorder.instances = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts a programmatic recording with combined video and audio tracks and returns a blob on stop', async () => {
+    const stopVideoStream = vi.fn();
+    const runtime = new SessionRecordingRuntime({
+      createVideoStream: vi.fn(() => new MockMediaStream([new MockTrack('video')]) as unknown as MediaStream),
+      getAudioStream: vi.fn(async () => new MockMediaStream([new MockTrack('audio')]) as unknown as MediaStream),
+      stopVideoStream,
+      mediaRecorderFactory: (stream, options) => new MockMediaRecorder(
+        stream as unknown as MockMediaStream,
+        options,
+      ) as unknown as MediaRecorder,
+      mediaStreamFactory: (tracks) => new MockMediaStream(tracks as any[]) as unknown as MediaStream,
+    });
+
+    await runtime.start({ frameRate: 24, mimeType: 'video/webm;codecs=vp9,opus' });
+
+    expect(runtime.isRecording()).toBe(true);
+    expect(MockMediaRecorder.instances).toHaveLength(1);
+    expect(MockMediaRecorder.instances[0].start).toHaveBeenCalledOnce();
+    expect(MockMediaRecorder.instances[0].stream.getVideoTracks()).toHaveLength(1);
+    expect(MockMediaRecorder.instances[0].stream.getAudioTracks()).toHaveLength(1);
+
+    MockMediaRecorder.instances[0].emitData([1, 2, 3, 4]);
+    const stopPromise = runtime.stop();
+    expect(MockMediaRecorder.instances[0].requestData).toHaveBeenCalledOnce();
+    expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalledOnce();
+    MockMediaRecorder.instances[0].emitStop();
+
+    const blob = await stopPromise;
+    expect(blob.size).toBe(4);
+    expect(runtime.isRecording()).toBe(false);
+    expect(stopVideoStream).toHaveBeenCalledOnce();
+  });
+
+  it('records video-only when no audio stream is available', async () => {
+    const runtime = new SessionRecordingRuntime({
+      createVideoStream: vi.fn(() => new MockMediaStream([new MockTrack('video')]) as unknown as MediaStream),
+      getAudioStream: vi.fn(async () => null),
+      stopVideoStream: vi.fn(),
+      mediaRecorderFactory: (stream, options) => new MockMediaRecorder(
+        stream as unknown as MockMediaStream,
+        options,
+      ) as unknown as MediaRecorder,
+      mediaStreamFactory: (tracks) => new MockMediaStream(tracks as any[]) as unknown as MediaStream,
+    });
+
+    await runtime.start();
+
+    expect(MockMediaRecorder.instances[0].stream.getVideoTracks()).toHaveLength(1);
+    expect(MockMediaRecorder.instances[0].stream.getAudioTracks()).toHaveLength(0);
+  });
+
+  it('stops the recording tracks during destroy cleanup', async () => {
+    const videoTrack = new MockTrack('video');
+    const audioTrack = new MockTrack('audio');
+    const runtime = new SessionRecordingRuntime({
+      createVideoStream: vi.fn(() => new MockMediaStream([videoTrack]) as unknown as MediaStream),
+      getAudioStream: vi.fn(async () => new MockMediaStream([audioTrack]) as unknown as MediaStream),
+      stopVideoStream: vi.fn(),
+      mediaRecorderFactory: (stream, options) => new MockMediaRecorder(
+        stream as unknown as MockMediaStream,
+        options,
+      ) as unknown as MediaRecorder,
+      mediaStreamFactory: (tracks) => new MockMediaStream(tracks as any[]) as unknown as MediaStream,
+    });
+
+    await runtime.start();
+    runtime.destroy();
+
+    expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalledOnce();
+    expect(videoTrack.stop).toHaveBeenCalledOnce();
+    expect(audioTrack.stop).toHaveBeenCalledOnce();
+    expect(runtime.isRecording()).toBe(false);
+  });
+});

--- a/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-runtime.test.ts
@@ -147,9 +147,12 @@ describe('SessionRecordingRuntime', () => {
       class {},
       { isTypeSupported },
     );
+    const createVideoStream = vi.fn(
+      () => new MockMediaStream([new MockTrack('video')]) as unknown as MediaStream,
+    );
 
     const runtime = new SessionRecordingRuntime({
-      createVideoStream: vi.fn(() => new MockMediaStream([new MockTrack('video')]) as unknown as MediaStream),
+      createVideoStream,
       getAudioStream: vi.fn(async () => new MockMediaStream([new MockTrack('audio')]) as unknown as MediaStream),
       stopVideoStream: vi.fn(),
       mediaRecorderFactory: (stream, options) => new MockMediaRecorder(
@@ -161,10 +164,11 @@ describe('SessionRecordingRuntime', () => {
 
     await runtime.start();
 
+    expect(createVideoStream).toHaveBeenCalledWith(24);
     expect(MockMediaRecorder.instances[0].options).toEqual(expect.objectContaining({
       mimeType: 'video/webm;codecs=vp9,opus',
-      videoBitsPerSecond: 3_000_000,
-      audioBitsPerSecond: 96_000,
+      videoBitsPerSecond: 2_000_000,
+      audioBitsPerSecond: 64_000,
     }));
     expect(isTypeSupported).toHaveBeenCalled();
   });

--- a/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
@@ -97,16 +97,16 @@ describe('SessionRecordingSurfaceRuntime', () => {
     expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1280, 720);
   });
 
-  it('uses the displayed canvas bounds for the recording output size', () => {
-    const sourceCanvas = createCanvas(892, 654);
-    const cursorCanvas = createCanvas(892, 654);
+  it('keeps the source bitmap size when the displayed canvas is scaled down', () => {
+    const sourceCanvas = createCanvas(1784, 1310);
+    const cursorCanvas = createCanvas(1784, 1310);
     sourceCanvas.getBoundingClientRect = () => ({
-      width: 1180,
-      height: 780,
+      width: 892,
+      height: 655,
       top: 0,
       left: 0,
-      right: 1180,
-      bottom: 780,
+      right: 892,
+      bottom: 655,
       x: 0,
       y: 0,
       toJSON() {
@@ -123,10 +123,10 @@ describe('SessionRecordingSurfaceRuntime', () => {
 
     const recordingCanvas = captureStreamSpy.mock.instances[0] as HTMLCanvasElement;
     const recordingContext = contexts.get(recordingCanvas)! as any;
-    expect(recordingCanvas.width).toBe(1180);
-    expect(recordingCanvas.height).toBe(780);
-    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(1, sourceCanvas, 0, 0, 1180, 780);
-    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1180, 780);
+    expect(recordingCanvas.width).toBe(1784);
+    expect(recordingCanvas.height).toBe(1310);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(1, sourceCanvas, 0, 0, 1784, 1310);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1784, 1310);
   });
 
   it('cancels the mirror loop when stopped', () => {

--- a/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
@@ -6,6 +6,19 @@ function createCanvas(width: number, height: number): HTMLCanvasElement {
   const canvas = document.createElement('canvas');
   canvas.width = width;
   canvas.height = height;
+  canvas.getBoundingClientRect = () => ({
+    width,
+    height,
+    top: 0,
+    left: 0,
+    right: width,
+    bottom: height,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return {};
+    },
+  }) as DOMRect;
   return canvas;
 }
 
@@ -82,6 +95,38 @@ describe('SessionRecordingSurfaceRuntime', () => {
     expect(recordingContext.clearRect).toHaveBeenCalledWith(0, 0, 1280, 720);
     expect(recordingContext.drawImage).toHaveBeenNthCalledWith(1, sourceCanvas, 0, 0, 1280, 720);
     expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1280, 720);
+  });
+
+  it('uses the displayed canvas bounds for the recording output size', () => {
+    const sourceCanvas = createCanvas(892, 654);
+    const cursorCanvas = createCanvas(892, 654);
+    sourceCanvas.getBoundingClientRect = () => ({
+      width: 1180,
+      height: 780,
+      top: 0,
+      left: 0,
+      right: 1180,
+      bottom: 780,
+      x: 0,
+      y: 0,
+      toJSON() {
+        return {};
+      },
+    }) as DOMRect;
+    const runtime = new SessionRecordingSurfaceRuntime({
+      sourceCanvas,
+      cursorCanvas,
+    });
+
+    runtime.start(30);
+    rafCallback?.(0);
+
+    const recordingCanvas = captureStreamSpy.mock.instances[0] as HTMLCanvasElement;
+    const recordingContext = contexts.get(recordingCanvas)! as any;
+    expect(recordingCanvas.width).toBe(1180);
+    expect(recordingCanvas.height).toBe(780);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(1, sourceCanvas, 0, 0, 1180, 780);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1180, 780);
   });
 
   it('cancels the mirror loop when stopped', () => {

--- a/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-recording-surface-runtime.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionRecordingSurfaceRuntime } from '../session-recording-surface-runtime.js';
+
+function createCanvas(width: number, height: number): HTMLCanvasElement {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  return canvas;
+}
+
+describe('SessionRecordingSurfaceRuntime', () => {
+  let contexts: WeakMap<HTMLCanvasElement, CanvasRenderingContext2D>;
+  let captureStreamSpy: ReturnType<typeof vi.fn>;
+  let rafCallback: FrameRequestCallback | null;
+  let cancelAnimationFrameSpy: ReturnType<typeof vi.fn>;
+  let captureTrackStopSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    contexts = new WeakMap();
+    captureTrackStopSpy = vi.fn();
+    captureStreamSpy = vi.fn(() => ({
+      getTracks: () => [{ stop: captureTrackStopSpy }],
+    }) as unknown as MediaStream);
+    rafCallback = null;
+    cancelAnimationFrameSpy = vi.fn();
+
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(function (
+      this: HTMLCanvasElement,
+      contextId: string,
+    ) {
+      if (contextId !== '2d') return null;
+      let context = contexts.get(this);
+      if (!context) {
+        context = {
+          clearRect: vi.fn(),
+          drawImage: vi.fn(),
+          canvas: this,
+        } as unknown as CanvasRenderingContext2D;
+        contexts.set(this, context);
+      }
+      return context;
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'captureStream', {
+      configurable: true,
+      writable: true,
+      value: captureStreamSpy,
+    });
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      rafCallback = callback;
+      return 17;
+    }));
+    vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('creates a capture stream from a dedicated recording surface and composites main output plus cursor overlay', () => {
+    const sourceCanvas = createCanvas(1280, 720);
+    const cursorCanvas = createCanvas(1280, 720);
+    const runtime = new SessionRecordingSurfaceRuntime({
+      sourceCanvas,
+      cursorCanvas,
+    });
+
+    const stream = runtime.start(30);
+
+    expect(stream).toBeDefined();
+    expect(captureStreamSpy).toHaveBeenCalledOnce();
+    expect(captureStreamSpy).toHaveBeenCalledWith(30);
+    expect(rafCallback).toBeTypeOf('function');
+
+    rafCallback?.(0);
+
+    const recordingCanvas = captureStreamSpy.mock.instances[0] as HTMLCanvasElement;
+    const recordingContext = contexts.get(recordingCanvas)! as any;
+    expect(recordingCanvas.width).toBe(1280);
+    expect(recordingCanvas.height).toBe(720);
+    expect(recordingContext.clearRect).toHaveBeenCalledWith(0, 0, 1280, 720);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(1, sourceCanvas, 0, 0, 1280, 720);
+    expect(recordingContext.drawImage).toHaveBeenNthCalledWith(2, cursorCanvas, 0, 0, 1280, 720);
+  });
+
+  it('cancels the mirror loop when stopped', () => {
+    const runtime = new SessionRecordingSurfaceRuntime({
+      sourceCanvas: createCanvas(800, 600),
+      cursorCanvas: createCanvas(800, 600),
+    });
+
+    runtime.start(24);
+    runtime.stop();
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(17);
+  });
+
+  it('stops the capture stream tracks when stopped', () => {
+    const runtime = new SessionRecordingSurfaceRuntime({
+      sourceCanvas: createCanvas(800, 600),
+      cursorCanvas: createCanvas(800, 600),
+    });
+
+    runtime.start(24);
+    runtime.stop();
+
+    expect(captureTrackStopSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/code/web/bpane-client/js/__tests__/session-transport-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-transport-runtime.test.ts
@@ -177,6 +177,30 @@ describe('SessionTransportRuntime', () => {
     expect(url).toMatch(/^https:\/\/localhost:4433\?session_ticket=session-ticket&_=\d+\.\w+$/);
   });
 
+  it('adds the recorder client role to the transport URL when requested', async () => {
+    const transport = createMockTransport();
+    const createTransport = vi.fn((url: string, options: WebTransportOptions) => {
+      void url;
+      void options;
+      return transport as unknown as WebTransport;
+    });
+    const { runtime } = createRuntime({
+      createTransport,
+      pingIntervalMs: 1000,
+    });
+
+    await runtime.connect({
+      gatewayUrl: 'https://localhost:4433',
+      token: 'test-token',
+      clientRole: 'recorder',
+    });
+
+    const [url] = createTransport.mock.calls[0];
+    expect(url).toMatch(
+      /^https:\/\/localhost:4433\?access_token=test-token&client_role=recorder&_=\d+\.\w+$/,
+    );
+  });
+
   it('passes server certificate hashes when fetch returns a valid hash', async () => {
     const transport = createMockTransport();
     const createTransport = vi.fn((url: string, options: WebTransportOptions) => {

--- a/code/web/bpane-client/js/__tests__/session.test.ts
+++ b/code/web/bpane-client/js/__tests__/session.test.ts
@@ -199,8 +199,78 @@ class MockAudioContext {
     addModule: vi.fn().mockResolvedValue(undefined),
   };
   createMediaStreamSource = vi.fn(() => ({ connect: vi.fn() }));
+  createMediaStreamDestination = vi.fn(() => ({
+    stream: new MockMediaStream([new MockMediaTrack('audio')]) as unknown as MediaStream,
+  }));
   resume = vi.fn();
   close = vi.fn();
+}
+
+class MockMediaTrack {
+  readonly kind: string;
+
+  constructor(kind: string) {
+    this.kind = kind;
+  }
+}
+
+class MockMediaStream {
+  private readonly tracks: any[];
+
+  constructor(tracks: any[] = []) {
+    this.tracks = [...tracks];
+  }
+
+  addTrack(track: any) {
+    this.tracks.push(track);
+  }
+
+  getTracks() {
+    return [...this.tracks];
+  }
+}
+
+class MockBlobEvent extends Event {
+  readonly data: Blob;
+
+  constructor(type: string, data: Blob) {
+    super(type);
+    this.data = data;
+  }
+}
+
+class MockMediaRecorder extends EventTarget {
+  static instances: MockMediaRecorder[] = [];
+
+  readonly stream: MockMediaStream;
+  readonly options?: MediaRecorderOptions;
+  readonly start = vi.fn();
+  readonly stop = vi.fn();
+  readonly requestData = vi.fn();
+  state: RecordingState = 'inactive';
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: ((event: Event) => void) | null = null;
+
+  constructor(stream: MockMediaStream, options?: MediaRecorderOptions) {
+    super();
+    this.stream = stream;
+    this.options = options;
+    MockMediaRecorder.instances.push(this);
+  }
+
+  emitData(bytes: number[]) {
+    const event = new MockBlobEvent(
+      'dataavailable',
+      new Blob([new Uint8Array(bytes)], { type: this.options?.mimeType ?? 'video/webm' }),
+    ) as unknown as BlobEvent;
+    this.ondataavailable?.(event);
+  }
+
+  emitStop() {
+    this.state = 'inactive';
+    const event = new Event('stop');
+    this.onstop?.(event);
+  }
 }
 
 class MockEncodedVideoIngressChunk {
@@ -269,6 +339,8 @@ beforeEach(() => {
   (globalThis as any).EncodedVideoChunk = MockEncodedVideoChunk;
   (globalThis as any).AudioContext = MockAudioContext;
   (globalThis as any).AudioWorkletNode = MockAudioWorkletNode;
+  (globalThis as any).MediaStream = MockMediaStream;
+  (globalThis as any).MediaRecorder = MockMediaRecorder;
   (globalThis as any).VideoEncoder = MockCameraVideoEncoder;
   (globalThis as any).VideoFrame = MockCameraVideoFrame;
   (globalThis as any).ImageData = class MockImageData {
@@ -313,8 +385,15 @@ beforeEach(() => {
     // Don't call cb to avoid infinite loop in tests
     return 1;
   });
+  (globalThis as any).cancelAnimationFrame = vi.fn();
+  Object.defineProperty(HTMLCanvasElement.prototype, 'captureStream', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => new MockMediaStream([new MockMediaTrack('video')]) as unknown as MediaStream),
+  });
 
   MockVideoDecoder.instances = [];
+  MockMediaRecorder.instances = [];
 });
 
 afterEach(() => {
@@ -426,6 +505,27 @@ describe('BpaneSession', () => {
       const { session } = await createSession();
       session.disconnect();
       expect(mockTransport.close).toHaveBeenCalled();
+    });
+
+    it('starts and stops programmatic recording from the composed session output', async () => {
+      const { session } = await createSession();
+
+      await session.startRecording({ frameRate: 24, mimeType: 'video/webm;codecs=vp9,opus' });
+
+      expect(session.isRecording()).toBe(true);
+      expect(MockMediaRecorder.instances).toHaveLength(1);
+      expect(MockMediaRecorder.instances[0].start).toHaveBeenCalledOnce();
+      expect((HTMLCanvasElement.prototype as any).captureStream).toHaveBeenCalledWith(24);
+
+      MockMediaRecorder.instances[0].emitData([1, 2, 3, 4]);
+      const stopPromise = session.stopRecording();
+      expect(MockMediaRecorder.instances[0].requestData).toHaveBeenCalledOnce();
+      expect(MockMediaRecorder.instances[0].stop).toHaveBeenCalledOnce();
+      MockMediaRecorder.instances[0].emitStop();
+
+      const blob = await stopPromise;
+      expect(blob.size).toBe(4);
+      expect(session.isRecording()).toBe(false);
     });
   });
 

--- a/code/web/bpane-client/js/__tests__/session.test.ts
+++ b/code/web/bpane-client/js/__tests__/session.test.ts
@@ -487,6 +487,15 @@ describe('BpaneSession', () => {
       expect(opts).toEqual({});
     });
 
+    it('constructs WebTransport with recorder client role when requested', async () => {
+      await createSession({ clientRole: 'recorder' });
+      expect(globalThis.WebTransport).toHaveBeenCalledOnce();
+      const [url] = (globalThis.WebTransport as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toMatch(
+        /^https:\/\/localhost:4433\?access_token=test-token&client_role=recorder&_=\d+\.\w+$/,
+      );
+    });
+
     it('removes canvas and cursor overlay on disconnect', async () => {
       const { session, container } = await createSession();
       session.disconnect();

--- a/code/web/bpane-client/js/audio-controller.ts
+++ b/code/web/bpane-client/js/audio-controller.ts
@@ -70,6 +70,13 @@ export class AudioController {
     this.microphoneRuntime.stop();
   }
 
+  async ensureRecordingStream(): Promise<MediaStream | null> {
+    if (!this.audioEnabled) {
+      return null;
+    }
+    return this.audioPlaybackRuntime.ensureRecordingStream();
+  }
+
   destroy(): void {
     this.stopMicrophone();
 

--- a/code/web/bpane-client/js/audio/audio-playback-runtime.ts
+++ b/code/web/bpane-client/js/audio/audio-playback-runtime.ts
@@ -9,6 +9,7 @@ function resolvePlaybackWorkletModuleUrl(): string {
 export class AudioPlaybackRuntime {
   private audioContext: AudioContext | null = null;
   private audioWorkletNode: AudioWorkletNode | null = null;
+  private recordingDestination: MediaStreamAudioDestinationNode | null = null;
   private starting: Promise<void> | null = null;
   private resumeHandler: (() => void) | null = null;
 
@@ -33,6 +34,16 @@ export class AudioPlaybackRuntime {
     );
   }
 
+  async ensureRecordingStream(): Promise<MediaStream | null> {
+    if (!this.audioWorkletNode && !this.starting) {
+      this.starting = this.start();
+    }
+    if (this.starting) {
+      await this.starting;
+    }
+    return this.recordingDestination?.stream ?? null;
+  }
+
   destroy(): void {
     this.detachResumeHandler();
 
@@ -40,6 +51,7 @@ export class AudioPlaybackRuntime {
       this.audioWorkletNode.disconnect();
       this.audioWorkletNode = null;
     }
+    this.recordingDestination = null;
     if (this.audioContext) {
       this.audioContext.close();
       this.audioContext = null;
@@ -64,6 +76,10 @@ export class AudioPlaybackRuntime {
         { outputChannelCount: [2] },
       );
       audioWorkletNode.connect(audioContext.destination);
+      if (typeof audioContext.createMediaStreamDestination === 'function') {
+        this.recordingDestination = audioContext.createMediaStreamDestination();
+        audioWorkletNode.connect(this.recordingDestination);
+      }
       this.audioWorkletNode = audioWorkletNode;
 
       if (audioContext.state === 'suspended') {

--- a/code/web/bpane-client/js/bpane-types.ts
+++ b/code/web/bpane-client/js/bpane-types.ts
@@ -35,3 +35,10 @@ export interface SessionCapabilities {
   fileTransfer: boolean;
   keyboardLayout: boolean;
 }
+
+export interface SessionRecordingOptions {
+  frameRate?: number;
+  mimeType?: string;
+  videoBitsPerSecond?: number;
+  audioBitsPerSecond?: number;
+}

--- a/code/web/bpane-client/js/bpane-types.ts
+++ b/code/web/bpane-client/js/bpane-types.ts
@@ -1,4 +1,5 @@
 export type RenderBackendPreference = 'auto' | 'canvas2d' | 'webgl2';
+export type SessionClientRole = 'interactive' | 'recorder';
 
 export interface BpaneOptions {
   container: HTMLElement;
@@ -9,6 +10,8 @@ export interface BpaneOptions {
   connectTicket?: string;
   /** Legacy dev-token compatibility path. Prefer `accessToken`. */
   token?: string;
+  /** Optional browser client role for gateway policy decisions. */
+  clientRole?: SessionClientRole;
   hiDpi?: boolean;
   audio?: boolean;
   microphone?: boolean;

--- a/code/web/bpane-client/js/bpane.ts
+++ b/code/web/bpane-client/js/bpane.ts
@@ -8,6 +8,7 @@
 export type {
   BpaneOptions,
   RenderBackendPreference,
+  SessionRecordingOptions,
   SessionCapabilities,
 } from './bpane-types.js';
 export { BpaneSession } from './session/bpane-session.js';

--- a/code/web/bpane-client/js/bpane.ts
+++ b/code/web/bpane-client/js/bpane.ts
@@ -8,6 +8,7 @@
 export type {
   BpaneOptions,
   RenderBackendPreference,
+  SessionClientRole,
   SessionRecordingOptions,
   SessionCapabilities,
 } from './bpane-types.js';

--- a/code/web/bpane-client/js/session-recording-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-runtime.ts
@@ -1,0 +1,151 @@
+import type { SessionRecordingOptions } from './bpane-types.js';
+
+export interface SessionRecordingRuntimeInput {
+  createVideoStream: (frameRate: number) => MediaStream;
+  getAudioStream: () => Promise<MediaStream | null>;
+  stopVideoStream: () => void;
+  mediaRecorderFactory?: (stream: MediaStream, options?: MediaRecorderOptions) => MediaRecorder;
+  mediaStreamFactory?: (tracks: MediaStreamTrack[]) => MediaStream;
+}
+
+export class SessionRecordingRuntime {
+  private readonly createVideoStream: (frameRate: number) => MediaStream;
+  private readonly getAudioStream: () => Promise<MediaStream | null>;
+  private readonly stopVideoStream: () => void;
+  private readonly mediaRecorderFactory: (
+    stream: MediaStream,
+    options?: MediaRecorderOptions,
+  ) => MediaRecorder;
+  private readonly mediaStreamFactory: (tracks: MediaStreamTrack[]) => MediaStream;
+  private recorder: MediaRecorder | null = null;
+  private activeStream: MediaStream | null = null;
+  private chunks: Blob[] = [];
+  private stopPromise: Promise<Blob> | null = null;
+  private lastMimeType = 'video/webm';
+
+  constructor(input: SessionRecordingRuntimeInput) {
+    this.createVideoStream = input.createVideoStream;
+    this.getAudioStream = input.getAudioStream;
+    this.stopVideoStream = input.stopVideoStream;
+    this.mediaRecorderFactory = input.mediaRecorderFactory
+      ?? ((stream, options) => new MediaRecorder(stream, options));
+    this.mediaStreamFactory = input.mediaStreamFactory
+      ?? ((tracks) => new MediaStream(tracks));
+  }
+
+  isRecording(): boolean {
+    return this.recorder !== null;
+  }
+
+  async start(options: SessionRecordingOptions = {}): Promise<void> {
+    if (this.recorder) {
+      throw new Error('recording is already active');
+    }
+
+    const videoStream = this.createVideoStream(options.frameRate ?? 30);
+    try {
+      const audioStream = await this.getAudioStream();
+      const tracks = [
+        ...videoStream.getTracks(),
+        ...(audioStream ? audioStream.getTracks() : []),
+      ];
+      const combinedStream = this.mediaStreamFactory(tracks);
+      this.activeStream = combinedStream;
+      const recorderOptions = this.buildRecorderOptions(options);
+      this.lastMimeType = recorderOptions.mimeType ?? this.lastMimeType;
+      const recorder = this.mediaRecorderFactory(combinedStream, recorderOptions);
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+          this.chunks.push(event.data);
+        }
+      };
+      recorder.start();
+      this.recorder = recorder;
+    } catch (error) {
+      this.stopVideoStream();
+      throw error;
+    }
+  }
+
+  async stop(): Promise<Blob> {
+    if (!this.recorder) {
+      throw new Error('recording is not active');
+    }
+    if (this.stopPromise) {
+      return this.stopPromise;
+    }
+
+    const recorder = this.recorder;
+    this.stopPromise = new Promise<Blob>((resolve, reject) => {
+      recorder.onstop = () => {
+        const blob = new Blob(this.chunks, { type: this.lastMimeType });
+        this.reset();
+        resolve(blob);
+      };
+      recorder.onerror = () => {
+        this.reset();
+        reject(new Error('recording failed'));
+      };
+    });
+
+    if (typeof recorder.requestData === 'function') {
+      recorder.requestData();
+    }
+    recorder.stop();
+    return this.stopPromise;
+  }
+
+  destroy(): void {
+    if (this.recorder) {
+      try {
+        if (typeof this.recorder.requestData === 'function') {
+          this.recorder.requestData();
+        }
+        this.recorder.stop();
+      } catch (_) {
+        // Ignore cleanup-time recorder stop failures.
+      }
+    }
+    this.reset();
+  }
+
+  private buildRecorderOptions(options: SessionRecordingOptions): MediaRecorderOptions {
+    const recorderOptions: MediaRecorderOptions = {};
+    if (options.mimeType) {
+      recorderOptions.mimeType = options.mimeType;
+    }
+    if (typeof options.audioBitsPerSecond === 'number') {
+      recorderOptions.audioBitsPerSecond = options.audioBitsPerSecond;
+    }
+    if (typeof options.videoBitsPerSecond === 'number') {
+      recorderOptions.videoBitsPerSecond = options.videoBitsPerSecond;
+    }
+    return recorderOptions;
+  }
+
+  private reset(): void {
+    if (this.recorder) {
+      this.recorder.ondataavailable = null;
+      this.recorder.onstop = null;
+      this.recorder.onerror = null;
+    }
+    if (this.activeStream) {
+      this.stopTracks(this.activeStream);
+      this.activeStream = null;
+    }
+    this.recorder = null;
+    this.chunks = [];
+    this.stopPromise = null;
+    this.stopVideoStream();
+  }
+
+  private stopTracks(stream: MediaStream): void {
+    for (const track of stream.getTracks()) {
+      try {
+        track.stop();
+      } catch (_) {
+        // Ignore cleanup-time track stop failures.
+      }
+    }
+  }
+}

--- a/code/web/bpane-client/js/session-recording-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-runtime.ts
@@ -1,7 +1,8 @@
 import type { SessionRecordingOptions } from './bpane-types.js';
 
-const DEFAULT_RECORDING_VIDEO_BITS_PER_SECOND = 3_000_000;
-const DEFAULT_RECORDING_AUDIO_BITS_PER_SECOND = 96_000;
+const DEFAULT_RECORDING_FRAME_RATE = 24;
+const DEFAULT_RECORDING_VIDEO_BITS_PER_SECOND = 2_000_000;
+const DEFAULT_RECORDING_AUDIO_BITS_PER_SECOND = 64_000;
 const PREFERRED_RECORDING_MIME_TYPES = [
   'video/webm;codecs=vp9,opus',
   'video/webm;codecs=vp8,opus',
@@ -50,7 +51,7 @@ export class SessionRecordingRuntime {
       throw new Error('recording is already active');
     }
 
-    const videoStream = this.createVideoStream(options.frameRate ?? 30);
+    const videoStream = this.createVideoStream(options.frameRate ?? DEFAULT_RECORDING_FRAME_RATE);
     try {
       const audioStream = await this.getAudioStream();
       const tracks = [

--- a/code/web/bpane-client/js/session-recording-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-runtime.ts
@@ -1,5 +1,13 @@
 import type { SessionRecordingOptions } from './bpane-types.js';
 
+const DEFAULT_RECORDING_VIDEO_BITS_PER_SECOND = 3_000_000;
+const DEFAULT_RECORDING_AUDIO_BITS_PER_SECOND = 96_000;
+const PREFERRED_RECORDING_MIME_TYPES = [
+  'video/webm;codecs=vp9,opus',
+  'video/webm;codecs=vp8,opus',
+  'video/webm',
+];
+
 export interface SessionRecordingRuntimeInput {
   createVideoStream: (frameRate: number) => MediaStream;
   getAudioStream: () => Promise<MediaStream | null>;
@@ -111,16 +119,28 @@ export class SessionRecordingRuntime {
 
   private buildRecorderOptions(options: SessionRecordingOptions): MediaRecorderOptions {
     const recorderOptions: MediaRecorderOptions = {};
-    if (options.mimeType) {
-      recorderOptions.mimeType = options.mimeType;
+    const preferredMimeType = options.mimeType ?? this.resolvePreferredMimeType();
+    if (preferredMimeType) {
+      recorderOptions.mimeType = preferredMimeType;
     }
-    if (typeof options.audioBitsPerSecond === 'number') {
-      recorderOptions.audioBitsPerSecond = options.audioBitsPerSecond;
-    }
-    if (typeof options.videoBitsPerSecond === 'number') {
-      recorderOptions.videoBitsPerSecond = options.videoBitsPerSecond;
-    }
+    recorderOptions.audioBitsPerSecond = typeof options.audioBitsPerSecond === 'number'
+      ? options.audioBitsPerSecond
+      : DEFAULT_RECORDING_AUDIO_BITS_PER_SECOND;
+    recorderOptions.videoBitsPerSecond = typeof options.videoBitsPerSecond === 'number'
+      ? options.videoBitsPerSecond
+      : DEFAULT_RECORDING_VIDEO_BITS_PER_SECOND;
     return recorderOptions;
+  }
+
+  private resolvePreferredMimeType(): string | undefined {
+    const supportsType = typeof MediaRecorder !== 'undefined'
+      && typeof MediaRecorder.isTypeSupported === 'function'
+      ? MediaRecorder.isTypeSupported.bind(MediaRecorder)
+      : null;
+    if (!supportsType) {
+      return undefined;
+    }
+    return PREFERRED_RECORDING_MIME_TYPES.find((mimeType) => supportsType(mimeType));
   }
 
   private reset(): void {

--- a/code/web/bpane-client/js/session-recording-surface-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-surface-runtime.ts
@@ -1,0 +1,84 @@
+export interface SessionRecordingSurfaceRuntimeInput {
+  sourceCanvas: HTMLCanvasElement;
+  cursorCanvas: HTMLCanvasElement | null;
+}
+
+export class SessionRecordingSurfaceRuntime {
+  private readonly sourceCanvas: HTMLCanvasElement;
+  private readonly cursorCanvas: HTMLCanvasElement | null;
+  private recordingCanvas: HTMLCanvasElement | null = null;
+  private recordingContext: CanvasRenderingContext2D | null = null;
+  private recordingStream: MediaStream | null = null;
+  private animationFrameId: number | null = null;
+
+  constructor(input: SessionRecordingSurfaceRuntimeInput) {
+    this.sourceCanvas = input.sourceCanvas;
+    this.cursorCanvas = input.cursorCanvas;
+  }
+
+  start(frameRate = 30): MediaStream {
+    if (this.recordingStream) {
+      return this.recordingStream;
+    }
+
+    const recordingCanvas = document.createElement('canvas');
+    recordingCanvas.width = this.sourceCanvas.width;
+    recordingCanvas.height = this.sourceCanvas.height;
+    const recordingContext = recordingCanvas.getContext('2d');
+    if (!recordingContext) {
+      throw new Error('2d recording canvas is unavailable');
+    }
+    const captureStream = (recordingCanvas as HTMLCanvasElement & {
+      captureStream?: (fps?: number) => MediaStream;
+    }).captureStream;
+    if (typeof captureStream !== 'function') {
+      throw new Error('canvas captureStream is unavailable in this browser');
+    }
+
+    this.recordingCanvas = recordingCanvas;
+    this.recordingContext = recordingContext;
+    this.drawFrame();
+    this.recordingStream = captureStream.call(recordingCanvas, frameRate);
+    return this.recordingStream;
+  }
+
+  stop(): void {
+    if (this.animationFrameId !== null) {
+      cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = null;
+    }
+    if (this.recordingStream) {
+      for (const track of this.recordingStream.getTracks()) {
+        try {
+          track.stop();
+        } catch (_) {
+          // Ignore cleanup-time capture track failures.
+        }
+      }
+    }
+    this.recordingStream = null;
+    this.recordingContext = null;
+    this.recordingCanvas = null;
+  }
+
+  private drawFrame = (): void => {
+    const canvas = this.recordingCanvas;
+    const context = this.recordingContext;
+    if (!canvas || !context) {
+      return;
+    }
+
+    if (canvas.width !== this.sourceCanvas.width || canvas.height !== this.sourceCanvas.height) {
+      canvas.width = this.sourceCanvas.width;
+      canvas.height = this.sourceCanvas.height;
+    }
+
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(this.sourceCanvas, 0, 0, canvas.width, canvas.height);
+    if (this.cursorCanvas) {
+      context.drawImage(this.cursorCanvas, 0, 0, canvas.width, canvas.height);
+    }
+
+    this.animationFrameId = requestAnimationFrame(this.drawFrame);
+  };
+}

--- a/code/web/bpane-client/js/session-recording-surface-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-surface-runtime.ts
@@ -86,8 +86,8 @@ export class SessionRecordingSurfaceRuntime {
 
   private getOutputSize(): { width: number; height: number } {
     const sourceRect = this.sourceCanvas.getBoundingClientRect();
-    const width = Math.max(1, Math.round(sourceRect.width) || this.sourceCanvas.width);
-    const height = Math.max(1, Math.round(sourceRect.height) || this.sourceCanvas.height);
+    const width = Math.max(1, this.sourceCanvas.width || Math.round(sourceRect.width));
+    const height = Math.max(1, this.sourceCanvas.height || Math.round(sourceRect.height));
     return { width, height };
   }
 }

--- a/code/web/bpane-client/js/session-recording-surface-runtime.ts
+++ b/code/web/bpane-client/js/session-recording-surface-runtime.ts
@@ -22,8 +22,9 @@ export class SessionRecordingSurfaceRuntime {
     }
 
     const recordingCanvas = document.createElement('canvas');
-    recordingCanvas.width = this.sourceCanvas.width;
-    recordingCanvas.height = this.sourceCanvas.height;
+    const outputSize = this.getOutputSize();
+    recordingCanvas.width = outputSize.width;
+    recordingCanvas.height = outputSize.height;
     const recordingContext = recordingCanvas.getContext('2d');
     if (!recordingContext) {
       throw new Error('2d recording canvas is unavailable');
@@ -68,9 +69,10 @@ export class SessionRecordingSurfaceRuntime {
       return;
     }
 
-    if (canvas.width !== this.sourceCanvas.width || canvas.height !== this.sourceCanvas.height) {
-      canvas.width = this.sourceCanvas.width;
-      canvas.height = this.sourceCanvas.height;
+    const outputSize = this.getOutputSize();
+    if (canvas.width !== outputSize.width || canvas.height !== outputSize.height) {
+      canvas.width = outputSize.width;
+      canvas.height = outputSize.height;
     }
 
     context.clearRect(0, 0, canvas.width, canvas.height);
@@ -81,4 +83,11 @@ export class SessionRecordingSurfaceRuntime {
 
     this.animationFrameId = requestAnimationFrame(this.drawFrame);
   };
+
+  private getOutputSize(): { width: number; height: number } {
+    const sourceRect = this.sourceCanvas.getBoundingClientRect();
+    const width = Math.max(1, Math.round(sourceRect.width) || this.sourceCanvas.width);
+    const height = Math.max(1, Math.round(sourceRect.height) || this.sourceCanvas.height);
+    return { width, height };
+  }
 }

--- a/code/web/bpane-client/js/session-surface-runtime.ts
+++ b/code/web/bpane-client/js/session-surface-runtime.ts
@@ -1,6 +1,7 @@
 import type { TileInfo } from './nal.js';
 import type { CacheMissEvent } from './render/tile-draw-runtime.js';
 import { SessionCursorRuntime } from './session-cursor-runtime.js';
+import { SessionRecordingSurfaceRuntime } from './session-recording-surface-runtime.js';
 import { SessionResizeRuntime } from './session-resize-runtime.js';
 import { SessionVideoDisplayRuntime } from './session-video-display-runtime.js';
 import {
@@ -40,6 +41,7 @@ export class SessionSurfaceRuntime {
   private cursorEl: HTMLCanvasElement | null;
   private readonly cursorRuntime: SessionCursorRuntime;
   private readonly resizeRuntime: SessionResizeRuntime;
+  private readonly recordingSurfaceRuntime: SessionRecordingSurfaceRuntime;
   private readonly videoDisplayRuntime: SessionVideoDisplayRuntime;
   private glRenderer: WebGLTileRenderer | null = null;
   private renderDiagnostics: WebGLRendererDiagnostics = {
@@ -79,6 +81,10 @@ export class SessionSurfaceRuntime {
       canvas: this.canvas,
       cursorEl: this.cursorEl,
       cursorCtx,
+    });
+    this.recordingSurfaceRuntime = new SessionRecordingSurfaceRuntime({
+      sourceCanvas: this.canvas,
+      cursorCanvas: this.cursorEl,
     });
 
     if ((input.renderBackend ?? 'auto') !== 'canvas2d') {
@@ -159,6 +165,14 @@ export class SessionSurfaceRuntime {
     return this.canvas;
   }
 
+  createRecordingStream(frameRate = 30): MediaStream {
+    return this.recordingSurfaceRuntime.start(frameRate);
+  }
+
+  stopRecordingStream(): void {
+    this.recordingSurfaceRuntime.stop();
+  }
+
   getRenderDiagnostics(): WebGLRendererDiagnostics {
     return { ...this.renderDiagnostics };
   }
@@ -198,6 +212,7 @@ export class SessionSurfaceRuntime {
   }
 
   destroy(): void {
+    this.recordingSurfaceRuntime.stop();
     this.resizeRuntime.destroy();
     this.videoDisplayRuntime.destroy();
     this.cursorRuntime.reset();

--- a/code/web/bpane-client/js/session-transport-runtime.ts
+++ b/code/web/bpane-client/js/session-transport-runtime.ts
@@ -1,3 +1,4 @@
+import type { SessionClientRole } from './bpane-types.js';
 import { UnsupportedFeatureError } from './shared/errors.js';
 
 export interface SessionTransportRuntimeInput {
@@ -21,6 +22,7 @@ export interface SessionTransportConnectOptions {
   connectTicket?: string;
   accessToken?: string;
   token?: string;
+  clientRole?: SessionClientRole;
   certHashUrl?: string;
 }
 
@@ -68,7 +70,10 @@ export class SessionTransportRuntime {
     }
     const queryParam = connectTicket ? 'session_ticket' : 'access_token';
     const queryValue = connectTicket ?? accessToken!;
-    const url = `${options.gatewayUrl}?${queryParam}=${encodeURIComponent(queryValue)}&_=${nonce}`;
+    const extraParams = options.clientRole === 'recorder'
+      ? '&client_role=recorder'
+      : '';
+    const url = `${options.gatewayUrl}?${queryParam}=${encodeURIComponent(queryValue)}${extraParams}&_=${nonce}`;
     const certHash = options.certHashUrl ? await this.fetchCertHash(options.certHashUrl) : null;
 
     try {

--- a/code/web/bpane-client/js/session/bpane-session.ts
+++ b/code/web/bpane-client/js/session/bpane-session.ts
@@ -8,7 +8,8 @@ import { FileTransferController } from '../file-transfer.js';
 import { fnvHash } from '../hash.js';
 import { InputController } from '../input-controller.js';
 import { NalReassembler } from '../nal.js';
-import type { BpaneOptions, SessionCapabilities } from '../bpane-types.js';
+import type { BpaneOptions, SessionCapabilities, SessionRecordingOptions } from '../bpane-types.js';
+import { SessionRecordingRuntime } from '../session-recording-runtime.js';
 import { SessionCapabilityRuntime } from '../session-capability-runtime.js';
 import { SessionControlRuntime } from '../session-control-runtime.js';
 import { SessionFrameRouterRuntime } from '../session-frame-router-runtime.js';
@@ -60,6 +61,7 @@ export class BpaneSession {
   private nalReassembler = new NalReassembler();
   private surfaceRuntime: SessionSurfaceRuntime;
   private videoDecoderRuntime: SessionVideoDecoderRuntime;
+  private recordingRuntime: SessionRecordingRuntime;
   private stats = new SessionStats();
 
   private constructor(options: BpaneOptions) {
@@ -162,6 +164,13 @@ export class BpaneSession {
     this.transportRuntime = runtimes.transportRuntime;
     this.surfaceRuntime = runtimes.surfaceRuntime;
     this.videoDecoderRuntime = runtimes.videoDecoderRuntime;
+    this.recordingRuntime = new SessionRecordingRuntime({
+      createVideoStream: (frameRate) => this.surfaceRuntime.createRecordingStream(frameRate),
+      getAudioStream: () => this.audio.ensureRecordingStream(),
+      stopVideoStream: () => {
+        this.surfaceRuntime.stopRecordingStream();
+      },
+    });
     this.surfaceRuntime.start();
   }
 
@@ -255,9 +264,22 @@ export class BpaneSession {
     return this.surfaceRuntime.getRenderDiagnostics();
   }
 
+  isRecording(): boolean {
+    return this.recordingRuntime.isRecording();
+  }
+
+  async startRecording(options: SessionRecordingOptions = {}): Promise<void> {
+    return this.recordingRuntime.start(options);
+  }
+
+  async stopRecording(): Promise<Blob> {
+    return this.recordingRuntime.stop();
+  }
+
   disconnect(): void {
     if (!this.connected) return;
     this.connected = false;
+    this.recordingRuntime.destroy();
     if (this.input) {
       this.input.destroy();
       this.input = null;

--- a/code/web/bpane-client/js/session/bpane-session.ts
+++ b/code/web/bpane-client/js/session/bpane-session.ts
@@ -322,6 +322,7 @@ export class BpaneSession {
       gatewayUrl: this.options.gatewayUrl,
       connectTicket: this.options.connectTicket,
       accessToken: this.options.accessToken ?? this.options.token,
+      clientRole: this.options.clientRole,
       certHashUrl: this.options.certHashUrl,
     });
   }

--- a/code/web/bpane-client/package.json
+++ b/code/web/bpane-client/package.json
@@ -8,6 +8,7 @@
     "benchmark:scroll": "node scripts/run-scroll-benchmark.mjs",
     "benchmark:stress": "node scripts/run-scroll-benchmark.mjs --profile stress",
     "benchmark:realistic": "node scripts/run-scroll-benchmark.mjs --profile realistic",
+    "smoke:recording": "node scripts/run-recording-smoke.mjs",
     "smoke:multisession": "node scripts/run-multi-session-smoke.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/code/web/bpane-client/scripts/run-recording-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-recording-smoke.mjs
@@ -2,7 +2,11 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
 import { chromium } from 'playwright-core';
+
+const execFile = promisify(execFileCallback);
 
 const DEFAULTS = {
   pageUrl: 'http://localhost:8080',
@@ -212,19 +216,18 @@ function buildRecorderPageUrl(pageUrl) {
   return url.toString();
 }
 
-async function startNewInteractiveSession(page, options) {
-  const resource = await page.evaluate(() => window.__bpaneControl.startNewSession({
-    clientRole: 'interactive',
-  }));
-  if (!resource?.id) {
-    throw new Error('Failed to create a new session resource.');
-  }
+async function connectInteractiveToSession(page, options, sessionId) {
+  await page.evaluate(async (id) => {
+    await window.__bpaneControl.refreshSessions({ preserveSelection: true, silent: true });
+    await window.__bpaneControl.selectSession(id);
+    await window.__bpaneControl.connectSelected({ clientRole: 'interactive' });
+  }, sessionId);
   await page.waitForFunction(
     () => window.__bpaneControl?.getState?.()?.connected === true,
     { timeout: options.connectTimeoutMs },
   );
   await page.waitForSelector('#desktop-container canvas', { timeout: options.connectTimeoutMs });
-  return resource;
+  return await page.evaluate(() => window.__bpaneControl.getState());
 }
 
 async function connectRecorderToSession(page, options, sessionId) {
@@ -282,6 +285,139 @@ async function fetchSessionResource(accessToken, options, sessionId) {
   });
 }
 
+async function createSessionResource(accessToken, options) {
+  return await fetchJson(`${options.pageUrl}/api/v1/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      owner_mode: 'collaborative',
+      idle_timeout_sec: 300,
+      recording: {
+        mode: 'manual',
+        format: 'webm',
+      },
+      integration_context: {
+        source: 'run-recording-smoke',
+        origin: new URL(options.pageUrl).origin,
+      },
+    }),
+  });
+}
+
+async function createSessionRecording(accessToken, options, sessionId) {
+  return await fetchJson(`${options.pageUrl}/api/v1/sessions/${sessionId}/recordings`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+async function stopSessionRecording(accessToken, options, sessionId, recordingId) {
+  return await fetchJson(
+    `${options.pageUrl}/api/v1/sessions/${sessionId}/recordings/${recordingId}/stop`,
+    {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+}
+
+async function completeSessionRecording(
+  accessToken,
+  options,
+  sessionId,
+  recordingId,
+  sourcePath,
+  mimeType,
+  bytes,
+  durationMs,
+) {
+  return await fetchJson(
+    `${options.pageUrl}/api/v1/sessions/${sessionId}/recordings/${recordingId}/complete`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        source_path: sourcePath,
+        mime_type: mimeType,
+        bytes,
+        duration_ms: durationMs,
+      }),
+    },
+  );
+}
+
+async function fetchSessionPlayback(accessToken, options, sessionId) {
+  return await fetchJson(`${options.pageUrl}/api/v1/sessions/${sessionId}/recording-playback`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+async function fetchSessionPlaybackManifest(accessToken, options, sessionId) {
+  return await fetchJson(
+    `${options.pageUrl}/api/v1/sessions/${sessionId}/recording-playback/manifest`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+}
+
+async function fetchSessionPlaybackExport(accessToken, options, sessionId) {
+  const response = await fetch(
+    `${options.pageUrl}/api/v1/sessions/${sessionId}/recording-playback/export`,
+    {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    },
+  );
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+  }
+  const bytes = Buffer.from(await response.arrayBuffer());
+  return {
+    bytes: bytes.byteLength,
+    contentType: response.headers.get('content-type') ?? '',
+  };
+}
+
+async function fetchRecordingOperations(accessToken, options) {
+  return await fetchJson(`${options.pageUrl}/api/v1/recording/operations`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+function resolveGatewayVisibleFinalizePath(sessionId, recordingId) {
+  const explicitHostRoot = process.env.BPANE_RECORDING_GATEWAY_STAGE_ROOT;
+  const explicitGatewayRoot = process.env.BPANE_RECORDING_GATEWAY_SOURCE_ROOT;
+  const fileName = `browserpane-${sessionId}-${recordingId}-control-plane.webm`;
+  if (explicitHostRoot && explicitGatewayRoot) {
+    return {
+      hostPath: path.join(explicitHostRoot, 'recording-smoke', fileName),
+      gatewayPath: path.posix.join(explicitGatewayRoot, 'recording-smoke', fileName),
+    };
+  }
+  return {
+    gatewayPath: path.posix.join('/run/bpane', 'recording-smoke', fileName),
+  };
+}
+
+async function stageFileForGateway(sourcePath, finalizeTarget) {
+  if (finalizeTarget.hostPath) {
+    await fs.mkdir(path.dirname(finalizeTarget.hostPath), { recursive: true });
+    await fs.copyFile(sourcePath, finalizeTarget.hostPath);
+    return;
+  }
+
+  const gatewayDir = path.posix.dirname(finalizeTarget.gatewayPath);
+  await execFile('docker', ['exec', 'deploy-gateway-1', 'mkdir', '-p', gatewayDir]);
+  await execFile('docker', ['cp', sourcePath, `deploy-gateway-1:${finalizeTarget.gatewayPath}`]);
+}
+
 async function deleteSession(accessToken, options, sessionId) {
   try {
     const response = await fetch(`${options.pageUrl}/api/v1/sessions/${sessionId}`, {
@@ -324,6 +460,7 @@ async function main() {
   let recorderPage = null;
   let accessToken = '';
   let sessionId = '';
+  let recordingId = '';
   let outputPath = options.outputPath;
 
   try {
@@ -348,8 +485,9 @@ async function main() {
     await configurePage(recorderPage, options, buildRecorderPageUrl(options.pageUrl));
 
     log('Starting source session');
-    const createdSession = await startNewInteractiveSession(ownerPage, options);
+    const createdSession = await createSessionResource(accessToken, options);
     sessionId = createdSession.id;
+    await connectInteractiveToSession(ownerPage, options, sessionId);
 
     log(`Connecting passive recorder client to session ${sessionId}`);
     const recorderState = await connectRecorderToSession(recorderPage, options, sessionId);
@@ -363,6 +501,11 @@ async function main() {
       (status) => status?.browser_clients >= 2 && status?.recorder_clients === 1,
       options.connectTimeoutMs,
     );
+    const recordingResource = await createSessionRecording(accessToken, options, sessionId);
+    recordingId = recordingResource.id;
+    if (!recordingId) {
+      throw new Error('Failed to create control-plane recording metadata.');
+    }
 
     await recorderPage.evaluate(() => {
       window.__bpaneRecording.setAutoDownload(false);
@@ -381,6 +524,7 @@ async function main() {
     if (!recordingStop.size) {
       throw new Error('Recording finalized without any media bytes.');
     }
+    await stopSessionRecording(accessToken, options, sessionId, recordingId);
 
     if (!outputPath) {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bpane-recording-smoke-'));
@@ -398,6 +542,37 @@ async function main() {
     if (artifactStats.size <= 1024) {
       throw new Error(`Recording artifact is unexpectedly small (${artifactStats.size} bytes).`);
     }
+    const finalizeTarget = resolveGatewayVisibleFinalizePath(sessionId, recordingId);
+    await stageFileForGateway(outputPath, finalizeTarget);
+    const completedRecording = await completeSessionRecording(
+      accessToken,
+      options,
+      sessionId,
+      recordingId,
+      finalizeTarget.gatewayPath,
+      recordingStop.type || 'video/webm',
+      artifactStats.size,
+      options.recordDurationMs,
+    );
+    const playback = await fetchSessionPlayback(accessToken, options, sessionId);
+    const playbackManifest = await fetchSessionPlaybackManifest(accessToken, options, sessionId);
+    const playbackExport = await fetchSessionPlaybackExport(accessToken, options, sessionId);
+    const recordingOperations = await fetchRecordingOperations(accessToken, options);
+
+    if (playback.state !== 'ready') {
+      throw new Error(`Expected playback state=ready, got ${playback.state}`);
+    }
+    if (playback.included_segment_count !== 1) {
+      throw new Error(
+        `Expected playback to include exactly one segment, got ${playback.included_segment_count}.`,
+      );
+    }
+    if (playbackManifest.segments?.length !== 1) {
+      throw new Error('Playback manifest did not include the expected segment entry.');
+    }
+    if (playbackExport.contentType !== 'application/zip' || playbackExport.bytes <= artifactStats.size) {
+      throw new Error('Playback export bundle was not generated as a non-empty zip artifact.');
+    }
 
     const sessionResource = await fetchSessionResource(accessToken, options, sessionId);
     const statusAfter = await fetchSessionStatus(accessToken, options, sessionId);
@@ -409,11 +584,17 @@ async function main() {
         runtime: sessionResource.runtime,
       },
       recording: {
+        id: recordingId,
         output_path: outputPath,
         bytes: artifactStats.size,
         mime_type: recordingStop.type,
         duration_ms: options.recordDurationMs,
+        control_plane: completedRecording,
       },
+      playback,
+      playback_manifest: playbackManifest,
+      playback_export: playbackExport,
+      recording_operations: recordingOperations,
       status_before_recording: statusBefore,
       status_after_recording: statusAfter,
       recorder_client: recorderState,

--- a/code/web/bpane-client/scripts/run-recording-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-recording-smoke.mjs
@@ -1,0 +1,441 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from 'playwright-core';
+
+const DEFAULTS = {
+  pageUrl: 'http://localhost:8080',
+  certSpki: process.env.BPANE_BENCHMARK_CERT_SPKI ?? '',
+  connectTimeoutMs: 30000,
+  recordDurationMs: 4000,
+  headless: false,
+  outputPath: '',
+  summaryPath: '',
+};
+
+const COMMON_CHROME_PATHS = [
+  process.env.BPANE_BENCHMARK_CHROME,
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Chromium.app/Contents/MacOS/Chromium',
+  '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+  '/usr/bin/google-chrome',
+  '/usr/bin/chromium',
+  '/usr/bin/chromium-browser',
+].filter(Boolean);
+
+function parseArgs(argv) {
+  const options = { ...DEFAULTS };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--page-url' && next) {
+      options.pageUrl = next;
+      i++;
+    } else if (arg === '--cert-spki' && next) {
+      options.certSpki = next;
+      i++;
+    } else if (arg === '--connect-timeout-ms' && next) {
+      options.connectTimeoutMs = Number(next);
+      i++;
+    } else if (arg === '--record-duration-ms' && next) {
+      options.recordDurationMs = Number(next);
+      i++;
+    } else if (arg === '--output' && next) {
+      options.outputPath = next;
+      i++;
+    } else if (arg === '--summary' && next) {
+      options.summaryPath = next;
+      i++;
+    } else if (arg === '--headless') {
+      options.headless = true;
+    } else if (arg === '--help') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function printHelp() {
+  console.log(`
+Usage: node scripts/run-recording-smoke.mjs [options]
+
+Options:
+  --page-url <url>            Local test page URL (default: ${DEFAULTS.pageUrl})
+  --cert-spki <base64>        SPKI pin for the local gateway cert
+  --connect-timeout-ms <ms>   Connect timeout (default: ${DEFAULTS.connectTimeoutMs})
+  --record-duration-ms <ms>   Capture duration after start (default: ${DEFAULTS.recordDurationMs})
+  --output <path>             Save the recorded WebM to this file
+  --summary <path>            Write JSON summary to file
+  --headless                  Run headless
+`);
+}
+
+function log(message) {
+  console.log(`[recording-smoke] ${message}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function poll(description, fn, predicate, timeoutMs, intervalMs = 500) {
+  const startedAt = Date.now();
+  let lastValue = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    lastValue = await fn();
+    if (predicate(lastValue)) {
+      return lastValue;
+    }
+    await sleep(intervalMs);
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function resolveChromeExecutable() {
+  for (const candidate of COMMON_CHROME_PATHS) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // ignore
+    }
+  }
+  throw new Error(
+    'No Chrome/Chromium executable found. Set BPANE_BENCHMARK_CHROME to a local Chrome path.',
+  );
+}
+
+async function resolveCertSpki(options) {
+  if (options.certSpki?.trim()) {
+    return options.certSpki.trim();
+  }
+  try {
+    const value = await fs.readFile(
+      new URL('../../../../dev/certs/cert-fingerprint.txt', import.meta.url),
+      'utf8',
+    );
+    return value.trim();
+  } catch {
+    return '';
+  }
+}
+
+async function fetchAuthConfig(options) {
+  try {
+    const response = await fetch(new URL('/auth-config.json', options.pageUrl));
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+async function configurePage(page, options, pageUrl = options.pageUrl) {
+  await page.goto(pageUrl, { waitUntil: 'networkidle' });
+  await page.waitForFunction(
+    () => Boolean(window.__bpaneAuth && window.__bpaneControl && window.__bpaneRecording),
+  );
+}
+
+async function ensureLoggedIn(page, options) {
+  const authConfig = await fetchAuthConfig(options);
+  if (!authConfig || authConfig.mode !== 'oidc') {
+    return authConfig;
+  }
+
+  const state = await page.evaluate(() => ({
+    configured: window.__bpaneAuth?.isConfigured?.() ?? false,
+    authenticated: window.__bpaneAuth?.isAuthenticated?.() ?? false,
+    exampleUser: window.__bpaneAuth?.getExampleUser?.() ?? null,
+  }));
+  if (!state.configured || state.authenticated) {
+    return authConfig;
+  }
+
+  const exampleUser = state.exampleUser;
+  if (!exampleUser?.username || !exampleUser?.password) {
+    throw new Error('OIDC auth is enabled, but no example user is configured for smoke login.');
+  }
+
+  await page.click('#btn-login');
+  const username = page.locator('input[name="username"], #username').first();
+  const password = page.locator('input[name="password"], #password').first();
+  const loginState = await poll(
+    'OIDC login readiness',
+    async () => ({
+      authenticated: await page
+        .evaluate(() => window.__bpaneAuth?.isAuthenticated?.() === true)
+        .catch(() => false),
+      usernameVisible: await username.isVisible().catch(() => false),
+    }),
+    (value) => value.authenticated || value.usernameVisible,
+    options.connectTimeoutMs,
+  );
+  if (!loginState.authenticated) {
+    await username.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await password.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await username.fill(exampleUser.username);
+    await password.fill(exampleUser.password);
+    await page.locator('input[type="submit"], #kc-login').click();
+  }
+
+  const pageUrl = new URL(options.pageUrl);
+  const targetPrefix = `${pageUrl.origin}${pageUrl.pathname}`;
+  await page.waitForURL(new RegExp(`^${targetPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), {
+    timeout: options.connectTimeoutMs,
+  });
+  await page.waitForFunction(() => window.__bpaneAuth?.isAuthenticated?.() === true, {
+    timeout: options.connectTimeoutMs,
+  });
+  return authConfig;
+}
+
+async function getAccessToken(page) {
+  return await page.evaluate(() => window.__bpaneAuth?.getAccessToken?.() ?? null);
+}
+
+function buildRecorderPageUrl(pageUrl) {
+  const url = new URL(pageUrl);
+  url.searchParams.set('client_role', 'recorder');
+  return url.toString();
+}
+
+async function startNewInteractiveSession(page, options) {
+  const resource = await page.evaluate(() => window.__bpaneControl.startNewSession({
+    clientRole: 'interactive',
+  }));
+  if (!resource?.id) {
+    throw new Error('Failed to create a new session resource.');
+  }
+  await page.waitForFunction(
+    () => window.__bpaneControl?.getState?.()?.connected === true,
+    { timeout: options.connectTimeoutMs },
+  );
+  await page.waitForSelector('#desktop-container canvas', { timeout: options.connectTimeoutMs });
+  return resource;
+}
+
+async function connectRecorderToSession(page, options, sessionId) {
+  await page.evaluate(async (id) => {
+    await window.__bpaneControl.refreshSessions({ preserveSelection: true, silent: true });
+    await window.__bpaneControl.selectSession(id);
+    await window.__bpaneControl.connectSelected({ clientRole: 'recorder' });
+  }, sessionId);
+  await page.waitForFunction(
+    () => window.__bpaneControl?.getState?.()?.connected === true,
+    { timeout: options.connectTimeoutMs },
+  );
+  await page.waitForSelector('#desktop-container canvas', { timeout: options.connectTimeoutMs });
+  return await page.evaluate(() => window.__bpaneControl.getState());
+}
+
+async function disconnectPage(page) {
+  await page.evaluate(async () => {
+    const state = window.__bpaneControl?.getState?.();
+    if (state?.connected) {
+      await window.__bpaneControl.disconnect();
+    }
+  }).catch(() => {});
+}
+
+async function nudgeRemotePage(page) {
+  const canvas = page.locator('#desktop-container canvas').first();
+  await canvas.waitFor({ state: 'visible', timeout: 10000 });
+  await canvas.click({ force: true });
+  await page.mouse.wheel(0, 1200);
+  await sleep(700);
+  await page.keyboard.press('PageDown');
+  await sleep(700);
+  await page.keyboard.press('PageUp');
+}
+
+async function fetchJson(url, init) {
+  const response = await fetch(url, init);
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+  }
+  return await response.json();
+}
+
+async function fetchSessionStatus(accessToken, options, sessionId) {
+  return await fetchJson(`${options.pageUrl}/api/v1/sessions/${sessionId}/status`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+async function fetchSessionResource(accessToken, options, sessionId) {
+  return await fetchJson(`${options.pageUrl}/api/v1/sessions/${sessionId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+async function deleteSession(accessToken, options, sessionId) {
+  try {
+    const response = await fetch(`${options.pageUrl}/api/v1/sessions/${sessionId}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!response.ok && response.status !== 404) {
+      const detail = await response.text().catch(() => '');
+      throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+    }
+  } catch (error) {
+    log(
+      `cleanup warning: failed to stop session ${sessionId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const executablePath = await resolveChromeExecutable();
+  const certSpki = await resolveCertSpki(options);
+  const chromeArgs = [
+    '--origin-to-force-quic-on=localhost:4433',
+    '--disable-background-timer-throttling',
+    '--disable-renderer-backgrounding',
+    '--disable-backgrounding-occluded-windows',
+  ];
+  if (certSpki) {
+    chromeArgs.push(`--ignore-certificate-errors-spki-list=${certSpki}`);
+  }
+
+  const browser = await chromium.launch({
+    headless: options.headless,
+    executablePath,
+    args: chromeArgs,
+  });
+
+  let context = null;
+  let ownerPage = null;
+  let recorderPage = null;
+  let accessToken = '';
+  let sessionId = '';
+  let outputPath = options.outputPath;
+
+  try {
+    context = await browser.newContext({
+      viewport: { width: 1440, height: 960 },
+      deviceScaleFactor: 1,
+      acceptDownloads: true,
+    });
+
+    ownerPage = await context.newPage();
+    await configurePage(ownerPage, options, options.pageUrl);
+    await ensureLoggedIn(ownerPage, options);
+    accessToken = (await getAccessToken(ownerPage)) ?? '';
+    if (!accessToken) {
+      throw new Error('Failed to acquire an access token from the owner page.');
+    }
+
+    recorderPage = await context.newPage();
+    await configurePage(recorderPage, options, buildRecorderPageUrl(options.pageUrl));
+    await ensureLoggedIn(recorderPage, options);
+
+    log('Starting source session');
+    const createdSession = await startNewInteractiveSession(ownerPage, options);
+    sessionId = createdSession.id;
+
+    log(`Connecting passive recorder client to session ${sessionId}`);
+    const recorderState = await connectRecorderToSession(recorderPage, options, sessionId);
+    if (recorderState.clientRole !== 'recorder') {
+      throw new Error(`Expected recorder page to connect with role=recorder, got ${recorderState.clientRole}`);
+    }
+
+    const statusBefore = await poll(
+      `recorder session status for ${sessionId}`,
+      () => fetchSessionStatus(accessToken, options, sessionId),
+      (status) => status?.browser_clients >= 2 && status?.recorder_clients === 1,
+      options.connectTimeoutMs,
+    );
+
+    await recorderPage.evaluate(() => {
+      window.__bpaneRecording.setAutoDownload(false);
+      return window.__bpaneRecording.start();
+    });
+    log(`Recording started for session ${sessionId}`);
+
+    await nudgeRemotePage(ownerPage);
+    await sleep(options.recordDurationMs);
+    await nudgeRemotePage(ownerPage);
+
+    const recordingStop = await recorderPage.evaluate(async () => {
+      const blob = await window.__bpaneRecording.stop();
+      return { size: blob?.size ?? 0, type: blob?.type ?? '' };
+    });
+    if (!recordingStop.size) {
+      throw new Error('Recording finalized without any media bytes.');
+    }
+
+    if (!outputPath) {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bpane-recording-smoke-'));
+      outputPath = path.join(tempDir, `browserpane-${sessionId}.webm`);
+    }
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+    const [download] = await Promise.all([
+      recorderPage.waitForEvent('download'),
+      recorderPage.evaluate(() => window.__bpaneRecording.downloadLast()),
+    ]);
+    await download.saveAs(outputPath);
+
+    const artifactStats = await fs.stat(outputPath);
+    if (artifactStats.size <= 1024) {
+      throw new Error(`Recording artifact is unexpectedly small (${artifactStats.size} bytes).`);
+    }
+
+    const sessionResource = await fetchSessionResource(accessToken, options, sessionId);
+    const statusAfter = await fetchSessionStatus(accessToken, options, sessionId);
+    const summary = {
+      scenario: 'recording-compose-smoke',
+      pageUrl: options.pageUrl,
+      session: {
+        id: sessionId,
+        runtime: sessionResource.runtime,
+      },
+      recording: {
+        output_path: outputPath,
+        bytes: artifactStats.size,
+        mime_type: recordingStop.type,
+        duration_ms: options.recordDurationMs,
+      },
+      status_before_recording: statusBefore,
+      status_after_recording: statusAfter,
+      recorder_client: recorderState,
+    };
+
+    log(`Recorded ${artifactStats.size} bytes to ${outputPath}`);
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (options.summaryPath) {
+      await fs.mkdir(path.dirname(options.summaryPath), { recursive: true });
+      await fs.writeFile(options.summaryPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    }
+  } finally {
+    if (recorderPage) {
+      await disconnectPage(recorderPage);
+    }
+    if (ownerPage) {
+      await disconnectPage(ownerPage);
+    }
+    if (accessToken && sessionId) {
+      await deleteSession(accessToken, options, sessionId);
+    }
+    if (context) {
+      await context.close().catch(() => {});
+    }
+    await browser.close().catch(() => {});
+  }
+}
+
+main().catch((error) => {
+  console.error(`[recording-smoke] ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/code/web/bpane-client/scripts/run-recording-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-recording-smoke.mjs
@@ -200,8 +200,14 @@ async function getAccessToken(page) {
   return await page.evaluate(() => window.__bpaneAuth?.getAccessToken?.() ?? null);
 }
 
-function buildRecorderPageUrl(pageUrl) {
+function buildBrowserOnlyPageUrl(pageUrl) {
   const url = new URL(pageUrl);
+  url.searchParams.set('layout', 'browser-only');
+  return url.toString();
+}
+
+function buildRecorderPageUrl(pageUrl) {
+  const url = new URL(buildBrowserOnlyPageUrl(pageUrl));
   url.searchParams.set('client_role', 'recorder');
   return url.toString();
 }
@@ -334,10 +340,12 @@ async function main() {
     if (!accessToken) {
       throw new Error('Failed to acquire an access token from the owner page.');
     }
+    await configurePage(ownerPage, options, buildBrowserOnlyPageUrl(options.pageUrl));
 
     recorderPage = await context.newPage();
-    await configurePage(recorderPage, options, buildRecorderPageUrl(options.pageUrl));
+    await configurePage(recorderPage, options, options.pageUrl);
     await ensureLoggedIn(recorderPage, options);
+    await configurePage(recorderPage, options, buildRecorderPageUrl(options.pageUrl));
 
     log('Starting source session');
     const createdSession = await startNewInteractiveSession(ownerPage, options);

--- a/code/web/bpane-client/scripts/run-recording-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-recording-smoke.mjs
@@ -245,12 +245,15 @@ async function connectRecorderToSession(page, options, sessionId) {
 }
 
 async function disconnectPage(page) {
-  await page.evaluate(async () => {
-    const state = window.__bpaneControl?.getState?.();
-    if (state?.connected) {
-      await window.__bpaneControl.disconnect();
-    }
-  }).catch(() => {});
+  await Promise.race([
+    page.evaluate(async () => {
+      const state = window.__bpaneControl?.getState?.();
+      if (state?.connected) {
+        await window.__bpaneControl.disconnect();
+      }
+    }).catch(() => {}),
+    sleep(5000),
+  ]);
 }
 
 async function nudgeRemotePage(page) {
@@ -418,6 +421,124 @@ async function stageFileForGateway(sourcePath, finalizeTarget) {
   await execFile('docker', ['cp', sourcePath, `deploy-gateway-1:${finalizeTarget.gatewayPath}`]);
 }
 
+function resolveSegmentOutputPath(requestedOutputPath, tempDir, sessionId, segmentIndex) {
+  if (!requestedOutputPath) {
+    return path.join(tempDir, `browserpane-${sessionId}-segment-${segmentIndex}.webm`);
+  }
+  if (segmentIndex === 1) {
+    return requestedOutputPath;
+  }
+  const extension = path.extname(requestedOutputPath) || '.webm';
+  const base = requestedOutputPath.slice(0, requestedOutputPath.length - extension.length);
+  return `${base}-segment-${segmentIndex}${extension}`;
+}
+
+async function savePlaywrightDownload(download, targetPath) {
+  await fs.mkdir(path.dirname(targetPath), { recursive: true });
+  await download.saveAs(targetPath);
+  const stats = await fs.stat(targetPath);
+  return {
+    path: targetPath,
+    bytes: stats.size,
+    suggestedFilename: download.suggestedFilename(),
+  };
+}
+
+async function captureRecordingSegment({
+  accessToken,
+  ownerPage,
+  recorderPage,
+  options,
+  sessionId,
+  segmentIndex,
+  requestedOutputPath,
+  tempDir,
+}) {
+  const recordingResource = await createSessionRecording(accessToken, options, sessionId);
+  const recordingId = recordingResource.id;
+  if (!recordingId) {
+    throw new Error(`Failed to create control-plane recording metadata for segment ${segmentIndex}.`);
+  }
+
+  await recorderPage.evaluate(() => {
+    window.__bpaneRecording.setAutoDownload(false);
+    return window.__bpaneRecording.start();
+  });
+  log(`Recording segment ${segmentIndex} started for session ${sessionId}`);
+
+  await nudgeRemotePage(ownerPage);
+  await sleep(options.recordDurationMs);
+  await nudgeRemotePage(ownerPage);
+
+  const recordingStop = await recorderPage.evaluate(async () => {
+    const blob = await window.__bpaneRecording.stop();
+    return { size: blob?.size ?? 0, type: blob?.type ?? '' };
+  });
+  if (!recordingStop.size) {
+    throw new Error(`Recording segment ${segmentIndex} finalized without any media bytes.`);
+  }
+
+  const stoppedRecording = await stopSessionRecording(accessToken, options, sessionId, recordingId);
+  const outputPath = resolveSegmentOutputPath(requestedOutputPath, tempDir, sessionId, segmentIndex);
+  const [download] = await Promise.all([
+    recorderPage.waitForEvent('download'),
+    recorderPage.evaluate(() => window.__bpaneRecording.downloadLast()),
+  ]);
+  const savedDownload = await savePlaywrightDownload(download, outputPath);
+  if (savedDownload.bytes <= 1024) {
+    throw new Error(
+      `Recording segment ${segmentIndex} artifact is unexpectedly small (${savedDownload.bytes} bytes).`,
+    );
+  }
+
+  const finalizeTarget = resolveGatewayVisibleFinalizePath(sessionId, recordingId);
+  await stageFileForGateway(savedDownload.path, finalizeTarget);
+  const completedRecording = await completeSessionRecording(
+    accessToken,
+    options,
+    sessionId,
+    recordingId,
+    finalizeTarget.gatewayPath,
+    recordingStop.type || 'video/webm',
+    savedDownload.bytes,
+    options.recordDurationMs,
+  );
+
+  return {
+    index: segmentIndex,
+    id: recordingId,
+    outputPath: savedDownload.path,
+    bytes: savedDownload.bytes,
+    mimeType: recordingStop.type || 'video/webm',
+    durationMs: options.recordDurationMs,
+    suggestedFilename: savedDownload.suggestedFilename,
+    stopResponse: stoppedRecording,
+    controlPlane: completedRecording,
+  };
+}
+
+async function downloadRecordingFromLibrary(page, recordingId, targetPath) {
+  const button = page.locator(
+    `[data-action="download-recording"][data-recording-id="${recordingId}"]`,
+  );
+  await button.waitFor({ state: 'visible', timeout: 10000 });
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    button.click(),
+  ]);
+  return await savePlaywrightDownload(download, targetPath);
+}
+
+async function downloadPlaybackExportFromLibrary(page, targetPath) {
+  const button = page.locator('#btn-recording-playback-download');
+  await button.waitFor({ state: 'visible', timeout: 10000 });
+  const [download] = await Promise.all([
+    page.waitForEvent('download'),
+    button.click(),
+  ]);
+  return await savePlaywrightDownload(download, targetPath);
+}
+
 async function deleteSession(accessToken, options, sessionId) {
   try {
     const response = await fetch(`${options.pageUrl}/api/v1/sessions/${sessionId}`, {
@@ -460,8 +581,7 @@ async function main() {
   let recorderPage = null;
   let accessToken = '';
   let sessionId = '';
-  let recordingId = '';
-  let outputPath = options.outputPath;
+  let tempDir = '';
 
   try {
     context = await browser.newContext({
@@ -477,12 +597,12 @@ async function main() {
     if (!accessToken) {
       throw new Error('Failed to acquire an access token from the owner page.');
     }
-    await configurePage(ownerPage, options, buildBrowserOnlyPageUrl(options.pageUrl));
 
     recorderPage = await context.newPage();
     await configurePage(recorderPage, options, options.pageUrl);
     await ensureLoggedIn(recorderPage, options);
     await configurePage(recorderPage, options, buildRecorderPageUrl(options.pageUrl));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bpane-recording-smoke-'));
 
     log('Starting source session');
     const createdSession = await createSessionResource(accessToken, options);
@@ -501,59 +621,22 @@ async function main() {
       (status) => status?.browser_clients >= 2 && status?.recorder_clients === 1,
       options.connectTimeoutMs,
     );
-    const recordingResource = await createSessionRecording(accessToken, options, sessionId);
-    recordingId = recordingResource.id;
-    if (!recordingId) {
-      throw new Error('Failed to create control-plane recording metadata.');
+    const recordingSegments = [];
+    for (let segmentIndex = 1; segmentIndex <= 2; segmentIndex++) {
+      recordingSegments.push(
+        await captureRecordingSegment({
+          accessToken,
+          ownerPage,
+          recorderPage,
+          options,
+          sessionId,
+          segmentIndex,
+          requestedOutputPath: options.outputPath,
+          tempDir,
+        }),
+      );
     }
 
-    await recorderPage.evaluate(() => {
-      window.__bpaneRecording.setAutoDownload(false);
-      return window.__bpaneRecording.start();
-    });
-    log(`Recording started for session ${sessionId}`);
-
-    await nudgeRemotePage(ownerPage);
-    await sleep(options.recordDurationMs);
-    await nudgeRemotePage(ownerPage);
-
-    const recordingStop = await recorderPage.evaluate(async () => {
-      const blob = await window.__bpaneRecording.stop();
-      return { size: blob?.size ?? 0, type: blob?.type ?? '' };
-    });
-    if (!recordingStop.size) {
-      throw new Error('Recording finalized without any media bytes.');
-    }
-    await stopSessionRecording(accessToken, options, sessionId, recordingId);
-
-    if (!outputPath) {
-      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bpane-recording-smoke-'));
-      outputPath = path.join(tempDir, `browserpane-${sessionId}.webm`);
-    }
-    await fs.mkdir(path.dirname(outputPath), { recursive: true });
-
-    const [download] = await Promise.all([
-      recorderPage.waitForEvent('download'),
-      recorderPage.evaluate(() => window.__bpaneRecording.downloadLast()),
-    ]);
-    await download.saveAs(outputPath);
-
-    const artifactStats = await fs.stat(outputPath);
-    if (artifactStats.size <= 1024) {
-      throw new Error(`Recording artifact is unexpectedly small (${artifactStats.size} bytes).`);
-    }
-    const finalizeTarget = resolveGatewayVisibleFinalizePath(sessionId, recordingId);
-    await stageFileForGateway(outputPath, finalizeTarget);
-    const completedRecording = await completeSessionRecording(
-      accessToken,
-      options,
-      sessionId,
-      recordingId,
-      finalizeTarget.gatewayPath,
-      recordingStop.type || 'video/webm',
-      artifactStats.size,
-      options.recordDurationMs,
-    );
     const playback = await fetchSessionPlayback(accessToken, options, sessionId);
     const playbackManifest = await fetchSessionPlaybackManifest(accessToken, options, sessionId);
     const playbackExport = await fetchSessionPlaybackExport(accessToken, options, sessionId);
@@ -562,16 +645,67 @@ async function main() {
     if (playback.state !== 'ready') {
       throw new Error(`Expected playback state=ready, got ${playback.state}`);
     }
-    if (playback.included_segment_count !== 1) {
+    if (playback.included_segment_count !== recordingSegments.length) {
       throw new Error(
-        `Expected playback to include exactly one segment, got ${playback.included_segment_count}.`,
+        `Expected playback to include exactly ${recordingSegments.length} segments, got ${playback.included_segment_count}.`,
       );
     }
-    if (playbackManifest.segments?.length !== 1) {
-      throw new Error('Playback manifest did not include the expected segment entry.');
+    if (playbackManifest.segments?.length !== recordingSegments.length) {
+      throw new Error('Playback manifest did not include the expected segment entries.');
     }
-    if (playbackExport.contentType !== 'application/zip' || playbackExport.bytes <= artifactStats.size) {
+    const largestSegmentBytes = Math.max(...recordingSegments.map((segment) => segment.bytes));
+    if (playbackExport.contentType !== 'application/zip' || playbackExport.bytes <= largestSegmentBytes) {
       throw new Error('Playback export bundle was not generated as a non-empty zip artifact.');
+    }
+
+    const refreshButton = ownerPage.locator('#btn-recording-library-refresh');
+    await refreshButton.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await refreshButton.click();
+    const recordingCatalog = await poll(
+      `recording library for ${sessionId}`,
+      () => ownerPage.evaluate(() => window.__bpaneRecording.getCatalogState()),
+      (state) => (
+        state?.loaded === true
+        && state?.recordings?.length >= 2
+        && state?.playback?.included_segment_count >= 2
+      ),
+      options.connectTimeoutMs,
+    );
+
+    const uiDownloadDir = path.join(tempDir, 'ui-downloads');
+    const downloadedSegments = [];
+    for (const segment of recordingSegments) {
+      const targetPath = path.join(uiDownloadDir, `segment-${segment.index}.webm`);
+      const downloaded = await downloadRecordingFromLibrary(ownerPage, segment.id, targetPath);
+      if (!downloaded.suggestedFilename.endsWith('.webm')) {
+        throw new Error(`Expected segment download filename to end with .webm, got ${downloaded.suggestedFilename}`);
+      }
+      if (downloaded.bytes !== segment.bytes) {
+        throw new Error(
+          `Segment download size mismatch for ${segment.id}: expected ${segment.bytes}, got ${downloaded.bytes}.`,
+        );
+      }
+      downloadedSegments.push({
+        recording_id: segment.id,
+        path: downloaded.path,
+        bytes: downloaded.bytes,
+        suggested_filename: downloaded.suggestedFilename,
+      });
+    }
+
+    const downloadedPlaybackExport = await downloadPlaybackExportFromLibrary(
+      ownerPage,
+      path.join(uiDownloadDir, 'recording-playback.zip'),
+    );
+    if (!downloadedPlaybackExport.suggestedFilename.endsWith('.zip')) {
+      throw new Error(
+        `Expected playback export download filename to end with .zip, got ${downloadedPlaybackExport.suggestedFilename}`,
+      );
+    }
+    if (downloadedPlaybackExport.bytes !== playbackExport.bytes) {
+      throw new Error(
+        `Playback export download size mismatch: expected ${playbackExport.bytes}, got ${downloadedPlaybackExport.bytes}.`,
+      );
     }
 
     const sessionResource = await fetchSessionResource(accessToken, options, sessionId);
@@ -583,24 +717,37 @@ async function main() {
         id: sessionId,
         runtime: sessionResource.runtime,
       },
-      recording: {
-        id: recordingId,
-        output_path: outputPath,
-        bytes: artifactStats.size,
-        mime_type: recordingStop.type,
-        duration_ms: options.recordDurationMs,
-        control_plane: completedRecording,
-      },
+      recordings: recordingSegments.map((segment) => ({
+        id: segment.id,
+        output_path: segment.outputPath,
+        bytes: segment.bytes,
+        mime_type: segment.mimeType,
+        duration_ms: segment.durationMs,
+        suggested_filename: segment.suggestedFilename,
+        control_plane: segment.controlPlane,
+      })),
       playback,
       playback_manifest: playbackManifest,
       playback_export: playbackExport,
+      ui_recording_library: {
+        recordings: recordingCatalog.recordings,
+        playback: recordingCatalog.playback,
+        downloaded_segments: downloadedSegments,
+        downloaded_playback_export: {
+          path: downloadedPlaybackExport.path,
+          bytes: downloadedPlaybackExport.bytes,
+          suggested_filename: downloadedPlaybackExport.suggestedFilename,
+        },
+      },
       recording_operations: recordingOperations,
       status_before_recording: statusBefore,
       status_after_recording: statusAfter,
       recorder_client: recorderState,
     };
 
-    log(`Recorded ${artifactStats.size} bytes to ${outputPath}`);
+    log(
+      `Recorded ${recordingSegments.length} segments for session ${sessionId} and verified UI downloads from test-embed.`,
+    );
     console.log(JSON.stringify(summary, null, 2));
 
     if (options.summaryPath) {

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -603,6 +603,89 @@
       background: rgba(18, 31, 54, 0.76);
     }
 
+    .recording-library {
+      display: grid;
+      gap: 12px;
+      padding-top: 4px;
+    }
+
+    .recording-library-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .recording-library-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .recording-library-card,
+    .recording-library-empty {
+      padding: 12px 14px;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: rgba(16, 27, 46, 0.74);
+    }
+
+    .recording-library-card {
+      display: grid;
+      gap: 10px;
+    }
+
+    .recording-library-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .recording-library-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+      font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .recording-library-title strong {
+      color: #eef4ff;
+      font-size: 13px;
+      line-height: 1.35;
+      word-break: break-all;
+    }
+
+    .recording-library-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 11px;
+      color: #c5d3eb;
+    }
+
+    .recording-library-meta span {
+      padding: 6px 8px;
+      border-radius: 999px;
+      border: 1px solid rgba(137, 161, 201, 0.12);
+      background: rgba(18, 31, 54, 0.76);
+    }
+
+    .recording-library-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .recording-library-empty {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
     .panel-logs {
       min-height: 300px;
       flex: 1;
@@ -863,6 +946,38 @@
           <button id="btn-recording-stop" disabled>Stop & Save WebM</button>
           <button id="btn-recording-download" disabled>Download Last WebM</button>
         </div>
+
+        <div class="recording-library">
+          <div class="recording-library-header">
+            <div class="panel-heading">
+              <span class="panel-title">Recording Library</span>
+              <p class="panel-copy">
+                Download retained control-plane recording segments for the selected session, or
+                fetch the current session export bundle built from those segments.
+              </p>
+            </div>
+            <button id="btn-recording-library-refresh" disabled>Refresh Library</button>
+          </div>
+
+          <div id="recording-library-note" class="helper-note info">
+            Select a session to inspect persisted recording segments and the session export bundle.
+          </div>
+
+          <div class="metrics-grid">
+            <span id="recording-library-status">Library: --</span>
+            <span id="recording-playback-status">Playback Export: --</span>
+          </div>
+
+          <div class="action-grid">
+            <button id="btn-recording-playback-download" disabled>Download Session Export</button>
+          </div>
+
+          <div id="recording-library-list" class="recording-library-list">
+            <div class="recording-library-empty">
+              No control-plane recordings loaded yet.
+            </div>
+          </div>
+        </div>
       </section>
 
       <section class="panel metrics-panel" id="panel-metrics">
@@ -967,6 +1082,12 @@
     const recordingSessionEl = document.getElementById('recording-session');
     const recordingFileEl = document.getElementById('recording-file');
     const recordingNoteEl = document.getElementById('recording-note');
+    const recordingLibraryRefreshBtn = document.getElementById('btn-recording-library-refresh');
+    const recordingLibraryNoteEl = document.getElementById('recording-library-note');
+    const recordingLibraryStatusEl = document.getElementById('recording-library-status');
+    const recordingPlaybackStatusEl = document.getElementById('recording-playback-status');
+    const recordingPlaybackDownloadBtn = document.getElementById('btn-recording-playback-download');
+    const recordingLibraryListEl = document.getElementById('recording-library-list');
     const loginBtn = document.getElementById('btn-login');
     const logoutBtn = document.getElementById('btn-logout');
     const renderBackendSelect = document.getElementById('render-backend-select');
@@ -1033,6 +1154,37 @@
     function formatRate(bytesPerSec) {
       if (!Number.isFinite(bytesPerSec) || bytesPerSec <= 0) return '0 B/s';
       return `${formatBytes(bytesPerSec)}/s`;
+    }
+
+    function formatTimestamp(value) {
+      if (!value) return '--';
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return '--';
+      return date.toLocaleString();
+    }
+
+    function formatTerminationReason(reason) {
+      if (!reason) return '--';
+      return String(reason)
+        .split('_')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+    }
+
+    function parseContentDispositionFilename(value) {
+      if (!value) {
+        return '';
+      }
+      const utf8Match = /filename\*=UTF-8''([^;]+)/i.exec(value);
+      if (utf8Match?.[1]) {
+        try {
+          return decodeURIComponent(utf8Match[1]);
+        } catch {
+          return utf8Match[1];
+        }
+      }
+      const plainMatch = /filename="?([^"]+)"?/i.exec(value);
+      return plainMatch?.[1] ?? '';
     }
 
     function topChannelRates(curr, prev, dtSec) {
@@ -1563,6 +1715,7 @@
       sessionDisplay.textContent = getSessionLabel(controlSessionState.resource);
       renderMcpDelegationState();
       renderRecordingState();
+      renderRecordingCatalogState();
     }
 
     function isJoinableSession(resource) {
@@ -1585,6 +1738,9 @@
       ) ?? null;
       controlSessionState.resource = selected;
       renderSessionState();
+      void refreshRecordingCatalogForSelectedSession({ force: false, silent: true }).catch((error) => {
+        log(`Recording library refresh failed: ${error.message}`, 'error');
+      });
       return selected;
     }
 
@@ -1850,6 +2006,7 @@
       controlSessionState.resource = null;
       controlSessionState.resources = [];
       controlSessionState.selectedSessionId = '';
+      clearRecordingCatalogState();
       stopMcpBridgePolling({ clearState: true });
       sessionStorage.removeItem(AUTH_STORAGE_KEY);
       renderSessionState();
@@ -2128,6 +2285,10 @@
         body: JSON.stringify({
           owner_mode: 'collaborative',
           idle_timeout_sec: 300,
+          recording: {
+            mode: 'manual',
+            format: 'webm',
+          },
           integration_context: {
             source: 'test-embed',
             origin: window.location.origin,
@@ -2436,6 +2597,17 @@
       lastFilename: '',
       autoDownload: true,
     };
+    const recordingCatalogState = {
+      sessionId: '',
+      recordings: [],
+      playback: null,
+      loading: false,
+      loaded: false,
+      error: '',
+      downloadingRecordingId: '',
+      downloadingPlayback: false,
+      requestId: 0,
+    };
 
     function makeRecordingFilename(sessionId) {
       const stamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -2452,6 +2624,363 @@
       anchor.click();
       anchor.remove();
       setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+
+    async function downloadAuthenticatedArtifact(accessToken, path, fallbackFilename) {
+      const response = await fetch(path, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        cache: 'no-store',
+      });
+      if (!response.ok) {
+        let detail = '';
+        try {
+          const payload = await response.json();
+          detail = payload?.error ?? '';
+        } catch {
+          detail = await response.text().catch(() => '');
+        }
+        throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+      }
+      const blob = await response.blob();
+      const filename = parseContentDispositionFilename(response.headers.get('content-disposition'))
+        || fallbackFilename;
+      downloadBlob(blob, filename);
+      return {
+        filename,
+        bytes: blob.size,
+        mimeType: response.headers.get('content-type') ?? blob.type ?? '',
+      };
+    }
+
+    async function fetchSessionRecordings(accessToken, sessionId) {
+      const response = await fetch(`${SESSION_API_URL}/${encodeURIComponent(sessionId)}/recordings`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+      });
+      if (!response.ok) {
+        let detail = '';
+        try {
+          const payload = await response.json();
+          detail = payload?.error ?? '';
+        } catch {
+          detail = await response.text().catch(() => '');
+        }
+        throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+      }
+      const payload = await response.json();
+      return Array.isArray(payload?.recordings) ? payload.recordings : [];
+    }
+
+    async function fetchSessionPlayback(accessToken, sessionId) {
+      const response = await fetch(
+        `${SESSION_API_URL}/${encodeURIComponent(sessionId)}/recording-playback`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+          cache: 'no-store',
+        },
+      );
+      if (!response.ok) {
+        let detail = '';
+        try {
+          const payload = await response.json();
+          detail = payload?.error ?? '';
+        } catch {
+          detail = await response.text().catch(() => '');
+        }
+        throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+      }
+      return await response.json();
+    }
+
+    function clearRecordingCatalogState(sessionId = '') {
+      recordingCatalogState.requestId += 1;
+      recordingCatalogState.sessionId = sessionId;
+      recordingCatalogState.recordings = [];
+      recordingCatalogState.playback = null;
+      recordingCatalogState.loading = false;
+      recordingCatalogState.loaded = false;
+      recordingCatalogState.error = '';
+      recordingCatalogState.downloadingRecordingId = '';
+      recordingCatalogState.downloadingPlayback = false;
+      renderRecordingCatalogState();
+    }
+
+    function buildRecordingCard(recording) {
+      const card = document.createElement('article');
+      card.className = 'recording-library-card';
+
+      const header = document.createElement('div');
+      header.className = 'recording-library-card-header';
+
+      const title = document.createElement('div');
+      title.className = 'recording-library-title';
+      title.textContent = `Segment ${getShortSessionId(recording.id)}`;
+      header.appendChild(title);
+
+      const stateBadge = document.createElement('span');
+      stateBadge.className = 'metric-badge';
+      stateBadge.textContent = recording.state ?? 'unknown';
+      header.appendChild(stateBadge);
+      card.appendChild(header);
+
+      const meta = document.createElement('div');
+      meta.className = 'recording-library-meta';
+      const metaItems = [
+        `Started: ${formatTimestamp(recording.started_at)}`,
+        `Completed: ${formatTimestamp(recording.completed_at)}`,
+        `Duration: ${formatDuration(recording.duration_ms ?? 0)}`,
+        `Size: ${formatBytes(recording.bytes ?? 0)}`,
+        `Termination: ${formatTerminationReason(recording.termination_reason)}`,
+      ];
+      if (recording.previous_recording_id) {
+        metaItems.push(`Previous: ${getShortSessionId(recording.previous_recording_id)}`);
+      }
+      if (recording.error) {
+        metaItems.push(`Error: ${recording.error}`);
+      }
+      for (const item of metaItems) {
+        const chip = document.createElement('span');
+        chip.textContent = item;
+        meta.appendChild(chip);
+      }
+      card.appendChild(meta);
+
+      const actions = document.createElement('div');
+      actions.className = 'recording-library-actions';
+      const downloadBtn = document.createElement('button');
+      downloadBtn.type = 'button';
+      downloadBtn.dataset.action = 'download-recording';
+      downloadBtn.dataset.recordingId = recording.id;
+      downloadBtn.textContent = recordingCatalogState.downloadingRecordingId === recording.id
+        ? 'Downloading...'
+        : 'Download Segment';
+      downloadBtn.disabled = !recording.artifact_available
+        || Boolean(recordingCatalogState.downloadingRecordingId)
+        || recordingCatalogState.downloadingPlayback;
+      if (!recording.artifact_available) {
+        downloadBtn.textContent = recording.state === 'ready' ? 'Artifact Unavailable' : 'Artifact Pending';
+      }
+      actions.appendChild(downloadBtn);
+      card.appendChild(actions);
+
+      return card;
+    }
+
+    function renderRecordingCatalogState() {
+      const selectedSessionId = controlSessionState.resource?.id ?? '';
+      const canManageSessions = authState.config?.mode === 'oidc' && Boolean(authState.tokens?.access_token);
+      const playback = recordingCatalogState.playback;
+      const hasPlayableExport = (playback?.included_segment_count ?? 0) > 0;
+
+      recordingLibraryRefreshBtn.disabled = !canManageSessions || !selectedSessionId || recordingCatalogState.loading;
+      recordingPlaybackDownloadBtn.disabled = !canManageSessions
+        || !selectedSessionId
+        || !hasPlayableExport
+        || recordingCatalogState.loading
+        || recordingCatalogState.downloadingPlayback
+        || Boolean(recordingCatalogState.downloadingRecordingId);
+      recordingPlaybackDownloadBtn.textContent = recordingCatalogState.downloadingPlayback
+        ? 'Downloading Export...'
+        : 'Download Session Export (.zip)';
+
+      if (!canManageSessions) {
+        recordingLibraryNoteEl.className = 'helper-note info';
+        recordingLibraryNoteEl.textContent = 'Login first to inspect retained session recordings.';
+        recordingLibraryStatusEl.textContent = 'Library: login required';
+        recordingPlaybackStatusEl.textContent = 'Playback Export: login required';
+        recordingLibraryListEl.innerHTML =
+          '<div class="recording-library-empty">Login first to load retained recordings.</div>';
+        return;
+      }
+
+      if (!selectedSessionId) {
+        recordingLibraryNoteEl.className = 'helper-note info';
+        recordingLibraryNoteEl.textContent =
+          'Select a session to inspect persisted recording segments and the session export bundle.';
+        recordingLibraryStatusEl.textContent = 'Library: no session selected';
+        recordingPlaybackStatusEl.textContent = 'Playback Export: --';
+        recordingLibraryListEl.innerHTML =
+          '<div class="recording-library-empty">Select a session to load retained recordings.</div>';
+        return;
+      }
+
+      if (recordingCatalogState.loading) {
+        recordingLibraryNoteEl.className = 'helper-note info';
+        recordingLibraryNoteEl.textContent =
+          `Loading retained recordings for session ${getShortSessionId(selectedSessionId)}...`;
+      } else if (recordingCatalogState.error) {
+        recordingLibraryNoteEl.className = 'helper-note warn';
+        recordingLibraryNoteEl.textContent = `Recording library failed to load: ${recordingCatalogState.error}`;
+      } else if (!recordingCatalogState.loaded) {
+        recordingLibraryNoteEl.className = 'helper-note info';
+        recordingLibraryNoteEl.textContent =
+          'Refresh the library to inspect retained recording segments and the session export bundle.';
+      } else if (recordingCatalogState.recordings.length === 0) {
+        recordingLibraryNoteEl.className = 'helper-note info';
+        recordingLibraryNoteEl.textContent =
+          'No retained recording segments exist for the selected session yet.';
+      } else {
+        recordingLibraryNoteEl.className = 'helper-note ok';
+        recordingLibraryNoteEl.textContent =
+          `Loaded ${recordingCatalogState.recordings.length} retained recording segment${recordingCatalogState.recordings.length === 1 ? '' : 's'} for session ${getShortSessionId(selectedSessionId)}.`;
+      }
+
+      if (recordingCatalogState.loading) {
+        recordingLibraryStatusEl.textContent = 'Library: loading...';
+      } else {
+        const count = recordingCatalogState.recordings.length;
+        recordingLibraryStatusEl.textContent = recordingCatalogState.loaded
+          ? `Library: ${count} segment${count === 1 ? '' : 's'}`
+          : 'Library: idle';
+      }
+
+      if (!playback) {
+        recordingPlaybackStatusEl.textContent = 'Playback Export: --';
+      } else {
+        recordingPlaybackStatusEl.textContent =
+          `Playback Export: ${playback.state} · ${playback.included_segment_count}/${playback.segment_count} segments · ${formatBytes(playback.included_bytes)}`;
+      }
+
+      recordingLibraryListEl.innerHTML = '';
+      if (!recordingCatalogState.recordings.length) {
+        const empty = document.createElement('div');
+        empty.className = 'recording-library-empty';
+        empty.textContent = recordingCatalogState.loading
+          ? 'Loading retained recordings...'
+          : 'No retained recording segments are available for this session yet.';
+        recordingLibraryListEl.appendChild(empty);
+        return;
+      }
+
+      for (const recording of recordingCatalogState.recordings) {
+        recordingLibraryListEl.appendChild(buildRecordingCard(recording));
+      }
+    }
+
+    async function refreshRecordingCatalogForSelectedSession({ force = false, silent = true } = {}) {
+      const accessToken = await getValidAccessToken();
+      const sessionId = controlSessionState.resource?.id ?? '';
+      if (!accessToken || !sessionId) {
+        clearRecordingCatalogState(sessionId);
+        return null;
+      }
+      if (!force
+        && !recordingCatalogState.error
+        && recordingCatalogState.loaded
+        && recordingCatalogState.sessionId === sessionId) {
+        return {
+          recordings: recordingCatalogState.recordings,
+          playback: recordingCatalogState.playback,
+        };
+      }
+
+      const requestId = recordingCatalogState.requestId + 1;
+      recordingCatalogState.requestId = requestId;
+      recordingCatalogState.sessionId = sessionId;
+      recordingCatalogState.loading = true;
+      recordingCatalogState.error = '';
+      renderRecordingCatalogState();
+
+      try {
+        const [recordings, playback] = await Promise.all([
+          fetchSessionRecordings(accessToken, sessionId),
+          fetchSessionPlayback(accessToken, sessionId),
+        ]);
+        if (recordingCatalogState.requestId !== requestId) {
+          return null;
+        }
+        recordingCatalogState.recordings = recordings;
+        recordingCatalogState.playback = playback;
+        recordingCatalogState.loading = false;
+        recordingCatalogState.loaded = true;
+        recordingCatalogState.error = '';
+        renderRecordingCatalogState();
+        if (!silent) {
+          log(
+            `Loaded ${recordings.length} retained recording segment${recordings.length === 1 ? '' : 's'} for session ${sessionId}`,
+            'info',
+          );
+        }
+        return {
+          recordings,
+          playback,
+        };
+      } catch (error) {
+        if (recordingCatalogState.requestId !== requestId) {
+          return null;
+        }
+        recordingCatalogState.recordings = [];
+        recordingCatalogState.playback = null;
+        recordingCatalogState.loading = false;
+        recordingCatalogState.loaded = true;
+        recordingCatalogState.error = error.message;
+        renderRecordingCatalogState();
+        if (!silent) {
+          log(`Recording library refresh failed: ${error.message}`, 'error');
+        }
+        throw error;
+      }
+    }
+
+    async function downloadCatalogRecordingById(recordingId) {
+      const accessToken = await getValidAccessToken();
+      const sessionId = controlSessionState.resource?.id ?? '';
+      const recording = recordingCatalogState.recordings.find((entry) => entry.id === recordingId);
+      if (!accessToken || !sessionId) {
+        throw new Error('login and session selection are required');
+      }
+      if (!recording) {
+        throw new Error(`recording ${recordingId} is not loaded`);
+      }
+      if (!recording.artifact_available) {
+        throw new Error(`recording ${recordingId} does not have a downloadable artifact`);
+      }
+
+      recordingCatalogState.downloadingRecordingId = recordingId;
+      renderRecordingCatalogState();
+      try {
+        const result = await downloadAuthenticatedArtifact(
+          accessToken,
+          recording.content_path,
+          `browserpane-${sessionId}-${recordingId}.webm`,
+        );
+        log(`Downloaded retained segment ${recordingId} (${formatBytes(result.bytes)})`, 'info');
+        return result;
+      } finally {
+        recordingCatalogState.downloadingRecordingId = '';
+        renderRecordingCatalogState();
+      }
+    }
+
+    async function downloadSessionPlaybackExport() {
+      const accessToken = await getValidAccessToken();
+      const sessionId = controlSessionState.resource?.id ?? '';
+      if (!accessToken || !sessionId) {
+        throw new Error('login and session selection are required');
+      }
+
+      recordingCatalogState.downloadingPlayback = true;
+      renderRecordingCatalogState();
+      try {
+        const result = await downloadAuthenticatedArtifact(
+          accessToken,
+          `${SESSION_API_URL}/${encodeURIComponent(sessionId)}/recording-playback/export`,
+          `browserpane-${sessionId}-recording-playback.zip`,
+        );
+        log(`Downloaded session export for ${sessionId} (${formatBytes(result.bytes)})`, 'info');
+        return result;
+      } finally {
+        recordingCatalogState.downloadingPlayback = false;
+        renderRecordingCatalogState();
+      }
     }
 
     function renderRecordingState() {
@@ -2966,6 +3495,29 @@
     recordingAutoDownloadToggle.addEventListener('change', () => {
       setRecordingAutoDownload(recordingAutoDownloadToggle.checked);
     });
+    recordingLibraryRefreshBtn.addEventListener('click', () => {
+      void refreshRecordingCatalogForSelectedSession({ force: true, silent: false }).catch((error) => {
+        log(`Recording library refresh failed: ${error.message}`, 'error');
+      });
+    });
+    recordingPlaybackDownloadBtn.addEventListener('click', () => {
+      void downloadSessionPlaybackExport().catch((error) => {
+        log(`Session export download failed: ${error.message}`, 'error');
+      });
+    });
+    recordingLibraryListEl.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action="download-recording"]');
+      if (!button) {
+        return;
+      }
+      const recordingId = button.dataset.recordingId;
+      if (!recordingId) {
+        return;
+      }
+      void downloadCatalogRecordingById(recordingId).catch((error) => {
+        log(`Recording download failed: ${error.message}`, 'error');
+      });
+    });
     metricsStartBtn.addEventListener('click', startBenchmarkSample);
     metricsStopBtn.addEventListener('click', () => stopBenchmarkSample('manual'));
     metricsCopyBtn.addEventListener('click', () => void copyBenchmarkSummary());
@@ -3048,6 +3600,9 @@
       start: startSessionRecording,
       stop: () => stopSessionRecording({ reason: 'api' }),
       downloadLast: downloadLastRecording,
+      refreshCatalog: (options = {}) => refreshRecordingCatalogForSelectedSession(options),
+      downloadCatalogRecording: downloadCatalogRecordingById,
+      downloadPlaybackExport: downloadSessionPlaybackExport,
       setAutoDownload: setRecordingAutoDownload,
       getState: () => ({
         active: recordingState.active,
@@ -3056,11 +3611,22 @@
         lastBlobSize: recordingState.lastBlob?.size ?? 0,
         autoDownload: recordingState.autoDownload,
       }),
+      getCatalogState: () => ({
+        sessionId: recordingCatalogState.sessionId,
+        recordings: cloneValue(recordingCatalogState.recordings) ?? [],
+        playback: cloneValue(recordingCatalogState.playback),
+        loading: recordingCatalogState.loading,
+        loaded: recordingCatalogState.loaded,
+        error: recordingCatalogState.error,
+        downloadingRecordingId: recordingCatalogState.downloadingRecordingId,
+        downloadingPlayback: recordingCatalogState.downloadingPlayback,
+      }),
     };
 
     // ── Startup ─────────────────────────────────────────────────────
     renderBenchmarkMetrics();
     renderRecordingState();
+    renderRecordingCatalogState();
     await initializeAuth();
     setToggleButtonState(cameraBtn, false, 'Camera On', 'Camera Off');
     setToggleButtonState(micBtn, false, 'Mic On', 'Mic Off');
@@ -3069,7 +3635,10 @@
     log(`Default client role: ${DEFAULT_CLIENT_ROLE}`, 'info');
     log('Benchmark metrics API: window.__bpaneBenchmarkMetrics.{startSample,stopSample,resetSample,getSummary}', 'info');
     log('Control API: window.__bpaneControl.{listSessions,getState,refreshSessions,selectSession,startNewSession,connectSelected,disconnect}', 'info');
-    log('Recording API: window.__bpaneRecording.{start,stop,downloadLast,setAutoDownload,getState}', 'info');
+    log(
+      'Recording API: window.__bpaneRecording.{start,stop,downloadLast,refreshCatalog,downloadCatalogRecording,downloadPlaybackExport,setAutoDownload,getState,getCatalogState}',
+      'info',
+    );
     if (authState.config?.mode === 'oidc') {
       log(`OIDC login configured for issuer ${authState.config.issuer}`, 'info');
       log(`Example user: ${getExampleUserLabel() || 'none configured'}`, 'info');

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -692,6 +692,7 @@
       <nav class="control-nav" aria-label="Console navigation">
         <a class="nav-link" href="#panel-sessions">Sessions</a>
         <a class="nav-link" href="#panel-display">Display</a>
+        <a class="nav-link" href="#panel-recording">Recording</a>
         <a class="nav-link" href="#panel-metrics">Metrics</a>
         <a class="nav-link" href="#panel-logs">Logs</a>
       </nav>
@@ -788,6 +789,46 @@
         </div>
       </section>
 
+      <section class="panel" id="panel-recording">
+        <div class="panel-header">
+          <div class="panel-heading">
+            <span class="panel-title">Recording</span>
+            <h2>Capture the composed session output</h2>
+            <p class="panel-copy">
+              Records the exact BrowserPane surface you see here: tile composition, ROI video,
+              cursor overlay, and desktop audio. The artifact stays local and is saved as WebM.
+            </p>
+          </div>
+        </div>
+
+        <div id="recording-note" class="helper-note info">
+          Connect to a session first, then start a local recording from the composed browser view.
+        </div>
+
+        <div class="metrics-grid">
+          <span id="recording-status">Recording: idle</span>
+          <span id="recording-session">Session: --</span>
+          <span id="recording-file">Artifact: --</span>
+        </div>
+
+        <label class="toggle-card">
+          <input type="checkbox" id="recording-autodownload-toggle" checked>
+          <span class="toggle-body">
+            <span class="toggle-text">
+              <strong>Auto Download</strong>
+              <small>Download the WebM automatically as soon as recording stops.</small>
+            </span>
+            <span class="toggle-visual" aria-hidden="true"></span>
+          </span>
+        </label>
+
+        <div class="action-grid tool-grid">
+          <button id="btn-recording-start" disabled>Start Recording</button>
+          <button id="btn-recording-stop" disabled>Stop & Save WebM</button>
+          <button id="btn-recording-download" disabled>Download Last WebM</button>
+        </div>
+      </section>
+
       <section class="panel metrics-panel" id="panel-metrics">
         <div class="metrics-header">
           <div class="panel-heading">
@@ -872,6 +913,14 @@
     const metricsStopBtn = document.getElementById('btn-metrics-stop');
     const metricsCopyBtn = document.getElementById('btn-metrics-copy');
     const metricsResetBtn = document.getElementById('btn-metrics-reset');
+    const recordingStartBtn = document.getElementById('btn-recording-start');
+    const recordingStopBtn = document.getElementById('btn-recording-stop');
+    const recordingDownloadBtn = document.getElementById('btn-recording-download');
+    const recordingAutoDownloadToggle = document.getElementById('recording-autodownload-toggle');
+    const recordingStatusEl = document.getElementById('recording-status');
+    const recordingSessionEl = document.getElementById('recording-session');
+    const recordingFileEl = document.getElementById('recording-file');
+    const recordingNoteEl = document.getElementById('recording-note');
     const loginBtn = document.getElementById('btn-login');
     const logoutBtn = document.getElementById('btn-logout');
     const renderBackendSelect = document.getElementById('render-backend-select');
@@ -1466,6 +1515,7 @@
     function renderSessionState() {
       sessionDisplay.textContent = getSessionLabel(controlSessionState.resource);
       renderMcpDelegationState();
+      renderRecordingState();
     }
 
     function isJoinableSession(resource) {
@@ -2318,6 +2368,147 @@
       maxBatchCommands: 0,
       lastObservedBatchCount: 0,
     };
+    const recordingState = {
+      active: false,
+      startedAtMs: 0,
+      lastBlob: null,
+      lastFilename: '',
+      autoDownload: true,
+    };
+
+    function makeRecordingFilename(sessionId) {
+      const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const sessionLabel = sessionId ? getShortSessionId(sessionId) : 'session';
+      return `browserpane-${sessionLabel}-${stamp}.webm`;
+    }
+
+    function downloadBlob(blob, filename) {
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+
+    function renderRecordingState() {
+      const selectedSessionId = controlSessionState.resource?.id ?? '';
+      const displaySessionId = selectedSessionId || '';
+      const activeDurationMs = recordingState.active
+        ? Math.max(0, Date.now() - recordingState.startedAtMs)
+        : 0;
+      recordingStatusEl.textContent = recordingState.active
+        ? `Recording: live ${formatDuration(activeDurationMs)}`
+        : recordingState.lastBlob
+          ? `Recording: ready ${formatBytes(recordingState.lastBlob.size)}`
+          : 'Recording: idle';
+      recordingSessionEl.textContent = displaySessionId
+        ? `Session: ${getShortSessionId(displaySessionId)}`
+        : 'Session: --';
+      recordingFileEl.textContent = recordingState.lastFilename
+        ? `Artifact: ${recordingState.lastFilename}`
+        : 'Artifact: --';
+      recordingStartBtn.disabled = !session || recordingState.active;
+      recordingStopBtn.disabled = !session || !recordingState.active;
+      recordingDownloadBtn.disabled = !recordingState.lastBlob;
+
+      if (recordingState.active) {
+        recordingNoteEl.className = 'helper-note ok';
+        recordingNoteEl.textContent =
+          `Recording is live for session ${displaySessionId ? getShortSessionId(displaySessionId) : '--'}. ` +
+          'Stopping will finalize a local WebM from the composed surface and desktop audio.';
+        return;
+      }
+      if (recordingState.lastBlob) {
+        recordingNoteEl.className = 'helper-note info';
+        recordingNoteEl.textContent =
+          `The last recording is ready${recordingState.autoDownload ? ' and was downloaded automatically' : ''}. ` +
+          'Use "Download Last WebM" to save it again.';
+        return;
+      }
+      recordingNoteEl.className = 'helper-note info';
+      recordingNoteEl.textContent = session
+        ? 'Connected. Start recording to capture the exact BrowserPane view and desktop audio into a local WebM.'
+        : 'Connect to a session first, then start a local recording from the composed browser view.';
+    }
+
+    async function startSessionRecording() {
+      if (!session) {
+        log('Cannot start recording: connect first.', 'warn');
+        return;
+      }
+      if (recordingState.active) {
+        return;
+      }
+
+      const sessionId = controlSessionState.resource?.id ?? '';
+      recordingState.startedAtMs = Date.now();
+      recordingState.lastBlob = null;
+      recordingState.lastFilename = makeRecordingFilename(sessionId);
+      renderRecordingState();
+
+      try {
+        await session.startRecording({
+          frameRate: 30,
+          videoBitsPerSecond: 8_000_000,
+          audioBitsPerSecond: 128_000,
+        });
+        recordingState.active = true;
+        renderRecordingState();
+        log(`Recording started for session ${sessionId || 'current session'}`, 'ok');
+      } catch (error) {
+        recordingState.active = false;
+        renderRecordingState();
+        log(`Recording start failed: ${error.message}`, 'error');
+      }
+    }
+
+    async function stopSessionRecording({
+      reason = 'manual',
+      sourceSession = session,
+      autoDownload = recordingState.autoDownload,
+    } = {}) {
+      if (!sourceSession || !sourceSession.isRecording()) {
+        recordingState.active = false;
+        renderRecordingState();
+        return null;
+      }
+
+      try {
+        const blob = await sourceSession.stopRecording();
+        recordingState.active = false;
+        recordingState.lastBlob = blob;
+        if (!recordingState.lastFilename) {
+          recordingState.lastFilename = makeRecordingFilename(controlSessionState.resource?.id ?? '');
+        }
+        renderRecordingState();
+        log(
+          `Recording finalized after ${reason}: ${recordingState.lastFilename} (${formatBytes(blob.size)})`,
+          'ok',
+        );
+        if (autoDownload) {
+          downloadBlob(blob, recordingState.lastFilename);
+          log(`Downloaded ${recordingState.lastFilename}`, 'info');
+        }
+        return blob;
+      } catch (error) {
+        recordingState.active = false;
+        renderRecordingState();
+        log(`Recording stop failed: ${error.message}`, 'error');
+        return null;
+      }
+    }
+
+    function downloadLastRecording() {
+      if (!recordingState.lastBlob || !recordingState.lastFilename) {
+        log('No recording is ready to download yet.', 'warn');
+        return;
+      }
+      downloadBlob(recordingState.lastBlob, recordingState.lastFilename);
+      log(`Downloaded ${recordingState.lastFilename}`, 'info');
+    }
 
     async function connect(mode = 'selected') {
       const accessToken = await getValidAccessToken();
@@ -2388,6 +2579,7 @@
             } else {
               setMetricsButtons();
             }
+            renderRecordingState();
             liveState.frameInterval = setInterval(() => {
               if (!session) return;
               const now = performance.now();
@@ -2482,10 +2674,20 @@
                 tileRate,
                 videoRate,
               });
+              if (recordingState.active) {
+                renderRecordingState();
+              }
             }, 200);
           },
           onDisconnect: (reason) => {
             log(`Disconnected: ${reason}`, 'warn');
+            const disconnectedSession = session;
+            if (disconnectedSession?.isRecording()) {
+              void stopSessionRecording({
+                reason: `transport disconnect (${reason})`,
+                sourceSession: disconnectedSession,
+              });
+            }
             // Don't call session.disconnect() here — it's already disconnecting.
             // Just update the UI state.
             if (liveState.frameInterval) { clearInterval(liveState.frameInterval); liveState.frameInterval = null; }
@@ -2521,6 +2723,7 @@
             liveState.resolution.width = 0;
             liveState.resolution.height = 0;
             setMetricsButtons();
+            renderRecordingState();
             void getValidAccessToken().then((accessToken) => {
               if (accessToken) {
                 return refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
@@ -2567,11 +2770,18 @@
       }
     }
 
-    function doDisconnect() {
+    async function doDisconnect() {
+      const activeSession = session;
+      if (activeSession?.isRecording()) {
+        await stopSessionRecording({
+          reason: 'manual disconnect',
+          sourceSession: activeSession,
+        });
+      }
       if (liveState.frameInterval) { clearInterval(liveState.frameInterval); liveState.frameInterval = null; }
       stopBenchmarkSample('disconnect');
-      if (session) {
-        session.disconnect();
+      if (activeSession) {
+        activeSession.disconnect();
         session = null;
       }
       if (overlay) overlay.style.display = '';
@@ -2604,6 +2814,7 @@
       liveState.resolution.width = 0;
       liveState.resolution.height = 0;
       setMetricsButtons();
+      renderRecordingState();
       void getValidAccessToken().then((accessToken) => {
         if (accessToken) {
           return refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
@@ -2672,7 +2883,15 @@
     }));
     newSessionBtn.addEventListener('click', () => void connect('new'));
     connectBtn.addEventListener('click', () => void connect('selected'));
-    disconnectBtn.addEventListener('click', () => doDisconnect());
+    disconnectBtn.addEventListener('click', () => void doDisconnect());
+    recordingStartBtn.addEventListener('click', () => void startSessionRecording());
+    recordingStopBtn.addEventListener('click', () => void stopSessionRecording());
+    recordingDownloadBtn.addEventListener('click', downloadLastRecording);
+    recordingAutoDownloadToggle.addEventListener('change', () => {
+      recordingState.autoDownload = recordingAutoDownloadToggle.checked;
+      renderRecordingState();
+      log(`Recording auto download ${recordingState.autoDownload ? 'enabled' : 'disabled'}`, 'info');
+    });
     metricsStartBtn.addEventListener('click', startBenchmarkSample);
     metricsStopBtn.addEventListener('click', () => stopBenchmarkSample('manual'));
     metricsCopyBtn.addEventListener('click', () => void copyBenchmarkSummary());
@@ -2706,15 +2925,29 @@
       resetSample: resetBenchmarkMetrics,
       getSummary: () => cloneSummary(benchmarkState.summary),
     };
+    window.__bpaneRecording = {
+      start: startSessionRecording,
+      stop: () => stopSessionRecording({ reason: 'api' }),
+      downloadLast: downloadLastRecording,
+      getState: () => ({
+        active: recordingState.active,
+        startedAtMs: recordingState.startedAtMs,
+        lastFilename: recordingState.lastFilename,
+        lastBlobSize: recordingState.lastBlob?.size ?? 0,
+        autoDownload: recordingState.autoDownload,
+      }),
+    };
 
     // ── Startup ─────────────────────────────────────────────────────
     renderBenchmarkMetrics();
+    renderRecordingState();
     await initializeAuth();
     setToggleButtonState(cameraBtn, false, 'Camera On', 'Camera Off');
     setToggleButtonState(micBtn, false, 'Mic On', 'Mic Off');
     log(`Gateway target: ${GATEWAY_URL}`);
     log(`Session control API: ${SESSION_API_URL}`, 'info');
     log('Benchmark metrics API: window.__bpaneBenchmarkMetrics.{startSample,stopSample,resetSample,getSummary}', 'info');
+    log('Recording API: window.__bpaneRecording.{start,stop,downloadLast,getState}', 'info');
     if (authState.config?.mode === 'oidc') {
       log(`OIDC login configured for issuer ${authState.config.issuer}`, 'info');
       log(`Example user: ${getExampleUserLabel() || 'none configured'}`, 'info');

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -879,10 +879,14 @@
     const { BpaneSession } = await import(SDK_PATH);
 
     // ── Config ──────────────────────────────────────────────────────
+    const pageParams = new URLSearchParams(window.location.search);
     const GATEWAY_HOST = location.hostname || 'localhost';
     const GATEWAY_PORT = 4433;
     const GATEWAY_URL = `https://${GATEWAY_HOST}:${GATEWAY_PORT}`;
     const SESSION_API_URL = '/api/v1/sessions';
+    const DEFAULT_CLIENT_ROLE = pageParams.get('client_role')?.toLowerCase() === 'recorder'
+      ? 'recorder'
+      : 'interactive';
 
     // ── DOM refs ────────────────────────────────────────────────────
     const container = document.getElementById('desktop-container');
@@ -1505,7 +1509,8 @@
       const shortId = getShortSessionId(resource.id);
       const state = resource.state ?? 'unknown';
       const suffix = resource.id === mcpBridgeState.controlSessionId ? ' · MCP delegated' : '';
-      return `Session: ${shortId} (${state})${suffix}`;
+      const clientRole = currentClientRole === 'recorder' ? ' · recorder' : '';
+      return `Session: ${shortId} (${state})${suffix}${clientRole}`;
     }
 
     function supportsLocalMcpDelegation(resource) {
@@ -1539,6 +1544,19 @@
       controlSessionState.resource = selected;
       renderSessionState();
       return selected;
+    }
+
+    function cloneValue(value) {
+      return value ? JSON.parse(JSON.stringify(value)) : value;
+    }
+
+    function setSelectedSessionId(sessionId) {
+      const nextSessionId = typeof sessionId === 'string' ? sessionId : '';
+      controlSessionState.selectedSessionId = nextSessionId;
+      if (sessionSelect.value !== nextSessionId) {
+        sessionSelect.value = nextSessionId;
+      }
+      return syncSelectedSessionResource();
     }
 
     function renderSessionPicker() {
@@ -2344,6 +2362,7 @@
 
     // ── Session state ───────────────────────────────────────────────
     let session = null;
+    let currentClientRole = DEFAULT_CLIENT_ROLE;
     const liveState = {
       frameInterval: null,
       lastFrameCount: 0,
@@ -2510,12 +2529,20 @@
       log(`Downloaded ${recordingState.lastFilename}`, 'info');
     }
 
-    async function connect(mode = 'selected') {
+    function setRecordingAutoDownload(enabled) {
+      recordingState.autoDownload = Boolean(enabled);
+      recordingAutoDownloadToggle.checked = recordingState.autoDownload;
+      renderRecordingState();
+      log(`Recording auto download ${recordingState.autoDownload ? 'enabled' : 'disabled'}`, 'info');
+      return recordingState.autoDownload;
+    }
+
+    async function connect(mode = 'selected', connectOptions = {}) {
       const accessToken = await getValidAccessToken();
       if (!accessToken) {
         setStatus('Login required', 'error');
         log('Connection cancelled: no access token available', 'error');
-        return;
+        return null;
       }
 
       if (overlay) overlay.style.display = 'none';
@@ -2529,13 +2556,19 @@
         if (!controlSession) {
           setStatus(mode === 'new' ? 'Session creation failed' : 'Session selection required', 'error');
           if (overlay) overlay.style.display = '';
-          return;
+          return null;
         }
         const connectCredential = await resolveSessionConnectCredential(accessToken, controlSession);
         const gatewayUrl = `${controlSession.connect.gateway_url}${controlSession.connect.transport_path}`;
+        const clientRole = connectOptions.clientRole === 'recorder'
+          ? 'recorder'
+          : connectOptions.clientRole === 'interactive'
+            ? 'interactive'
+            : DEFAULT_CLIENT_ROLE;
+        currentClientRole = clientRole;
         log(`Connecting to ${gatewayUrl} via session ${controlSession.id}...`);
         log(
-          `Connect options: render=${renderBackendSelect.value}, scrollCopy=${scrollCopyToggle.checked ? 'on' : 'off'}, hiDpi=${hidpiToggle.checked}`,
+          `Connect options: render=${renderBackendSelect.value}, scrollCopy=${scrollCopyToggle.checked ? 'on' : 'off'}, hiDpi=${hidpiToggle.checked}, role=${clientRole}`,
           'info',
         );
         session = await BpaneSession.connect({
@@ -2550,6 +2583,7 @@
           audio: true,
           camera: true,
           fileTransfer: true,
+          clientRole,
           certHashUrl: '/cert-hash',
           onConnect: () => {
             log('Connected', 'ok');
@@ -2693,6 +2727,7 @@
             if (liveState.frameInterval) { clearInterval(liveState.frameInterval); liveState.frameInterval = null; }
             stopBenchmarkSample('disconnect');
             session = null;
+            currentClientRole = DEFAULT_CLIENT_ROLE;
             if (overlay) overlay.style.display = '';
             setStatus('Disconnected', 'disconnected');
             if (controlSessionState.resource && isRuntimeCandidateSessionState(controlSessionState.resource.state)) {
@@ -2755,6 +2790,7 @@
         renderBackendEl.textContent = formatRenderDiagnostics(session.getRenderDiagnostics());
         log(formatRenderDiagnostics(session.getRenderDiagnostics()), 'info');
         renderAuthState();
+        return controlSessionState.resource;
       } catch (e) {
         log(`Connection failed: ${e.message}`, 'error');
         setStatus('Connection failed', 'error');
@@ -2767,6 +2803,7 @@
         log('Hint: Chrome requires trusted TLS for WebTransport.', 'warn');
         log(`Launch Chrome with: --origin-to-force-quic-on=${GATEWAY_HOST}:${GATEWAY_PORT}`, 'warn');
         if (overlay) overlay.style.display = '';
+        return null;
       }
     }
 
@@ -2784,6 +2821,7 @@
         activeSession.disconnect();
         session = null;
       }
+      currentClientRole = DEFAULT_CLIENT_ROLE;
       if (overlay) overlay.style.display = '';
       setStatus('Disconnected', 'disconnected');
       if (controlSessionState.resource && isRuntimeCandidateSessionState(controlSessionState.resource.state)) {
@@ -2888,9 +2926,7 @@
     recordingStopBtn.addEventListener('click', () => void stopSessionRecording());
     recordingDownloadBtn.addEventListener('click', downloadLastRecording);
     recordingAutoDownloadToggle.addEventListener('change', () => {
-      recordingState.autoDownload = recordingAutoDownloadToggle.checked;
-      renderRecordingState();
-      log(`Recording auto download ${recordingState.autoDownload ? 'enabled' : 'disabled'}`, 'info');
+      setRecordingAutoDownload(recordingAutoDownloadToggle.checked);
     });
     metricsStartBtn.addEventListener('click', startBenchmarkSample);
     metricsStopBtn.addEventListener('click', () => stopBenchmarkSample('manual'));
@@ -2925,10 +2961,56 @@
       resetSample: resetBenchmarkMetrics,
       getSummary: () => cloneSummary(benchmarkState.summary),
     };
+    window.__bpaneControl = {
+      listSessions: () => cloneValue(controlSessionState.resources) ?? [],
+      getState: () => ({
+        connected: Boolean(session),
+        selectedSessionId: controlSessionState.selectedSessionId,
+        sessionId: controlSessionState.resource?.id ?? '',
+        clientRole: currentClientRole,
+        status: statusEl.textContent?.trim() ?? '',
+      }),
+      refreshSessions: async ({ preserveSelection = true, silent = false } = {}) => {
+        const accessToken = await getValidAccessToken();
+        if (!accessToken) {
+          throw new Error('no access token available');
+        }
+        const sessions = await refreshSessionResources(accessToken, { preserveSelection, silent });
+        return cloneValue(sessions) ?? [];
+      },
+      selectSession: async (sessionId) => {
+        if (!sessionId) {
+          throw new Error('session id is required');
+        }
+        const accessToken = await getValidAccessToken();
+        if (!accessToken) {
+          throw new Error('no access token available');
+        }
+        if (!controlSessionState.resources.some((resource) => resource.id === sessionId)) {
+          await refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
+        }
+        const resource = setSelectedSessionId(sessionId);
+        if (!resource) {
+          throw new Error(`session ${sessionId} is not visible`);
+        }
+        renderAuthState();
+        return cloneValue(resource);
+      },
+      startNewSession: async (options = {}) => {
+        await connect('new', options);
+        return cloneValue(controlSessionState.resource);
+      },
+      connectSelected: async (options = {}) => {
+        await connect('selected', options);
+        return cloneValue(controlSessionState.resource);
+      },
+      disconnect: doDisconnect,
+    };
     window.__bpaneRecording = {
       start: startSessionRecording,
       stop: () => stopSessionRecording({ reason: 'api' }),
       downloadLast: downloadLastRecording,
+      setAutoDownload: setRecordingAutoDownload,
       getState: () => ({
         active: recordingState.active,
         startedAtMs: recordingState.startedAtMs,
@@ -2946,8 +3028,10 @@
     setToggleButtonState(micBtn, false, 'Mic On', 'Mic Off');
     log(`Gateway target: ${GATEWAY_URL}`);
     log(`Session control API: ${SESSION_API_URL}`, 'info');
+    log(`Default client role: ${DEFAULT_CLIENT_ROLE}`, 'info');
     log('Benchmark metrics API: window.__bpaneBenchmarkMetrics.{startSample,stopSample,resetSample,getSummary}', 'info');
-    log('Recording API: window.__bpaneRecording.{start,stop,downloadLast,getState}', 'info');
+    log('Control API: window.__bpaneControl.{listSessions,getState,refreshSessions,selectSession,startNewSession,connectSelected,disconnect}', 'info');
+    log('Recording API: window.__bpaneRecording.{start,stop,downloadLast,setAutoDownload,getState}', 'info');
     if (authState.config?.mode === 'oidc') {
       log(`OIDC login configured for issuer ${authState.config.issuer}`, 'info');
       log(`Example user: ${getExampleUserLabel() || 'none configured'}`, 'info');

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -2511,9 +2511,7 @@
       renderRecordingState();
 
       try {
-        await session.startRecording({
-          frameRate: 30,
-        });
+        await session.startRecording();
         recordingState.active = true;
         renderRecordingState();
         log(`Recording started for session ${sessionId || 'current session'}`, 'ok');

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -2513,8 +2513,6 @@
       try {
         await session.startRecording({
           frameRate: 30,
-          videoBitsPerSecond: 8_000_000,
-          audioBitsPerSecond: 128_000,
         });
         recordingState.active = true;
         renderRecordingState();

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -40,6 +40,11 @@
       overflow: hidden;
     }
 
+    body.browser-only {
+      padding: 0;
+      background: #02060d;
+    }
+
     button,
     select,
     input {
@@ -93,11 +98,21 @@
       height: calc(100vh - 36px);
     }
 
+    body.browser-only .app-shell {
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0;
+      height: 100vh;
+    }
+
     .workspace {
       min-width: 0;
       display: flex;
       flex-direction: column;
       gap: 14px;
+    }
+
+    body.browser-only .workspace {
+      gap: 0;
     }
 
     .workspace-header,
@@ -235,6 +250,15 @@
       box-shadow: var(--shadow);
     }
 
+    body.browser-only .browser-panel {
+      gap: 0;
+      padding: 0;
+      border: none;
+      border-radius: 0;
+      background: #000;
+      box-shadow: none;
+    }
+
     #desktop-container {
       flex: 1;
       min-height: 420px;
@@ -245,6 +269,12 @@
         #000;
       border: 1px solid rgba(196, 213, 244, 0.08);
       position: relative;
+    }
+
+    body.browser-only #desktop-container {
+      min-height: 100vh;
+      border: none;
+      border-radius: 0;
     }
 
     #desktop-container canvas {
@@ -300,6 +330,12 @@
     .info-bar > span {
       flex: 0 0 auto;
       white-space: nowrap;
+    }
+
+    body.browser-only .workspace-header,
+    body.browser-only .sidebar,
+    body.browser-only .info-bar {
+      display: none;
     }
 
     .sidebar {
@@ -884,9 +920,15 @@
     const GATEWAY_PORT = 4433;
     const GATEWAY_URL = `https://${GATEWAY_HOST}:${GATEWAY_PORT}`;
     const SESSION_API_URL = '/api/v1/sessions';
+    const LAYOUT_MODE = pageParams.get('layout')?.toLowerCase() === 'browser-only'
+      ? 'browser-only'
+      : 'console';
     const DEFAULT_CLIENT_ROLE = pageParams.get('client_role')?.toLowerCase() === 'recorder'
       ? 'recorder'
       : 'interactive';
+    if (LAYOUT_MODE === 'browser-only') {
+      document.body.classList.add('browser-only');
+    }
 
     // ── DOM refs ────────────────────────────────────────────────────
     const container = document.getElementById('desktop-container');

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -273,6 +273,85 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recording-playback:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    get:
+      tags: [Session Recordings]
+      summary: Summarize session-level playback built from retained recording segments
+      operationId: getSessionRecordingPlayback
+      responses:
+        '200':
+          description: Session playback resource
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingPlaybackResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recording-playback/manifest:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    get:
+      tags: [Session Recordings]
+      summary: Materialize a session playback manifest over included recording segments
+      operationId: getSessionRecordingPlaybackManifest
+      responses:
+        '200':
+          description: Session playback manifest
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingPlaybackManifest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recording-playback/export:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    get:
+      tags: [Session Recordings]
+      summary: Download a packaged playback bundle containing manifest, player, and included segments
+      operationId: getSessionRecordingPlaybackExport
+      responses:
+        '200':
+          description: Zipped session playback bundle
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/recording/operations:
+    get:
+      tags: [Session Recordings]
+      summary: Read gateway-local recording operation counters and timestamps
+      operationId: getRecordingOperations
+      responses:
+        '200':
+          description: Recording operation snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecordingObservabilitySnapshot'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/access-tokens:
     parameters:
       - $ref: '#/components/parameters/SessionId'
@@ -804,6 +883,207 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SessionRecordingResource'
+    SessionRecordingPlaybackState:
+      type: string
+      enum:
+        - empty
+        - ready
+        - partial
+    SessionRecordingPlaybackResource:
+      type: object
+      required:
+        - session_id
+        - state
+        - segment_count
+        - included_segment_count
+        - failed_segment_count
+        - active_segment_count
+        - missing_artifact_segment_count
+        - included_bytes
+        - included_duration_ms
+        - manifest_path
+        - export_path
+        - generated_at
+      properties:
+        session_id:
+          type: string
+          format: uuid
+        state:
+          $ref: '#/components/schemas/SessionRecordingPlaybackState'
+        segment_count:
+          type: integer
+          minimum: 0
+        included_segment_count:
+          type: integer
+          minimum: 0
+        failed_segment_count:
+          type: integer
+          minimum: 0
+        active_segment_count:
+          type: integer
+          minimum: 0
+        missing_artifact_segment_count:
+          type: integer
+          minimum: 0
+        included_bytes:
+          type: integer
+          minimum: 0
+        included_duration_ms:
+          type: integer
+          minimum: 0
+        manifest_path:
+          type: string
+        export_path:
+          type: string
+        generated_at:
+          type: string
+          format: date-time
+    SessionRecordingPlaybackSegment:
+      type: object
+      required:
+        - sequence
+        - recording_id
+        - previous_recording_id
+        - file_name
+        - content_path
+        - mime_type
+        - bytes
+        - duration_ms
+        - termination_reason
+        - started_at
+        - completed_at
+      properties:
+        sequence:
+          type: integer
+          minimum: 1
+        recording_id:
+          type: string
+          format: uuid
+        previous_recording_id:
+          type: string
+          format: uuid
+          nullable: true
+        file_name:
+          type: string
+        content_path:
+          type: string
+        mime_type:
+          type: string
+        bytes:
+          type: integer
+          nullable: true
+          minimum: 0
+        duration_ms:
+          type: integer
+          nullable: true
+          minimum: 0
+        termination_reason:
+          allOf:
+            - $ref: '#/components/schemas/SessionRecordingTerminationReason'
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+    SessionRecordingPlaybackOmittedSegment:
+      type: object
+      required:
+        - recording_id
+        - previous_recording_id
+        - state
+        - artifact_available
+        - omitted_reason
+        - termination_reason
+        - error
+        - started_at
+        - completed_at
+      properties:
+        recording_id:
+          type: string
+          format: uuid
+        previous_recording_id:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          $ref: '#/components/schemas/SessionRecordingResourceState'
+        artifact_available:
+          type: boolean
+        omitted_reason:
+          type: string
+        termination_reason:
+          allOf:
+            - $ref: '#/components/schemas/SessionRecordingTerminationReason'
+          nullable: true
+        error:
+          type: string
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+    SessionRecordingPlaybackManifest:
+      type: object
+      required:
+        - format_version
+        - session_id
+        - state
+        - segment_count
+        - included_segment_count
+        - failed_segment_count
+        - active_segment_count
+        - missing_artifact_segment_count
+        - included_bytes
+        - included_duration_ms
+        - generated_at
+        - segments
+        - omitted_segments
+      properties:
+        format_version:
+          type: string
+        session_id:
+          type: string
+          format: uuid
+        state:
+          $ref: '#/components/schemas/SessionRecordingPlaybackState'
+        segment_count:
+          type: integer
+          minimum: 0
+        included_segment_count:
+          type: integer
+          minimum: 0
+        failed_segment_count:
+          type: integer
+          minimum: 0
+        active_segment_count:
+          type: integer
+          minimum: 0
+        missing_artifact_segment_count:
+          type: integer
+          minimum: 0
+        included_bytes:
+          type: integer
+          minimum: 0
+        included_duration_ms:
+          type: integer
+          minimum: 0
+        generated_at:
+          type: string
+          format: date-time
+        segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionRecordingPlaybackSegment'
+        omitted_segments:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionRecordingPlaybackOmittedSegment'
     CompleteSessionRecordingRequest:
       type: object
       required: [source_path]
@@ -858,6 +1138,7 @@ components:
         - mcp_owner
         - resolution
         - recording
+        - playback
         - telemetry
       properties:
         browser_clients:
@@ -888,6 +1169,8 @@ components:
             minimum: 0
         recording:
           $ref: '#/components/schemas/SessionRecordingStatus'
+        playback:
+          $ref: '#/components/schemas/SessionRecordingPlaybackResource'
         telemetry:
           $ref: '#/components/schemas/SessionTelemetry'
     SessionRecordingStatusState:
@@ -1001,6 +1284,72 @@ components:
         egress_lagged_frames_total:
           type: integer
           minimum: 0
+    RecordingObservabilitySnapshot:
+      type: object
+      required:
+        - artifact_finalize_requests_total
+        - artifact_finalize_successes_total
+        - artifact_finalize_failures_total
+        - recording_failures_total
+        - playback_manifest_requests_total
+        - playback_export_requests_total
+        - playback_export_successes_total
+        - playback_export_failures_total
+        - playback_export_bytes_total
+        - retention_passes_total
+        - retention_candidates_total
+        - retention_deleted_artifacts_total
+        - retention_failures_total
+        - last_playback_export_at
+        - last_retention_pass_at
+      properties:
+        artifact_finalize_requests_total:
+          type: integer
+          minimum: 0
+        artifact_finalize_successes_total:
+          type: integer
+          minimum: 0
+        artifact_finalize_failures_total:
+          type: integer
+          minimum: 0
+        recording_failures_total:
+          type: integer
+          minimum: 0
+        playback_manifest_requests_total:
+          type: integer
+          minimum: 0
+        playback_export_requests_total:
+          type: integer
+          minimum: 0
+        playback_export_successes_total:
+          type: integer
+          minimum: 0
+        playback_export_failures_total:
+          type: integer
+          minimum: 0
+        playback_export_bytes_total:
+          type: integer
+          minimum: 0
+        retention_passes_total:
+          type: integer
+          minimum: 0
+        retention_candidates_total:
+          type: integer
+          minimum: 0
+        retention_deleted_artifacts_total:
+          type: integer
+          minimum: 0
+        retention_failures_total:
+          type: integer
+          minimum: 0
+        last_playback_export_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_retention_pass_at:
+          type: string
+          format: date-time
+          nullable: true
     SetAutomationDelegateRequest:
       type: object
       required: [client_id]

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -517,6 +517,7 @@ components:
       required:
         - browser_clients
         - viewer_clients
+        - recorder_clients
         - max_viewers
         - viewer_slots_remaining
         - exclusive_browser_owner
@@ -528,6 +529,9 @@ components:
           type: integer
           minimum: 0
         viewer_clients:
+          type: integer
+          minimum: 0
+        recorder_clients:
           type: integer
           minimum: 0
         max_viewers:

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -15,6 +15,7 @@ servers:
 tags:
   - name: Sessions
   - name: Session Runtime
+  - name: Session Recordings
   - name: Session Automation
 security:
   - bearerAuth: []
@@ -78,6 +79,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '410':
+          $ref: '#/components/responses/Gone'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
     delete:
@@ -97,6 +100,177 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    get:
+      tags: [Session Recordings]
+      summary: List recordings associated with a visible session
+      operationId: listSessionRecordings
+      responses:
+        '200':
+          description: Session recording metadata list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    post:
+      tags: [Session Recordings]
+      summary: Create a new recording resource for a runtime-compatible session
+      operationId: createSessionRecording
+      responses:
+        '201':
+          description: Recording metadata created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings/{recording_id}:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - $ref: '#/components/parameters/RecordingId'
+    get:
+      tags: [Session Recordings]
+      summary: Fetch one recording resource for a visible session
+      operationId: getSessionRecording
+      responses:
+        '200':
+          description: Recording metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings/{recording_id}/stop:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - $ref: '#/components/parameters/RecordingId'
+    post:
+      tags: [Session Recordings]
+      summary: Transition an active recording toward finalization
+      operationId: stopSessionRecording
+      responses:
+        '200':
+          description: Recording metadata after stop request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings/{recording_id}/complete:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - $ref: '#/components/parameters/RecordingId'
+    post:
+      tags: [Session Recordings]
+      summary: Finalize recording metadata with artifact details
+      operationId: completeSessionRecording
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteSessionRecordingRequest'
+      responses:
+        '200':
+          description: Recording metadata after artifact finalization
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings/{recording_id}/fail:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - $ref: '#/components/parameters/RecordingId'
+    post:
+      tags: [Session Recordings]
+      summary: Mark a recording resource as failed
+      operationId: failSessionRecording
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FailSessionRecordingRequest'
+      responses:
+        '200':
+          description: Recording metadata after failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionRecordingResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/recordings/{recording_id}/content:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - $ref: '#/components/parameters/RecordingId'
+    get:
+      tags: [Session Recordings]
+      summary: Download recording artifact content when available
+      operationId: getSessionRecordingContent
+      responses:
+        '200':
+          description: Recording artifact bytes
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            video/webm:
+              schema:
+                type: string
+                format: binary
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/access-tokens:
@@ -247,6 +421,13 @@ components:
       schema:
         type: string
         format: uuid
+    RecordingId:
+      name: recording_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
   responses:
     BadRequest:
       description: Request validation failed
@@ -268,6 +449,12 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
     Conflict:
       description: Runtime or lifecycle conflict
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Gone:
+      description: Artifact was previously available but has expired or been removed
       content:
         application/json:
           schema:
@@ -355,6 +542,30 @@ components:
           type: boolean
         resize:
           type: boolean
+    SessionRecordingMode:
+      type: string
+      enum:
+        - disabled
+        - manual
+        - always
+    SessionRecordingFormat:
+      type: string
+      enum: [webm]
+    SessionRecordingPolicy:
+      type: object
+      required:
+        - mode
+        - format
+        - retention_sec
+      properties:
+        mode:
+          $ref: '#/components/schemas/SessionRecordingMode'
+        format:
+          $ref: '#/components/schemas/SessionRecordingFormat'
+        retention_sec:
+          type: integer
+          nullable: true
+          minimum: 1
     SessionConnectInfo:
       type: object
       required:
@@ -412,6 +623,7 @@ components:
         - idle_timeout_sec
         - labels
         - integration_context
+        - recording
         - connect
         - runtime
         - created_at
@@ -450,6 +662,8 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        recording:
+          $ref: '#/components/schemas/SessionRecordingPolicy'
         connect:
           $ref: '#/components/schemas/SessionConnectInfo'
         runtime:
@@ -487,6 +701,8 @@ components:
           type: object
           nullable: true
           additionalProperties: true
+        recording:
+          $ref: '#/components/schemas/SessionRecordingPolicy'
     SessionListResponse:
       type: object
       required: [sessions]
@@ -495,6 +711,124 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SessionResource'
+    SessionRecordingResourceState:
+      type: string
+      enum:
+        - starting
+        - recording
+        - finalizing
+        - ready
+        - failed
+    SessionRecordingTerminationReason:
+      type: string
+      enum:
+        - manual_stop
+        - session_stop
+        - idle_stop
+        - gateway_restart
+        - worker_exit
+    SessionRecordingResource:
+      type: object
+      required:
+        - id
+        - session_id
+        - previous_recording_id
+        - state
+        - format
+        - mime_type
+        - bytes
+        - duration_ms
+        - error
+        - termination_reason
+        - artifact_available
+        - content_path
+        - started_at
+        - completed_at
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        session_id:
+          type: string
+          format: uuid
+        previous_recording_id:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          $ref: '#/components/schemas/SessionRecordingResourceState'
+        format:
+          $ref: '#/components/schemas/SessionRecordingFormat'
+        mime_type:
+          type: string
+          nullable: true
+        bytes:
+          type: integer
+          nullable: true
+          minimum: 0
+        duration_ms:
+          type: integer
+          nullable: true
+          minimum: 0
+        error:
+          type: string
+          nullable: true
+        termination_reason:
+          allOf:
+            - $ref: '#/components/schemas/SessionRecordingTerminationReason'
+          nullable: true
+        artifact_available:
+          type: boolean
+        content_path:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SessionRecordingListResponse:
+      type: object
+      required: [recordings]
+      properties:
+        recordings:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionRecordingResource'
+    CompleteSessionRecordingRequest:
+      type: object
+      required: [source_path]
+      properties:
+        source_path:
+          type: string
+        mime_type:
+          type: string
+          nullable: true
+        bytes:
+          type: integer
+          nullable: true
+          minimum: 0
+        duration_ms:
+          type: integer
+          nullable: true
+          minimum: 0
+    FailSessionRecordingRequest:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+        termination_reason:
+          $ref: '#/components/schemas/SessionRecordingTerminationReason'
     SessionAccessTokenResponse:
       type: object
       required: [session_id, token_type, token, expires_at, connect]
@@ -523,6 +857,7 @@ components:
         - exclusive_browser_owner
         - mcp_owner
         - resolution
+        - recording
         - telemetry
       properties:
         browser_clients:
@@ -551,8 +886,59 @@ components:
           items:
             type: integer
             minimum: 0
+        recording:
+          $ref: '#/components/schemas/SessionRecordingStatus'
         telemetry:
           $ref: '#/components/schemas/SessionTelemetry'
+    SessionRecordingStatusState:
+      type: string
+      enum:
+        - disabled
+        - idle
+        - recording
+        - finalizing
+        - ready
+        - failed
+    SessionRecordingStatus:
+      type: object
+      required:
+        - configured_mode
+        - format
+        - retention_sec
+        - state
+        - active_recording_id
+        - recorder_attached
+        - started_at
+        - bytes_written
+        - duration_ms
+      properties:
+        configured_mode:
+          $ref: '#/components/schemas/SessionRecordingMode'
+        format:
+          $ref: '#/components/schemas/SessionRecordingFormat'
+        retention_sec:
+          type: integer
+          nullable: true
+          minimum: 1
+        state:
+          $ref: '#/components/schemas/SessionRecordingStatusState'
+        active_recording_id:
+          type: string
+          nullable: true
+        recorder_attached:
+          type: boolean
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        bytes_written:
+          type: integer
+          nullable: true
+          minimum: 0
+        duration_ms:
+          type: integer
+          nullable: true
+          minimum: 0
     SessionTelemetry:
       type: object
       required:


### PR DESCRIPTION
## Summary

This PR implements the low-overhead BrowserPane session recording model from #5 by treating recording as a passive browser-side recorder client rather than adding a second host-side capture pipeline.

The result is a session-managed recording pipeline that keeps the authoritative composed output in the browser client path while making recording lifecycle, artifacts, playback/export, and retention visible through the control plane.

## What Changed

- added browser-side recording support in the web client, including a dedicated recording surface, audio teeing, and programmatic recording APIs
- introduced a first-class passive `recorder` client role in the gateway with ownership/capability restrictions and recorder-aware session status
- moved recording into the session control plane with session recording policy, persisted recording metadata, recording content routes, and session-scoped playback/export APIs
- added recorder-worker integration for control-plane managed recording segments, `recording.mode=always`, restart reconciliation, segment termination/linkage, and retention cleanup
- introduced a gateway-owned recording artifact storage boundary with `local_fs` as the first backend
- added recording observability for artifact finalization, playback export generation, and retention passes
- updated `test-embed.html` so retained recording segments and playback exports can be downloaded directly from the page
- expanded the recording smoke test to validate end-to-end segment downloads and playback export downloads from the test embed UI

## Testing

- `cargo test -p bpane-gateway`
- `cd code/integrations/recording-worker && npm run build`
- `cd code/web/bpane-client && npm run smoke:recording -- --headless`

## Follow-Up

Remaining storage/export follow-up work is tracked in #43.

Closes #5
