### PR TITLE
Clarify session lifecycle controls and default local runtime mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Current product shape:
   - `workflow_event_delivery.rs`: owner-scoped workflow event subscriptions, signed outbound webhook delivery, retry/backoff, and persisted delivery diagnostics.
   - `workflow_observability.rs`: gateway-local counters/timestamps for workflow event delivery, produced-file uploads, and workflow retention passes.
   - `workflow_retention.rs`: periodic cleanup of retained workflow logs and structured outputs after the configured workflow retention windows expire.
-  - `runtime_manager.rs`: current `SessionManager` backend implementation; supports `static_single`, `docker_single`, and `docker_pool`. The default stack still uses the single-runtime path; `docker_pool` adds explicit runtime caps for parallel session workers and can now be exercised from local compose for browser sessions. Docker-backed workers carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are persisted/reconciled through Postgres on gateway restart.
+  - `runtime_manager.rs`: current `SessionManager` backend implementation; supports `static_single`, `docker_single`, and `docker_pool`. Local compose defaults to `docker_pool` for browser-session testing. Docker-backed workers carry a session id into their Chromium profile path so stopped sessions can restart against the same persisted browser profile, and Docker runtime assignments are persisted/reconciled through Postgres on gateway restart.
   - `api.rs`: legacy compatibility endpoints plus the frozen owner-scoped `/api/v1/sessions` surface and session-scoped `access-tokens`, `automation-owner`, `status`, and `mcp-owner` routes.
 - `code/shared/bpane-protocol`
   - Shared wire protocol, frame envelope, channel IDs, and message types.
@@ -97,7 +97,7 @@ Current product shape:
   - Local auth in compose is OIDC via Keycloak on `:8091`.
   - Local session-control persistence in compose is Postgres on `:5433`.
   - Local workflow credential binding dev/testing uses HashiCorp Vault dev mode on `:8200`.
-  - Local compose can now be switched to `docker_pool` for browser-session workers via gateway env overrides; `mcp-bridge` resolves the delegated session's runtime endpoint dynamically in that mode.
+  - Local compose defaults to `docker_pool` for browser-session workers; `mcp-bridge` resolves the delegated session's runtime endpoint dynamically in that mode.
   - The gateway is configured to auto-launch workflow workers against the `deploy-workflow-worker` image on the compose network. Build that image before workflow-run smoke tests or local workflow execution.
   - The gateway mounts the repo at `/workspace:ro` so local git-backed workflow sources can be resolved and materialized during development smokes.
 
@@ -168,8 +168,8 @@ Run these where applicable:
 ## Local development flow
 
 1. `./deploy/gen-dev-cert.sh dev/certs`
-2. For the multi-session control-plane path, prefer:
-   `BPANE_GATEWAY_RUNTIME_BACKEND=docker_pool BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES=2 docker compose -f deploy/compose.yml up --build`
+2. Start the local stack:
+   `BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES=2 docker compose -f deploy/compose.yml up --build`
 3. Open `http://localhost:8080` in Chromium.
 4. Log in through the local Keycloak realm with `demo / demo-demo`.
 5. The test page will resolve or create an owner-scoped `/api/v1/sessions` resource before transport connect.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,11 +36,11 @@ Current product shape:
 - Browser runtime: Chromium desktop only. Firefox and Safari are not production targets.
 - Shared sessions: supported for small curated groups, not broadcast-scale delivery.
 - Exclusive browser-owner mode: optional in `bpane-gateway` via `--exclusive-browser-owner`; default is disabled.
-- Viewer cap: configurable in `bpane-gateway` via `--max-viewers`, default `10` when exclusive-owner mode or MCP ownership is active.
+- Viewer cap: configurable in `bpane-gateway` via `--max-viewers`, default `10` for restricted browser viewers.
 - MCP automation: supported via `mcp-bridge` and gateway ownership APIs.
 - Browser extensions: owner-approved unpacked extensions are supported for docker-backed sessions and workflow runs; `static_single` does not support session extension sets.
 - Camera ingress: disabled by default in compose; requires browser H.264 encode support and a mapped `v4l2loopback` device on the host.
-- In exclusive-owner or MCP-owned sessions, restricted browser viewers are view-only: no input, clipboard, microphone, camera, upload, download, or resize.
+- In exclusive-owner sessions, restricted browser viewers are view-only: no input, clipboard, microphone, camera, upload, download, or resize.
 
 ## Architecture map
 
@@ -84,7 +84,7 @@ Current product shape:
 - `code/web/bpane-client`
   - TypeScript package. There is no meaningful Rust browser client crate in the current repo.
 - `code/integrations/mcp-bridge`
-  - SSE bridge to `@playwright/mcp`; owns session registration and MCP supervision behavior.
+  - Streamable HTTP and legacy SSE bridge to `@playwright/mcp`; owns session registration and MCP supervision behavior.
   - Can resolve an explicit control-plane session via `/api/v1/sessions`, accepts delegated-session assignment through its local `/control-session` API, resolves the managed session's runtime CDP endpoint from the session resource, and uses session-scoped `status` / `mcp-owner` APIs when a managed session is configured, including in `docker_pool` mode.
 - `code/integrations/recording-worker`
   - Playwright-driven recorder worker that attaches as a `recorder` browser client through the control plane.
@@ -115,7 +115,7 @@ Current product shape:
 
 - Browser sessions are collaborative by default.
 - If `--exclusive-browser-owner` is enabled, one owner drives the session and additional browser clients join as viewers.
-- MCP ownership still locks browser clients into viewer behavior.
+- MCP automation does not by itself lock browser clients into viewer behavior. If MCP is the initial connector it seeds the display size; if a browser client is already connected, that browser-defined display size remains authoritative.
 - Late joiners are bootstrapped from cached session state and late-join refreshes are tracked in gateway telemetry.
 - If a worker is still alive, reconnect returns to the exact live runtime. After idle-stop, reconnect restarts from the persisted Chromium profile instead of a true suspended process image.
 - Gateway session status reports:

--- a/ARCH.md
+++ b/ARCH.md
@@ -56,7 +56,7 @@ The system has seven primary runtime roles plus persistent control-plane stores:
 | Wire protocol | Custom binary, no serde | Manual `[u8]` encode/decode for minimal overhead and zero alloc on hot path |
 | Tile compression | QOI or Zstd (configurable) | QOI: fast decode, good for UI; Zstd: better ratio for complex content |
 | Audio | PipeWire -> FFmpeg -> Opus or IMA-ADPCM | 48 kHz stereo, silence-gated; Opus default (64 kbps CBR), ADPCM fallback |
-| MCP bridge | Node.js + @playwright/mcp | SSE proxy for browser automation with live supervision |
+| MCP bridge | Node.js + @playwright/mcp | Streamable HTTP + SSE bridge for browser automation with live supervision |
 | Session store | PostgreSQL 16 | Durable owner-scoped `/api/v1/sessions`, workflows, recordings, and reusable runtime inputs |
 | Secret store | HashiCorp Vault KV v2 | Externalized workflow credential payloads |
 | Deployment | Docker Compose, 7 long-lived services + on-demand workers | Isolated services on a bridge network |
@@ -91,8 +91,8 @@ long-lived compose service.
    v              v              v              v              v              v              v
 ┌──────────┐ ┌──────────────┐ ┌───────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────┐
 │bpane-host│ │bpane-gateway │ │  mcp-bridge   │ │   Keycloak   │ │   Postgres   │ │  Vault   │
-│ .0.10    │ │ :4433 (QUIC) │ │ :8931 (SSE)   │ │ :8080/.8091  │ │ :5432/.5433  │ │ :8200    │
-│          │ │ :8932 (HTTP) │ │               │ │ local OIDC   │ │ control-plane│ │ KV v2    │
+│ .0.10    │ │ :4433 (QUIC) │ │ :8931 (/mcp,  │ │ :8080/.8091  │ │ :5432/.5433  │ │ :8200    │
+│          │ │ :8932 (HTTP) │ │  /sse)        │ │ local OIDC   │ │ control-plane│ │ KV v2    │
 │ Xorg :99 │ │              │ │ @playwright/  │ │ realm        │ │ state        │ │ secrets   │
 │ OpenBox  │ │ Unix socket  │ │ mcp (STDIO)   │ │              │ │              │ │          │
 │ Chromium │ │ <-> host IPC │ │               │ │              │ │              │ │          │
@@ -113,7 +113,7 @@ long-lived compose service.
 - `4433/tcp+udp` — WebTransport (QUIC)
 - `8932/tcp` — gateway HTTP API
 - `8091/tcp` — local Keycloak realm for dev/testing
-- `8931/tcp` — MCP bridge (SSE)
+- `8931/tcp` — MCP bridge (`/mcp` for Streamable HTTP, `/sse` for legacy SSE)
 - `5433/tcp` — local Postgres for the session control plane
 - `8200/tcp` — local Vault dev server for credential bindings
 
@@ -241,20 +241,28 @@ Stateless relay between host agent and browser clients.
   - Docker runtime assignment metadata is now persisted in Postgres and reconciled on gateway startup, so an existing pool-mode worker can be rebound after a gateway restart without launching a duplicate runtime
   - Docker-backed workers now receive `BPANE_SESSION_ID` and reuse a session-specific Chromium profile rooted under the shared `/run/bpane` volume, so reconnecting a stopped session reuses cookies/cache/downloads and Chromium session-restore state
   - this is profile-backed restoration, not true container/process suspension: exact live in-memory browser state only survives while the worker is still running
-- **MCP ownership**: atomic flag that locks resolution for browser clients
-  when an MCP agent owns the session
-- **Auth** (`auth.rs`): OIDC/JWT validation for browser and API clients, plus legacy HMAC token compatibility for migration and tests
+- **MCP ownership**: atomic session-automation state in the gateway
+  - MCP automation does not by itself demote browser clients into viewers
+  - if MCP is the initial active connector it can seed and hold the session
+    resolution until ownership is cleared
+  - if a browser client is already active, that browser-defined input/ownership
+    state remains authoritative while MCP automation attaches alongside it
+- **Auth** (`auth/`): OIDC/JWT validation for browser and API clients, plus legacy HMAC token compatibility for migration and tests
 - **Heartbeat**: disconnects after 15s without CONTROL ping
 - **HTTP API** (`api.rs`, :8932):
   - canonical frozen v1 contract: `openapi/bpane-control-v1.yaml`
   - `POST /api/v1/sessions` — create a persistent session resource
   - `GET /api/v1/sessions` — list owner-scoped sessions
   - `GET /api/v1/sessions/{id}` — fetch one owner-scoped session resource
-  - `DELETE /api/v1/sessions/{id}` — stop one owner-scoped session resource
+  - `DELETE /api/v1/sessions/{id}` — safe-stop one owner-scoped session resource
   - `POST /api/v1/sessions/{id}/access-tokens` — mint a short-lived session-scoped connect ticket
+  - `POST /api/v1/sessions/{id}/stop` — explicit safe-stop with blocker reporting
+  - `POST /api/v1/sessions/{id}/kill` — force-kill live attachments and release runtime
+  - `POST /api/v1/sessions/{id}/connections/{connection_id}/disconnect` — disconnect one live attachment
+  - `POST /api/v1/sessions/{id}/connections/disconnect-all` — disconnect all live attachments without force-killing the session
   - `POST /api/v1/sessions/{id}/automation-owner` — delegate one session to an automation principal
   - `DELETE /api/v1/sessions/{id}/automation-owner` — clear automation delegation
-  - `GET /api/v1/sessions/{id}/status` — session-scoped runtime telemetry for compatibility mode
+  - `GET /api/v1/sessions/{id}/status` — side-effect-free session-scoped lifecycle/runtime/presence view, including role counts, idle timing, stop eligibility, live connection descriptors, and stopped-session snapshots
   - `POST /api/v1/sessions/{id}/mcp-owner` — session-scoped MCP ownership claim
   - `DELETE /api/v1/sessions/{id}/mcp-owner` — session-scoped MCP ownership release
   - session-scoped recording routes expose segment lifecycle, playback/export, and artifact download
@@ -364,15 +372,17 @@ decompression.
 Optional. Bridges external MCP clients (e.g., Claude Code) to Playwright MCP
 running against the Chromium instance inside the host container.
 
-- SSE server for MCP client connections (per-connection `Server` instances)
+- Streamable HTTP server on `/mcp` and legacy SSE endpoint on `/sse`
 - Proxies tool calls to @playwright/mcp subprocess (STDIO mode)
 - Supervisor-aware: adds configurable delay (default 1500ms) when browser
   viewers are watching (polls gateway status every 2s)
-- Lazy registration: only claims MCP ownership on first SSE client connect
-- Registers/clears MCP ownership with gateway (resolution lock)
+- Lazy registration: only claims MCP ownership on first MCP client connect
+- Registers/clears MCP ownership with the gateway so delegated automation can attach without forcing browser clients into viewer mode
 - Uses OIDC client-credentials for gateway API access in the local compose stack
 - Exposes a local control-session API on `:8931` so the browser test page can point
   the bridge at an explicitly delegated session without restarting the service
+- Resolves the delegated session's runtime CDP endpoint from the gateway session
+  resource before binding Playwright MCP
 - Graceful shutdown: always releases ownership on SIGINT/SIGTERM
 
 ### workflow-worker (~1,100 lines TypeScript)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The shared protocol is a compact binary protocol implemented in `bpane-protocol`
 
 ### Recommended: Docker Compose
 
-If you want the full multi-session flow from the local session console, start the stack in `docker_pool` mode:
+The local session console now defaults to `docker_pool` mode so `Start New Session` provisions an isolated browser runtime instead of reusing one shared legacy worker:
 
 Generate a dev certificate once:
 
@@ -114,12 +114,9 @@ Generate a dev certificate once:
 Start the stack:
 
 ```bash
-BPANE_GATEWAY_RUNTIME_BACKEND=docker_pool \
 BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES=2 \
 docker compose -f deploy/compose.yml up --build
 ```
-
-If you rebuild `gateway` later without those env overrides, Compose will fall back to the default `static_single` backend.
 
 Then open `http://localhost:8080` in Chromium.
 
@@ -135,9 +132,10 @@ Then:
 3. Open the same selected session in another signed-in browser window if you want to share it live with another user
 4. Click `Delegate MCP` if you want the local `mcp-bridge` to drive that exact session
 
-If you only want the older single-runtime dev stack, the default command still works:
+If you explicitly want the older single-runtime compatibility stack, opt into it:
 
 ```bash
+BPANE_GATEWAY_RUNTIME_BACKEND=static_single \
 docker compose -f deploy/compose.yml up --build
 ```
 
@@ -159,7 +157,7 @@ The gateway supports three runtime backends:
 - `docker_single`: one start-on-demand runtime container with idle shutdown
 - `docker_pool`: multiple start-on-demand runtime containers with explicit `max_active_runtimes` and `max_starting_runtimes`
 
-`deploy/compose.yml` still defaults to `static_single`, but the local stack is wired so you can switch to the pool backend with:
+`deploy/compose.yml` now defaults to `docker_pool`, but you can still switch backends explicitly when you need a compatibility check:
 
 ```bash
 BPANE_GATEWAY_RUNTIME_BACKEND=docker_pool \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ browser client <-> bpane-gateway <-> bpane-host <-> Chromium inside Linux contai
 | `code/apps/bpane-gateway` | WebTransport entry point and shared-session coordinator. Relays frames between browser clients and the host, applies owner/viewer policy, and exposes the HTTP session/ownership API. |
 | `code/shared/bpane-protocol` | Shared binary wire contract. Defines channels, frame envelopes, typed protocol messages, and incremental frame decoding used by the Rust services and validated against the browser client. |
 | `code/web/bpane-client` | Real browser client. Renders tiles/video, decodes media, captures keyboard/mouse/clipboard input, and manages browser-side audio, camera, and file-transfer flows. |
-| `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes Streamable HTTP on `/mcp` and legacy SSE on `/sse`, and integrates with gateway ownership APIs so automation can drive a session while humans observe. |
+| `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes Streamable HTTP on `/mcp` and legacy SSE on `/sse`, and integrates with gateway ownership APIs so automation can attach alongside interactive browser users through delegated session control. |
 | `code/integrations/workflow-worker` | On-demand workflow executor. Downloads pinned workflow source snapshots, attaches with session automation access, runs Playwright workflow entrypoints, resolves credential/workspace inputs, and writes logs, outputs, and produced files back to the gateway. |
 | `code/integrations/recording-worker` | On-demand recording executor. Attaches as a passive recorder client, captures WebM output, and finalizes recording metadata into gateway-managed artifact storage. |
 | `deploy/` | Local runtime manifests and container images. This is the practical source of truth for how the dev stack is assembled and started. |
@@ -219,10 +219,32 @@ The same frozen API surface also includes session-scoped runtime routes:
 
 - `POST /api/v1/sessions/{id}/access-tokens`
 - `GET /api/v1/sessions/{id}/status`
+- `POST /api/v1/sessions/{id}/stop`
+- `POST /api/v1/sessions/{id}/kill`
+- `POST /api/v1/sessions/{id}/connections/{connection_id}/disconnect`
+- `POST /api/v1/sessions/{id}/connections/disconnect-all`
 - `POST /api/v1/sessions/{id}/mcp-owner`
 - `DELETE /api/v1/sessions/{id}/mcp-owner`
 - `POST /api/v1/sessions/{id}/automation-owner`
 - `DELETE /api/v1/sessions/{id}/automation-owner`
+
+Session resources and status responses now expose a richer lifecycle model:
+
+- persisted `state`
+- derived `runtime_state`
+- derived `presence_state`
+- `connection_counts` by role
+- live `connections` descriptors on the status route
+- `stop_eligibility` with blocker details
+- idle timing metadata
+- side-effect-free status snapshots, including for stopped sessions
+
+Lifecycle control semantics are now explicit:
+
+- `DELETE /api/v1/sessions/{id}` follows safe-stop semantics
+- `POST /api/v1/sessions/{id}/stop` stops only when no blockers remain
+- `POST /api/v1/sessions/{id}/kill` force-terminates live attachments and releases the runtime
+- connection-level disconnect routes remove live attachments without stopping the session runtime
 
 The local dev flow uses those routes to bridge browser-owned and automation-owned control:
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ browser client <-> bpane-gateway <-> bpane-host <-> Chromium inside Linux contai
 | `code/apps/bpane-gateway` | WebTransport entry point and shared-session coordinator. Relays frames between browser clients and the host, applies owner/viewer policy, and exposes the HTTP session/ownership API. |
 | `code/shared/bpane-protocol` | Shared binary wire contract. Defines channels, frame envelopes, typed protocol messages, and incremental frame decoding used by the Rust services and validated against the browser client. |
 | `code/web/bpane-client` | Real browser client. Renders tiles/video, decodes media, captures keyboard/mouse/clipboard input, and manages browser-side audio, camera, and file-transfer flows. |
-| `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Integrates with gateway ownership APIs so automation can drive a session while humans observe. |
+| `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes Streamable HTTP on `/mcp` and legacy SSE on `/sse`, and integrates with gateway ownership APIs so automation can drive a session while humans observe. |
 | `code/integrations/workflow-worker` | On-demand workflow executor. Downloads pinned workflow source snapshots, attaches with session automation access, runs Playwright workflow entrypoints, resolves credential/workspace inputs, and writes logs, outputs, and produced files back to the gateway. |
 | `code/integrations/recording-worker` | On-demand recording executor. Attaches as a passive recorder client, captures WebM output, and finalizes recording metadata into gateway-managed artifact storage. |
 | `deploy/` | Local runtime manifests and container images. This is the practical source of truth for how the dev stack is assembled and started. |
@@ -149,7 +149,7 @@ The compose stack starts:
 - `vault`: local HashiCorp Vault dev server on `:8200` for workflow credential bindings
 - `keycloak`: local OIDC provider on `:8091`
 - `web`: local frontend on `:8080`
-- `mcp-bridge`: MCP bridge on `:8931`
+- `mcp-bridge`: MCP bridge on `:8931` (`/mcp` for Streamable HTTP, `/sse` for legacy SSE)
 
 The local compose file also defines a `workflow-worker` image profile. The gateway launches workflow-worker containers on demand; you normally do not start that container as a long-lived service yourself.
 
@@ -412,7 +412,7 @@ cd code/web/bpane-client && npm run smoke:multisession -- --headless
 
 - Sessions are collaborative by default.
 - If the gateway runs with exclusive browser ownership, one browser client is interactive and later clients become viewers.
-- MCP ownership also forces browser clients into viewer behavior.
+- MCP automation does not force browser clients into viewer behavior. If MCP is the first connector it seeds the display size; otherwise the browser-defined display size remains authoritative.
 - Viewers are read-only and do not get interactive capabilities like input, clipboard, upload, download, microphone, camera, or resize.
 
 ## Authentication Model

--- a/code/apps/bpane-gateway/src/api/authz/mod.rs
+++ b/code/apps/bpane-gateway/src/api/authz/mod.rs
@@ -13,5 +13,6 @@ pub(super) use resources::{
 pub(super) use sessions::{
     authorize_runtime_access_principal_with_automation_access, authorize_runtime_session_request,
     authorize_runtime_session_request_with_automation_access, authorize_visible_session_request,
-    load_session_owner_principal, prepare_runtime_access_session,
+    authorize_visible_session_request_with_automation_access, load_session_owner_principal,
+    prepare_runtime_access_session,
 };

--- a/code/apps/bpane-gateway/src/api/resources.rs
+++ b/code/apps/bpane-gateway/src/api/resources.rs
@@ -85,6 +85,7 @@ pub(super) fn session_status_from_snapshot(
     SessionStatus {
         state,
         summary,
+        connections: session_connections_from_snapshot(&snapshot),
         browser_clients: snapshot.browser_clients,
         viewer_clients: snapshot.viewer_clients,
         recorder_clients: snapshot.recorder_clients,
@@ -93,7 +94,7 @@ pub(super) fn session_status_from_snapshot(
         exclusive_browser_owner: snapshot.exclusive_browser_owner,
         mcp_owner: snapshot.mcp_owner,
         resolution: snapshot.resolution,
-        recording: recording_status_from_snapshot(snapshot, recording_policy, latest_recording),
+        recording: recording_status_from_snapshot(&snapshot, recording_policy, latest_recording),
         playback,
         telemetry: SessionTelemetry {
             joins_accepted: snapshot.joins_accepted,
@@ -114,6 +115,19 @@ pub(super) fn session_status_from_snapshot(
             egress_lagged_frames_total: snapshot.egress_lagged_frames_total,
         },
     }
+}
+
+fn session_connections_from_snapshot(
+    snapshot: &SessionTelemetrySnapshot,
+) -> Vec<SessionConnectionInfo> {
+    snapshot
+        .connections
+        .iter()
+        .map(|connection| SessionConnectionInfo {
+            connection_id: connection.connection_id,
+            role: connection.role.into(),
+        })
+        .collect()
 }
 
 fn derive_session_runtime_state(
@@ -259,7 +273,7 @@ fn derive_session_idle_status(
 }
 
 pub(super) fn recording_status_from_snapshot(
-    snapshot: SessionTelemetrySnapshot,
+    snapshot: &SessionTelemetrySnapshot,
     recording_policy: &SessionRecordingPolicy,
     latest_recording: Option<&StoredSessionRecording>,
 ) -> SessionRecordingStatus {
@@ -319,6 +333,33 @@ pub(super) async fn session_resource(
             .into(),
         status,
         state_override,
+    ))
+}
+
+pub(super) async fn load_session_status(
+    state: &ApiState,
+    session: &StoredSession,
+) -> Result<SessionStatus, SessionStoreError> {
+    let snapshot = state
+        .registry
+        .telemetry_snapshot_if_live(session.id)
+        .await
+        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
+    let summary = session_status_summary(state, session).await?;
+    let recordings = state
+        .session_store
+        .list_recordings_for_session(session.id)
+        .await?;
+    let latest_recording = latest_recording(&recordings);
+    let playback = prepare_session_recording_playback(session.id, &recordings, Utc::now());
+
+    Ok(session_status_from_snapshot(
+        session.state,
+        summary,
+        snapshot,
+        &session.recording,
+        latest_recording,
+        playback.resource,
     ))
 }
 

--- a/code/apps/bpane-gateway/src/api/resources.rs
+++ b/code/apps/bpane-gateway/src/api/resources.rs
@@ -1,12 +1,49 @@
 use super::*;
+use crate::session_control::{
+    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
+    SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
+};
+use crate::session_manager::SessionRuntimeAssignmentStatus;
+
+pub(super) async fn session_status_summary(
+    state: &ApiState,
+    stored: &StoredSession,
+) -> SessionStatusSummary {
+    let snapshot = state
+        .registry
+        .telemetry_snapshot_if_live(stored.id)
+        .await
+        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
+    let runtime_assignment = state
+        .session_manager
+        .describe_session_runtime_assignment_status(stored.id)
+        .await;
+    let runtime_state = derive_session_runtime_state(stored.state, runtime_assignment);
+    let connection_counts = session_connection_counts_from_snapshot(snapshot);
+    let presence_state = derive_session_presence_state(stored.state, &connection_counts);
+    let stop_eligibility = derive_session_stop_eligibility(&connection_counts);
+    let idle = derive_session_idle_status(stored, presence_state);
+
+    SessionStatusSummary {
+        runtime_state,
+        presence_state,
+        connection_counts,
+        stop_eligibility,
+        idle,
+    }
+}
 
 pub(super) fn session_status_from_snapshot(
+    state: SessionLifecycleState,
+    summary: SessionStatusSummary,
     snapshot: SessionTelemetrySnapshot,
     recording_policy: &SessionRecordingPolicy,
     latest_recording: Option<&StoredSessionRecording>,
     playback: SessionRecordingPlaybackResource,
 ) -> SessionStatus {
     SessionStatus {
+        state,
+        summary,
         browser_clients: snapshot.browser_clients,
         viewer_clients: snapshot.viewer_clients,
         recorder_clients: snapshot.recorder_clients,
@@ -35,6 +72,125 @@ pub(super) fn session_status_from_snapshot(
             egress_lagged_receives_total: snapshot.egress_lagged_receives_total,
             egress_lagged_frames_total: snapshot.egress_lagged_frames_total,
         },
+    }
+}
+
+fn derive_session_runtime_state(
+    lifecycle: SessionLifecycleState,
+    runtime_assignment: Option<SessionRuntimeAssignmentStatus>,
+) -> SessionRuntimeState {
+    match lifecycle {
+        SessionLifecycleState::Stopped
+        | SessionLifecycleState::Failed
+        | SessionLifecycleState::Expired => SessionRuntimeState::Stopped,
+        SessionLifecycleState::Stopping => SessionRuntimeState::Stopping,
+        SessionLifecycleState::Starting => SessionRuntimeState::Starting,
+        SessionLifecycleState::Pending => match runtime_assignment {
+            Some(SessionRuntimeAssignmentStatus::Starting) => SessionRuntimeState::Starting,
+            Some(SessionRuntimeAssignmentStatus::Ready) => SessionRuntimeState::Running,
+            None => SessionRuntimeState::NotStarted,
+        },
+        SessionLifecycleState::Ready
+        | SessionLifecycleState::Active
+        | SessionLifecycleState::Idle => match runtime_assignment {
+            Some(SessionRuntimeAssignmentStatus::Starting) => SessionRuntimeState::Starting,
+            Some(SessionRuntimeAssignmentStatus::Ready) => SessionRuntimeState::Running,
+            None => SessionRuntimeState::NotStarted,
+        },
+    }
+}
+
+fn session_connection_counts_from_snapshot(
+    snapshot: SessionTelemetrySnapshot,
+) -> SessionConnectionCounts {
+    let total_clients = snapshot.browser_clients;
+    let recorder_clients = snapshot.recorder_clients;
+    let viewer_clients = snapshot.viewer_clients;
+    let interactive_clients = total_clients.saturating_sub(recorder_clients);
+    let owner_clients = interactive_clients.saturating_sub(viewer_clients);
+    let automation_clients = if snapshot.mcp_owner { 1 } else { 0 };
+
+    SessionConnectionCounts {
+        interactive_clients,
+        owner_clients,
+        viewer_clients,
+        recorder_clients,
+        automation_clients,
+        total_clients,
+    }
+}
+
+fn derive_session_presence_state(
+    lifecycle: SessionLifecycleState,
+    counts: &SessionConnectionCounts,
+) -> SessionPresenceState {
+    if counts.interactive_clients > 0 {
+        return SessionPresenceState::Connected;
+    }
+    if counts.recorder_clients > 0 {
+        return SessionPresenceState::RecordingOnly;
+    }
+    if counts.automation_clients > 0 {
+        return SessionPresenceState::AutomationOwned;
+    }
+    if lifecycle == SessionLifecycleState::Idle {
+        return SessionPresenceState::Idle;
+    }
+    SessionPresenceState::Empty
+}
+
+fn derive_session_stop_eligibility(counts: &SessionConnectionCounts) -> SessionStopEligibility {
+    let mut blockers = Vec::new();
+    if counts.owner_clients > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::OwnerClients,
+            count: counts.owner_clients,
+        });
+    }
+    if counts.viewer_clients > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::ViewerClients,
+            count: counts.viewer_clients,
+        });
+    }
+    if counts.recorder_clients > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::RecorderClients,
+            count: counts.recorder_clients,
+        });
+    }
+    if counts.automation_clients > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::AutomationOwner,
+            count: counts.automation_clients,
+        });
+    }
+
+    SessionStopEligibility {
+        allowed: blockers.is_empty(),
+        blockers,
+    }
+}
+
+fn derive_session_idle_status(
+    stored: &StoredSession,
+    presence_state: SessionPresenceState,
+) -> SessionIdleStatus {
+    let idle_since = if presence_state == SessionPresenceState::Idle {
+        Some(stored.updated_at)
+    } else {
+        None
+    };
+    let idle_deadline = idle_since.and_then(|since| {
+        stored
+            .idle_timeout_sec
+            .map(|timeout| since + chrono::Duration::seconds(i64::from(timeout)))
+    });
+
+    SessionIdleStatus {
+        idle_timeout_sec: stored.idle_timeout_sec,
+        idle_since,
+        idle_deadline,
     }
 }
 
@@ -76,17 +232,19 @@ pub(super) fn recording_status_from_snapshot(
     }
 }
 
-pub(super) fn session_resource(
+pub(super) async fn session_resource(
     state: &ApiState,
     stored: &StoredSession,
     state_override: Option<SessionLifecycleState>,
 ) -> SessionResource {
+    let status = session_status_summary(state, stored).await;
     stored.to_resource(
         &state.public_gateway_url,
         state
             .session_manager
             .describe_session_runtime(stored.id)
             .into(),
+        status,
         state_override,
     )
 }

--- a/code/apps/bpane-gateway/src/api/resources.rs
+++ b/code/apps/bpane-gateway/src/api/resources.rs
@@ -1,14 +1,18 @@
 use super::*;
+use std::collections::HashSet;
+
+use crate::auth::AuthenticatedPrincipal;
 use crate::session_control::{
     SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
     SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
+    SessionStoreError, StoredSession,
 };
 use crate::session_manager::SessionRuntimeAssignmentStatus;
 
 pub(super) async fn session_status_summary(
     state: &ApiState,
     stored: &StoredSession,
-) -> SessionStatusSummary {
+) -> Result<SessionStatusSummary, SessionStoreError> {
     let snapshot = state
         .registry
         .telemetry_snapshot_if_live(stored.id)
@@ -21,16 +25,53 @@ pub(super) async fn session_status_summary(
     let runtime_state = derive_session_runtime_state(stored.state, runtime_assignment);
     let connection_counts = session_connection_counts_from_snapshot(snapshot);
     let presence_state = derive_session_presence_state(stored.state, &connection_counts);
-    let stop_eligibility = derive_session_stop_eligibility(&connection_counts);
+    let owner = session_owner_principal(stored);
+    let recordings = state
+        .session_store
+        .list_recordings_for_session(stored.id)
+        .await?;
+    let active_recording_count = recordings
+        .iter()
+        .filter(|recording| recording.state.is_active())
+        .count() as u32;
+    let active_workflow_runs = state
+        .session_store
+        .list_workflow_runs_for_owner(&owner)
+        .await?
+        .into_iter()
+        .filter(|run| run.session_id == stored.id && !run.state.is_terminal())
+        .collect::<Vec<_>>();
+    let workflow_run_task_ids = active_workflow_runs
+        .iter()
+        .map(|run| run.automation_task_id)
+        .collect::<HashSet<_>>();
+    let active_workflow_run_count = active_workflow_runs.len() as u32;
+    let active_automation_task_count = state
+        .session_store
+        .list_automation_tasks_for_owner(&owner)
+        .await?
+        .into_iter()
+        .filter(|task| {
+            task.session_id == stored.id
+                && !task.state.is_terminal()
+                && !workflow_run_task_ids.contains(&task.id)
+        })
+        .count() as u32;
+    let stop_eligibility = derive_session_stop_eligibility(
+        &connection_counts,
+        active_recording_count,
+        active_automation_task_count,
+        active_workflow_run_count,
+    );
     let idle = derive_session_idle_status(stored, presence_state);
 
-    SessionStatusSummary {
+    Ok(SessionStatusSummary {
         runtime_state,
         presence_state,
         connection_counts,
         stop_eligibility,
         idle,
-    }
+    })
 }
 
 pub(super) fn session_status_from_snapshot(
@@ -139,7 +180,12 @@ fn derive_session_presence_state(
     SessionPresenceState::Empty
 }
 
-fn derive_session_stop_eligibility(counts: &SessionConnectionCounts) -> SessionStopEligibility {
+fn derive_session_stop_eligibility(
+    counts: &SessionConnectionCounts,
+    active_recording_count: u32,
+    active_automation_task_count: u32,
+    active_workflow_run_count: u32,
+) -> SessionStopEligibility {
     let mut blockers = Vec::new();
     if counts.owner_clients > 0 {
         blockers.push(SessionStopBlocker {
@@ -163,6 +209,24 @@ fn derive_session_stop_eligibility(counts: &SessionConnectionCounts) -> SessionS
         blockers.push(SessionStopBlocker {
             kind: SessionStopBlockerKind::AutomationOwner,
             count: counts.automation_clients,
+        });
+    }
+    if active_recording_count > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::RecordingActivity,
+            count: active_recording_count,
+        });
+    }
+    if active_automation_task_count > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::AutomationTasks,
+            count: active_automation_task_count,
+        });
+    }
+    if active_workflow_run_count > 0 {
+        blockers.push(SessionStopBlocker {
+            kind: SessionStopBlockerKind::WorkflowRuns,
+            count: active_workflow_run_count,
         });
     }
 
@@ -232,13 +296,22 @@ pub(super) fn recording_status_from_snapshot(
     }
 }
 
+fn session_owner_principal(stored: &StoredSession) -> AuthenticatedPrincipal {
+    AuthenticatedPrincipal {
+        subject: stored.owner.subject.clone(),
+        issuer: stored.owner.issuer.clone(),
+        display_name: stored.owner.display_name.clone(),
+        client_id: None,
+    }
+}
+
 pub(super) async fn session_resource(
     state: &ApiState,
     stored: &StoredSession,
     state_override: Option<SessionLifecycleState>,
-) -> SessionResource {
-    let status = session_status_summary(state, stored).await;
-    stored.to_resource(
+) -> Result<SessionResource, SessionStoreError> {
+    let status = session_status_summary(state, stored).await?;
+    Ok(stored.to_resource(
         &state.public_gateway_url,
         state
             .session_manager
@@ -246,7 +319,7 @@ pub(super) async fn session_resource(
             .into(),
         status,
         state_override,
-    )
+    ))
 }
 
 pub(super) async fn load_session_recording(

--- a/code/apps/bpane-gateway/src/api/runtime_access.rs
+++ b/code/apps/bpane-gateway/src/api/runtime_access.rs
@@ -49,20 +49,6 @@ fn map_session_manager_error(error: SessionManagerError) -> (StatusCode, Json<Er
     )
 }
 
-pub(super) fn map_runtime_compat_status(status: StatusCode) -> (StatusCode, Json<ErrorResponse>) {
-    (
-        status,
-        Json(ErrorResponse {
-            error: if status == StatusCode::CONFLICT {
-                "runtime is not currently available for the requested compatibility route"
-                    .to_string()
-            } else {
-                "compatibility route failed".to_string()
-            },
-        }),
-    )
-}
-
 pub(super) fn ensure_legacy_runtime_routes_supported(
     state: &ApiState,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {

--- a/code/apps/bpane-gateway/src/api/runtime_access.rs
+++ b/code/apps/bpane-gateway/src/api/runtime_access.rs
@@ -1,23 +1,5 @@
 use super::*;
 
-pub(super) async fn runtime_is_currently_in_use(state: &ApiState) -> bool {
-    let Some(session_id) = legacy_runtime_session_id(state).await else {
-        return false;
-    };
-    let Some(snapshot) = state.registry.telemetry_snapshot_if_live(session_id).await else {
-        return false;
-    };
-    snapshot.browser_clients > 0 || snapshot.viewer_clients > 0 || snapshot.mcp_owner
-}
-
-pub(super) fn should_block_session_stop(
-    state: SessionLifecycleState,
-    supports_legacy_global_routes: bool,
-    runtime_in_use: bool,
-) -> bool {
-    supports_legacy_global_routes && state.is_runtime_candidate() && runtime_in_use
-}
-
 pub(super) async fn resolve_runtime(
     state: &ApiState,
     session_id: Uuid,

--- a/code/apps/bpane-gateway/src/api/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/sessions.rs
@@ -4,6 +4,7 @@ use super::*;
 
 mod access;
 mod crud;
+mod disconnect;
 mod kill;
 mod mcp;
 mod ownership;
@@ -39,6 +40,14 @@ pub(super) fn session_operation_routes() -> Router<Arc<ApiState>> {
         .route(
             "/api/v1/sessions/{session_id}/status",
             get(status::get_session_status),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/connections/{connection_id}/disconnect",
+            post(disconnect::disconnect_session_connection),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/connections/disconnect-all",
+            post(disconnect::disconnect_all_session_connections),
         )
         .route(
             "/api/v1/sessions/{session_id}/kill",

--- a/code/apps/bpane-gateway/src/api/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/sessions.rs
@@ -4,6 +4,7 @@ use super::*;
 
 mod access;
 mod crud;
+mod kill;
 mod mcp;
 mod ownership;
 mod status;
@@ -38,6 +39,10 @@ pub(super) fn session_operation_routes() -> Router<Arc<ApiState>> {
         .route(
             "/api/v1/sessions/{session_id}/status",
             get(status::get_session_status),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/kill",
+            post(kill::kill_session),
         )
         .route(
             "/api/v1/sessions/{session_id}/stop",

--- a/code/apps/bpane-gateway/src/api/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/sessions.rs
@@ -7,6 +7,7 @@ mod crud;
 mod mcp;
 mod ownership;
 mod status;
+mod stop;
 
 pub(super) fn session_routes() -> Router<Arc<ApiState>> {
     Router::new()
@@ -16,7 +17,7 @@ pub(super) fn session_routes() -> Router<Arc<ApiState>> {
         )
         .route(
             "/api/v1/sessions/{session_id}",
-            get(crud::get_session).delete(crud::delete_session),
+            get(crud::get_session).delete(stop::delete_session),
         )
 }
 
@@ -37,6 +38,10 @@ pub(super) fn session_operation_routes() -> Router<Arc<ApiState>> {
         .route(
             "/api/v1/sessions/{session_id}/status",
             get(status::get_session_status),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/stop",
+            post(stop::stop_session),
         )
         .route(
             "/api/v1/sessions/{session_id}/mcp-owner",

--- a/code/apps/bpane-gateway/src/api/sessions/access.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/access.rs
@@ -21,7 +21,7 @@ pub(super) async fn issue_session_access_token(
                 }),
             )
         })?;
-    let resource = session_resource(&state, &connectable, None);
+    let resource = session_resource(&state, &connectable, None).await;
 
     Ok(Json(SessionAccessTokenResponse {
         session_id,
@@ -42,7 +42,7 @@ pub(super) async fn issue_session_automation_access(
             .await?;
     let connectable = prepare_runtime_access_session(&state, &principal, session_id).await?;
     resolve_runtime(&state, session_id).await?;
-    let resource = session_resource(&state, &connectable, None);
+    let resource = session_resource(&state, &connectable, None).await;
     let endpoint_url = resource.runtime.cdp_endpoint.ok_or_else(|| {
         (
             StatusCode::CONFLICT,

--- a/code/apps/bpane-gateway/src/api/sessions/access.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/access.rs
@@ -21,7 +21,9 @@ pub(super) async fn issue_session_access_token(
                 }),
             )
         })?;
-    let resource = session_resource(&state, &connectable, None).await;
+    let resource = session_resource(&state, &connectable, None)
+        .await
+        .map_err(map_session_store_error)?;
 
     Ok(Json(SessionAccessTokenResponse {
         session_id,
@@ -42,7 +44,9 @@ pub(super) async fn issue_session_automation_access(
             .await?;
     let connectable = prepare_runtime_access_session(&state, &principal, session_id).await?;
     resolve_runtime(&state, session_id).await?;
-    let resource = session_resource(&state, &connectable, None).await;
+    let resource = session_resource(&state, &connectable, None)
+        .await
+        .map_err(map_session_store_error)?;
     let endpoint_url = resource.runtime.cdp_endpoint.ok_or_else(|| {
         (
             StatusCode::CONFLICT,

--- a/code/apps/bpane-gateway/src/api/sessions/crud.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/crud.rs
@@ -13,7 +13,11 @@ pub(super) async fn create_session(
 
     Ok((
         StatusCode::CREATED,
-        Json(session_resource(&state, &stored, None).await),
+        Json(
+            session_resource(&state, &stored, None)
+                .await
+                .map_err(map_session_store_error)?,
+        ),
     ))
 }
 
@@ -31,7 +35,11 @@ pub(super) async fn list_sessions(
         .map_err(map_session_store_error)?;
     let mut resources = Vec::with_capacity(sessions.len());
     for session in sessions {
-        resources.push(session_resource(&state, &session, None).await);
+        resources.push(
+            session_resource(&state, &session, None)
+                .await
+                .map_err(map_session_store_error)?,
+        );
     }
 
     Ok(Json(SessionListResponse {
@@ -46,72 +54,9 @@ pub(super) async fn get_session(
 ) -> Result<Json<SessionResource>, (StatusCode, Json<ErrorResponse>)> {
     let stored = authorize_visible_session_request(&headers, &state, session_id).await?;
 
-    Ok(Json(session_resource(&state, &stored, None).await))
-}
-
-pub(super) async fn delete_session(
-    headers: HeaderMap,
-    Path(session_id): Path<Uuid>,
-    State(state): State<Arc<ApiState>>,
-) -> Result<Json<SessionResource>, (StatusCode, Json<ErrorResponse>)> {
-    let principal = authorize_api_request(&headers, &state.auth_validator)
-        .await
-        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
-
-    let stored = state
-        .session_store
-        .get_session_for_owner(&principal, session_id)
-        .await
-        .map_err(map_session_store_error)?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: format!("session {session_id} not found"),
-                }),
-            )
-        })?;
-
-    if should_block_session_stop(
-        stored.state,
-        state
-            .session_manager
-            .profile()
-            .supports_legacy_global_routes,
-        runtime_is_currently_in_use(&state).await,
-    ) {
-        return Err((
-            StatusCode::CONFLICT,
-            Json(ErrorResponse {
-                error: "cannot stop the legacy single-session runtime while it is in use"
-                    .to_string(),
-            }),
-        ));
-    }
-
-    let stopped = state
-        .session_store
-        .stop_session_for_owner(&principal, session_id)
-        .await
-        .map_err(map_session_store_error)?
-        .ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ErrorResponse {
-                    error: format!("session {session_id} not found"),
-                }),
-            )
-        })?;
-
-    if let Err(error) = state
-        .recording_lifecycle
-        .request_stop_and_wait(session_id, SessionRecordingTerminationReason::SessionStop)
-        .await
-    {
-        info!(%session_id, "recording finalization before session stop returned: {error}");
-    }
-    state.session_manager.release(session_id).await;
-    state.registry.remove_session(session_id).await;
-
-    Ok(Json(session_resource(&state, &stopped, None).await))
+    Ok(Json(
+        session_resource(&state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
 }

--- a/code/apps/bpane-gateway/src/api/sessions/crud.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/crud.rs
@@ -13,7 +13,7 @@ pub(super) async fn create_session(
 
     Ok((
         StatusCode::CREATED,
-        Json(session_resource(&state, &stored, None)),
+        Json(session_resource(&state, &stored, None).await),
     ))
 }
 
@@ -28,12 +28,15 @@ pub(super) async fn list_sessions(
         .session_store
         .list_sessions_for_owner(&principal)
         .await
-        .map_err(map_session_store_error)?
-        .into_iter()
-        .map(|session| session_resource(&state, &session, None))
-        .collect();
+        .map_err(map_session_store_error)?;
+    let mut resources = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        resources.push(session_resource(&state, &session, None).await);
+    }
 
-    Ok(Json(SessionListResponse { sessions }))
+    Ok(Json(SessionListResponse {
+        sessions: resources,
+    }))
 }
 
 pub(super) async fn get_session(
@@ -43,7 +46,7 @@ pub(super) async fn get_session(
 ) -> Result<Json<SessionResource>, (StatusCode, Json<ErrorResponse>)> {
     let stored = authorize_visible_session_request(&headers, &state, session_id).await?;
 
-    Ok(Json(session_resource(&state, &stored, None)))
+    Ok(Json(session_resource(&state, &stored, None).await))
 }
 
 pub(super) async fn delete_session(
@@ -110,5 +113,5 @@ pub(super) async fn delete_session(
     state.session_manager.release(session_id).await;
     state.registry.remove_session(session_id).await;
 
-    Ok(Json(session_resource(&state, &stopped, None)))
+    Ok(Json(session_resource(&state, &stopped, None).await))
 }

--- a/code/apps/bpane-gateway/src/api/sessions/disconnect.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/disconnect.rs
@@ -1,0 +1,126 @@
+use tracing::info;
+
+use super::super::*;
+use crate::session_hub::SessionTerminationReason;
+
+pub(super) async fn disconnect_session_connection(
+    headers: HeaderMap,
+    Path((session_id, connection_id)): Path<(Uuid, u64)>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionStatus>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let session = load_owned_session(&state, &principal, session_id).await?;
+    let disconnected = state
+        .registry
+        .disconnect_session_client(
+            session_id,
+            connection_id,
+            SessionTerminationReason::DisconnectedByOwner,
+        )
+        .await;
+    if !disconnected {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("connection {connection_id} was not found for session {session_id}"),
+            }),
+        ));
+    }
+    info!(%session_id, connection_id, "disconnected session connection");
+    let updated = reconcile_session_after_disconnect(&state, session).await?;
+    Ok(Json(
+        load_session_status(&state, &updated)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
+}
+
+pub(super) async fn disconnect_all_session_connections(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionStatus>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let session = load_owned_session(&state, &principal, session_id).await?;
+    let disconnected = state
+        .registry
+        .disconnect_all_session_clients(session_id, SessionTerminationReason::DisconnectedByOwner)
+        .await;
+    info!(%session_id, disconnected, "disconnected all live session connections");
+    let updated = reconcile_session_after_disconnect(&state, session).await?;
+    Ok(Json(
+        load_session_status(&state, &updated)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
+}
+
+async fn load_owned_session(
+    state: &Arc<ApiState>,
+    principal: &AuthenticatedPrincipal,
+    session_id: Uuid,
+) -> Result<StoredSession, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .session_store
+        .get_session_for_owner(principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })
+}
+
+async fn reconcile_session_after_disconnect(
+    state: &Arc<ApiState>,
+    session: StoredSession,
+) -> Result<StoredSession, (StatusCode, Json<ErrorResponse>)> {
+    let snapshot = state
+        .registry
+        .telemetry_snapshot_if_live(session.id)
+        .await
+        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
+
+    if snapshot.browser_clients == 0 && !snapshot.mcp_owner && session.state.is_runtime_candidate()
+    {
+        if let Some(idle) = state
+            .session_store
+            .mark_session_idle(session.id)
+            .await
+            .map_err(map_session_store_error)?
+        {
+            state.session_manager.mark_session_idle(session.id).await;
+            schedule_idle_session_stop(
+                session.id,
+                state.idle_stop_timeout,
+                state.registry.clone(),
+                state.session_store.clone(),
+                state.session_manager.clone(),
+                state.recording_lifecycle.clone(),
+            );
+            return Ok(idle);
+        }
+    }
+
+    state
+        .session_store
+        .get_session_by_id(session.id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {} not found", session.id),
+                }),
+            )
+        })
+}

--- a/code/apps/bpane-gateway/src/api/sessions/kill.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/kill.rs
@@ -1,0 +1,172 @@
+use tracing::{info, warn};
+
+use super::super::*;
+use crate::automation_tasks::{AutomationTaskState, AutomationTaskTransitionRequest};
+use crate::session_control::SessionRecordingTerminationReason;
+use crate::session_hub::SessionTerminationReason;
+use crate::workflow::{WorkflowRunState, WorkflowRunTransitionRequest};
+
+pub(super) async fn kill_session(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let stored = state
+        .session_store
+        .get_session_for_owner(&principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    if stored.state == SessionLifecycleState::Stopped {
+        return Ok(Json(
+            session_resource(&state, &stored, None)
+                .await
+                .map_err(map_session_store_error)?,
+        ));
+    }
+
+    terminate_session_workloads(&state, &stored).await?;
+
+    if let Err(error) = state
+        .recording_lifecycle
+        .request_stop_and_wait(session_id, SessionRecordingTerminationReason::SessionKill)
+        .await
+    {
+        warn!(%session_id, "recording finalization before session kill returned: {error}");
+    }
+
+    let terminated_clients = state
+        .registry
+        .terminate_session_clients(session_id, SessionTerminationReason::SessionKilled)
+        .await;
+
+    let stopped = state
+        .session_store
+        .stop_session_for_owner(&principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    state.session_manager.release(session_id).await;
+    state.registry.remove_session(session_id).await;
+    info!(
+        %session_id,
+        terminated_clients,
+        "force killed session and released runtime"
+    );
+
+    Ok(Json(
+        session_resource(&state, &stopped, None)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
+}
+
+async fn terminate_session_workloads(
+    state: &Arc<ApiState>,
+    session: &StoredSession,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let owner = AuthenticatedPrincipal {
+        subject: session.owner.subject.clone(),
+        issuer: session.owner.issuer.clone(),
+        display_name: session.owner.display_name.clone(),
+        client_id: None,
+    };
+    let active_runs = state
+        .session_store
+        .list_workflow_runs_for_owner(&owner)
+        .await
+        .map_err(map_session_store_error)?
+        .into_iter()
+        .filter(|run| run.session_id == session.id && !run.state.is_terminal())
+        .collect::<Vec<_>>();
+    let workflow_task_ids = active_runs
+        .iter()
+        .map(|run| run.automation_task_id)
+        .collect::<std::collections::HashSet<_>>();
+
+    for run in active_runs {
+        if let Err(error) = state
+            .session_store
+            .transition_workflow_run(
+                run.id,
+                WorkflowRunTransitionRequest {
+                    state: WorkflowRunState::Cancelled,
+                    output: run.output.clone(),
+                    error: None,
+                    artifact_refs: run.artifact_refs.clone(),
+                    message: Some(
+                        "workflow run cancelled because its session was force killed".to_string(),
+                    ),
+                    data: Some(serde_json::json!({
+                        "reason": "session_kill",
+                        "session_id": session.id,
+                    })),
+                },
+            )
+            .await
+        {
+            warn!(run_id = %run.id, session_id = %session.id, "failed to transition workflow run during session kill: {error}");
+        }
+        if let Err(error) = state.workflow_lifecycle.cancel_run(run.id).await {
+            warn!(run_id = %run.id, session_id = %session.id, "failed to stop workflow worker during session kill: {error}");
+        }
+    }
+
+    let active_tasks = state
+        .session_store
+        .list_automation_tasks_for_owner(&owner)
+        .await
+        .map_err(map_session_store_error)?
+        .into_iter()
+        .filter(|task| {
+            task.session_id == session.id
+                && !task.state.is_terminal()
+                && !workflow_task_ids.contains(&task.id)
+        })
+        .collect::<Vec<_>>();
+    for task in active_tasks {
+        if let Err(error) = state
+            .session_store
+            .transition_automation_task(
+                task.id,
+                AutomationTaskTransitionRequest {
+                    state: AutomationTaskState::Cancelled,
+                    output: task.output.clone(),
+                    error: None,
+                    artifact_refs: task.artifact_refs.clone(),
+                    event_type: "automation_task.cancelled".to_string(),
+                    event_message: "automation task cancelled because its session was force killed"
+                        .to_string(),
+                    event_data: Some(serde_json::json!({
+                        "reason": "session_kill",
+                        "session_id": session.id,
+                    })),
+                },
+            )
+            .await
+        {
+            warn!(task_id = %task.id, session_id = %session.id, "failed to transition automation task during session kill: {error}");
+        }
+    }
+
+    Ok(())
+}

--- a/code/apps/bpane-gateway/src/api/sessions/ownership.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/ownership.rs
@@ -23,7 +23,7 @@ pub(super) async fn set_automation_owner(
             )
         })?;
 
-    Ok(Json(session_resource(&state, &stored, None)))
+    Ok(Json(session_resource(&state, &stored, None).await))
 }
 
 pub(super) async fn clear_automation_owner(
@@ -48,5 +48,5 @@ pub(super) async fn clear_automation_owner(
             )
         })?;
 
-    Ok(Json(session_resource(&state, &stored, None)))
+    Ok(Json(session_resource(&state, &stored, None).await))
 }

--- a/code/apps/bpane-gateway/src/api/sessions/ownership.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/ownership.rs
@@ -23,7 +23,11 @@ pub(super) async fn set_automation_owner(
             )
         })?;
 
-    Ok(Json(session_resource(&state, &stored, None).await))
+    Ok(Json(
+        session_resource(&state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
 }
 
 pub(super) async fn clear_automation_owner(
@@ -48,5 +52,9 @@ pub(super) async fn clear_automation_owner(
             )
         })?;
 
-    Ok(Json(session_resource(&state, &stored, None).await))
+    Ok(Json(
+        session_resource(&state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
 }

--- a/code/apps/bpane-gateway/src/api/sessions/status.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/status.rs
@@ -8,24 +8,14 @@ pub(super) async fn get_session_status(
     State(state): State<Arc<ApiState>>,
 ) -> Result<Json<SessionStatus>, (StatusCode, Json<ErrorResponse>)> {
     let session =
-        authorize_runtime_session_request_with_automation_access(&headers, &state, session_id)
+        authorize_visible_session_request_with_automation_access(&headers, &state, session_id)
             .await?;
-    let hub = state
+    let snapshot = state
         .registry
-        .ensure_hub_for_session(
-            session_id,
-            &resolve_runtime(&state, session_id).await?.agent_socket_path,
-        )
+        .telemetry_snapshot_if_live(session_id)
         .await
-        .map_err(|error| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(ErrorResponse {
-                    error: format!("failed to connect to host agent: {error}"),
-                }),
-            )
-        })?;
-    let snapshot = hub.telemetry_snapshot().await;
+        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
+    let summary = session_status_summary(&state, &session).await;
     let recordings = state
         .session_store
         .list_recordings_for_session(session_id)
@@ -35,6 +25,8 @@ pub(super) async fn get_session_status(
     let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
 
     Ok(Json(session_status_from_snapshot(
+        session.state,
+        summary,
         snapshot,
         &session.recording,
         latest_recording,
@@ -58,9 +50,6 @@ pub(super) async fn session_status(
             }),
         ));
     };
-    let runtime = resolve_runtime_compat(&state, session_id)
-        .await
-        .map_err(map_runtime_compat_status)?;
     let session = state
         .session_store
         .get_session_by_id(session_id)
@@ -74,19 +63,12 @@ pub(super) async fn session_status(
                 }),
             )
         })?;
-    let hub = state
+    let snapshot = state
         .registry
-        .ensure_hub_for_session(session_id, &runtime.agent_socket_path)
+        .telemetry_snapshot_if_live(session_id)
         .await
-        .map_err(|error| {
-            (
-                StatusCode::SERVICE_UNAVAILABLE,
-                Json(ErrorResponse {
-                    error: format!("failed to connect to host agent: {error}"),
-                }),
-            )
-        })?;
-    let snapshot = hub.telemetry_snapshot().await;
+        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
+    let summary = session_status_summary(&state, &session).await;
     let recordings = state
         .session_store
         .list_recordings_for_session(session_id)
@@ -96,6 +78,8 @@ pub(super) async fn session_status(
     let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
 
     Ok(Json(session_status_from_snapshot(
+        session.state,
+        summary,
         snapshot,
         &session.recording,
         latest_recording,

--- a/code/apps/bpane-gateway/src/api/sessions/status.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/status.rs
@@ -15,7 +15,9 @@ pub(super) async fn get_session_status(
         .telemetry_snapshot_if_live(session_id)
         .await
         .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
-    let summary = session_status_summary(&state, &session).await;
+    let summary = session_status_summary(&state, &session)
+        .await
+        .map_err(map_session_store_error)?;
     let recordings = state
         .session_store
         .list_recordings_for_session(session_id)
@@ -68,7 +70,9 @@ pub(super) async fn session_status(
         .telemetry_snapshot_if_live(session_id)
         .await
         .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
-    let summary = session_status_summary(&state, &session).await;
+    let summary = session_status_summary(&state, &session)
+        .await
+        .map_err(map_session_store_error)?;
     let recordings = state
         .session_store
         .list_recordings_for_session(session_id)

--- a/code/apps/bpane-gateway/src/api/sessions/status.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/status.rs
@@ -1,5 +1,3 @@
-use chrono::Utc;
-
 use super::super::*;
 
 pub(super) async fn get_session_status(
@@ -10,30 +8,11 @@ pub(super) async fn get_session_status(
     let session =
         authorize_visible_session_request_with_automation_access(&headers, &state, session_id)
             .await?;
-    let snapshot = state
-        .registry
-        .telemetry_snapshot_if_live(session_id)
-        .await
-        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
-    let summary = session_status_summary(&state, &session)
-        .await
-        .map_err(map_session_store_error)?;
-    let recordings = state
-        .session_store
-        .list_recordings_for_session(session_id)
-        .await
-        .map_err(map_session_store_error)?;
-    let latest_recording = latest_recording(&recordings);
-    let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
-
-    Ok(Json(session_status_from_snapshot(
-        session.state,
-        summary,
-        snapshot,
-        &session.recording,
-        latest_recording,
-        playback.resource,
-    )))
+    Ok(Json(
+        load_session_status(&state, &session)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
 }
 
 pub(super) async fn session_status(
@@ -65,28 +44,9 @@ pub(super) async fn session_status(
                 }),
             )
         })?;
-    let snapshot = state
-        .registry
-        .telemetry_snapshot_if_live(session_id)
-        .await
-        .unwrap_or_else(|| state.registry.empty_telemetry_snapshot());
-    let summary = session_status_summary(&state, &session)
-        .await
-        .map_err(map_session_store_error)?;
-    let recordings = state
-        .session_store
-        .list_recordings_for_session(session_id)
-        .await
-        .map_err(map_session_store_error)?;
-    let latest_recording = latest_recording(&recordings);
-    let playback = prepare_session_recording_playback(session_id, &recordings, Utc::now());
-
-    Ok(Json(session_status_from_snapshot(
-        session.state,
-        summary,
-        snapshot,
-        &session.recording,
-        latest_recording,
-        playback.resource,
-    )))
+    Ok(Json(
+        load_session_status(&state, &session)
+            .await
+            .map_err(map_session_store_error)?,
+    ))
 }

--- a/code/apps/bpane-gateway/src/api/sessions/stop.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/stop.rs
@@ -1,0 +1,133 @@
+use axum::response::{IntoResponse, Response};
+use tracing::info;
+
+use super::super::*;
+use crate::session_control::{SessionStopBlockerKind, SessionStopEligibility};
+
+pub(super) async fn stop_session(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    stop_session_for_owner(&state, &principal, session_id).await
+}
+
+pub(super) async fn delete_session(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    stop_session_for_owner(&state, &principal, session_id).await
+}
+
+pub(super) async fn stop_session_for_owner(
+    state: &Arc<ApiState>,
+    principal: &AuthenticatedPrincipal,
+    session_id: Uuid,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let stored = state
+        .session_store
+        .get_session_for_owner(principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    if stored.state == SessionLifecycleState::Stopped {
+        let resource = session_resource(state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?;
+        return Ok((StatusCode::OK, Json(resource)).into_response());
+    }
+
+    let status = session_status_summary(state, &stored)
+        .await
+        .map_err(map_session_store_error)?;
+    if !status.stop_eligibility.allowed {
+        let session = session_resource(state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?;
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(SessionStopConflictResponse {
+                error: session_stop_conflict_message(&status.stop_eligibility),
+                session,
+            }),
+        )
+            .into_response());
+    }
+
+    let stopped = state
+        .session_store
+        .stop_session_for_owner(principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    if let Err(error) = state
+        .recording_lifecycle
+        .request_stop_and_wait(session_id, SessionRecordingTerminationReason::SessionStop)
+        .await
+    {
+        info!(%session_id, "recording finalization before session stop returned: {error}");
+    }
+    state.session_manager.release(session_id).await;
+    state.registry.remove_session(session_id).await;
+
+    let resource = session_resource(state, &stopped, None)
+        .await
+        .map_err(map_session_store_error)?;
+    Ok((StatusCode::OK, Json(resource)).into_response())
+}
+
+fn session_stop_conflict_message(stop_eligibility: &SessionStopEligibility) -> String {
+    let blockers = stop_eligibility
+        .blockers
+        .iter()
+        .map(|blocker| match blocker.kind {
+            SessionStopBlockerKind::OwnerClients => {
+                format!("{} owner client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::ViewerClients => {
+                format!("{} viewer client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::RecorderClients => {
+                format!("{} recorder client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::AutomationOwner => {
+                format!("{} automation owner(s)", blocker.count)
+            }
+            SessionStopBlockerKind::RecordingActivity => {
+                format!("{} active recording operation(s)", blocker.count)
+            }
+            SessionStopBlockerKind::AutomationTasks => {
+                format!("{} active automation task(s)", blocker.count)
+            }
+            SessionStopBlockerKind::WorkflowRuns => {
+                format!("{} active workflow run(s)", blocker.count)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!("session cannot be stopped while blockers remain: {blockers}")
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions.rs
@@ -5,5 +5,6 @@ pub(super) use crate::session_registry::SessionRegistry;
 mod automation;
 mod constraints;
 mod contract;
+mod kill;
 mod stop;
 mod visibility;

--- a/code/apps/bpane-gateway/src/api/tests/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions.rs
@@ -5,6 +5,7 @@ pub(super) use crate::session_registry::SessionRegistry;
 mod automation;
 mod constraints;
 mod contract;
+mod disconnect;
 mod kill;
 mod stop;
 mod visibility;

--- a/code/apps/bpane-gateway/src/api/tests/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions.rs
@@ -5,4 +5,5 @@ pub(super) use crate::session_registry::SessionRegistry;
 mod automation;
 mod constraints;
 mod contract;
+mod stop;
 mod visibility;

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -21,25 +21,6 @@ async fn rejects_v1_session_routes_without_bearer_auth() {
 }
 
 #[test]
-fn blocking_session_stop_only_applies_to_legacy_runtime_backends() {
-    assert!(should_block_session_stop(
-        SessionLifecycleState::Ready,
-        true,
-        true,
-    ));
-    assert!(!should_block_session_stop(
-        SessionLifecycleState::Ready,
-        false,
-        true,
-    ));
-    assert!(!should_block_session_stop(
-        SessionLifecycleState::Stopped,
-        true,
-        true,
-    ));
-}
-
-#[test]
 fn session_status_maps_recorder_clients() {
     let latest_recording = StoredSessionRecording {
         id: uuid::Uuid::now_v7(),

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -3,6 +3,7 @@ use crate::session_control::{
     SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
     SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
 };
+use crate::session_hub::{SessionConnectionTelemetry, SessionConnectionTelemetryRole};
 
 #[tokio::test]
 async fn rejects_v1_session_routes_without_bearer_auth() {
@@ -95,6 +96,20 @@ fn session_status_maps_recorder_clients() {
             full_refresh_tiles_requested: 30,
             last_full_refresh_tiles: 30,
             max_full_refresh_tiles: 30,
+            connections: vec![
+                SessionConnectionTelemetry {
+                    connection_id: 1,
+                    role: SessionConnectionTelemetryRole::Owner,
+                },
+                SessionConnectionTelemetry {
+                    connection_id: 2,
+                    role: SessionConnectionTelemetryRole::Viewer,
+                },
+                SessionConnectionTelemetry {
+                    connection_id: 3,
+                    role: SessionConnectionTelemetryRole::Recorder,
+                },
+            ],
             egress_send_stream_lock_acquires_total: 10,
             egress_send_stream_lock_wait_us_total: 20,
             egress_send_stream_lock_wait_us_average: 2.0,
@@ -122,6 +137,22 @@ fn session_status_maps_recorder_clients() {
     assert_eq!(status.summary.connection_counts.viewer_clients, 1);
     assert!(!status.summary.stop_eligibility.allowed);
     assert_eq!(status.summary.stop_eligibility.blockers.len(), 3);
+    assert_eq!(status.connections.len(), 3);
+    assert_eq!(status.connections[0].connection_id, 1);
+    assert!(matches!(
+        status.connections[0].role,
+        SessionConnectionRole::Owner
+    ));
+    assert_eq!(status.connections[1].connection_id, 2);
+    assert!(matches!(
+        status.connections[1].role,
+        SessionConnectionRole::Viewer
+    ));
+    assert_eq!(status.connections[2].connection_id, 3);
+    assert!(matches!(
+        status.connections[2].role,
+        SessionConnectionRole::Recorder
+    ));
     assert_eq!(status.browser_clients, 3);
     assert_eq!(status.viewer_clients, 1);
     assert_eq!(status.recorder_clients, 1);

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::session_control::{
+    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
+    SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
+};
 
 #[tokio::test]
 async fn rejects_v1_session_routes_without_bearer_auth() {
@@ -57,6 +61,41 @@ fn session_status_maps_recorder_clients() {
     let playback =
         prepare_session_recording_playback(latest_recording.session_id, &[], chrono::Utc::now());
     let status = session_status_from_snapshot(
+        SessionLifecycleState::Active,
+        SessionStatusSummary {
+            runtime_state: SessionRuntimeState::Running,
+            presence_state: SessionPresenceState::Connected,
+            connection_counts: SessionConnectionCounts {
+                interactive_clients: 2,
+                owner_clients: 1,
+                viewer_clients: 1,
+                recorder_clients: 1,
+                automation_clients: 0,
+                total_clients: 3,
+            },
+            stop_eligibility: SessionStopEligibility {
+                allowed: false,
+                blockers: vec![
+                    SessionStopBlocker {
+                        kind: SessionStopBlockerKind::OwnerClients,
+                        count: 1,
+                    },
+                    SessionStopBlocker {
+                        kind: SessionStopBlockerKind::ViewerClients,
+                        count: 1,
+                    },
+                    SessionStopBlocker {
+                        kind: SessionStopBlockerKind::RecorderClients,
+                        count: 1,
+                    },
+                ],
+            },
+            idle: SessionIdleStatus {
+                idle_timeout_sec: Some(300),
+                idle_since: None,
+                idle_deadline: None,
+            },
+        },
         SessionTelemetrySnapshot {
             browser_clients: 3,
             viewer_clients: 1,
@@ -91,6 +130,17 @@ fn session_status_maps_recorder_clients() {
         playback.resource,
     );
 
+    assert_eq!(status.state, SessionLifecycleState::Active);
+    assert_eq!(status.summary.runtime_state, SessionRuntimeState::Running);
+    assert_eq!(
+        status.summary.presence_state,
+        SessionPresenceState::Connected
+    );
+    assert_eq!(status.summary.connection_counts.total_clients, 3);
+    assert_eq!(status.summary.connection_counts.owner_clients, 1);
+    assert_eq!(status.summary.connection_counts.viewer_clients, 1);
+    assert!(!status.summary.stop_eligibility.allowed);
+    assert_eq!(status.summary.stop_eligibility.blockers.len(), 3);
     assert_eq!(status.browser_clients, 3);
     assert_eq!(status.viewer_clients, 1);
     assert_eq!(status.recorder_clients, 1);
@@ -184,6 +234,31 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
         "legacy_single_runtime"
     );
     assert_eq!(created["runtime"]["cdp_endpoint"], "http://host:9223");
+    assert_eq!(created["status"]["runtime_state"], "not_started");
+    assert_eq!(created["status"]["presence_state"], "empty");
+    assert_eq!(
+        created["status"]["connection_counts"]["interactive_clients"],
+        0
+    );
+    assert_eq!(created["status"]["connection_counts"]["owner_clients"], 0);
+    assert_eq!(created["status"]["connection_counts"]["viewer_clients"], 0);
+    assert_eq!(
+        created["status"]["connection_counts"]["recorder_clients"],
+        0
+    );
+    assert_eq!(
+        created["status"]["connection_counts"]["automation_clients"],
+        0
+    );
+    assert_eq!(created["status"]["connection_counts"]["total_clients"], 0);
+    assert_eq!(created["status"]["stop_eligibility"]["allowed"], true);
+    assert!(created["status"]["stop_eligibility"]["blockers"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+    assert_eq!(created["status"]["idle"]["idle_timeout_sec"], 900);
+    assert!(created["status"]["idle"]["idle_since"].is_null());
+    assert!(created["status"]["idle"]["idle_deadline"].is_null());
     assert!(created["created_at"].is_string());
     assert!(created["updated_at"].is_string());
     assert!(created["stopped_at"].is_null());
@@ -220,6 +295,8 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
     assert_eq!(fetched["id"], session_id);
     assert_eq!(fetched["labels"]["suite"], "contract");
     assert_eq!(fetched["recording"]["mode"], "manual");
+    assert_eq!(fetched["status"]["runtime_state"], "not_started");
+    assert_eq!(fetched["status"]["presence_state"], "empty");
 
     let issue_response = app
         .clone()

--- a/code/apps/bpane-gateway/src/api/tests/sessions/disconnect.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/disconnect.rs
@@ -1,0 +1,169 @@
+use crate::session_hub::BrowserClientRole;
+
+use super::*;
+
+#[tokio::test]
+async fn session_status_reports_live_connection_descriptors() {
+    let (app, token, state, agent_server) = test_router_with_live_agent_state().await;
+
+    let created = create_session_via_api(&app, &token).await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = uuid::Uuid::parse_str(&session_id).unwrap();
+    let hub = state
+        .registry
+        .ensure_hub_for_session(session_uuid, &agent_server.socket_path())
+        .await
+        .unwrap();
+
+    let owner = hub.subscribe().await.unwrap();
+    let recorder = hub
+        .subscribe_with_role(BrowserClientRole::Recorder)
+        .await
+        .unwrap();
+
+    let status_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}/status"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_response.status(), StatusCode::OK);
+    let status = response_json(status_response).await;
+    let connections = status["connections"].as_array().unwrap();
+    assert_eq!(connections.len(), 2);
+
+    let owner_entry = connections
+        .iter()
+        .find(|entry| entry["connection_id"] == owner.client_id)
+        .unwrap();
+    assert_eq!(owner_entry["role"], "owner");
+
+    let recorder_entry = connections
+        .iter()
+        .find(|entry| entry["connection_id"] == recorder.client_id)
+        .unwrap();
+    assert_eq!(recorder_entry["role"], "recorder");
+}
+
+#[tokio::test]
+async fn explicit_disconnect_route_terminates_selected_client_and_updates_status() {
+    let (app, token, state, agent_server) = test_router_with_live_agent_state().await;
+
+    let created = create_session_via_api(&app, &token).await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = uuid::Uuid::parse_str(&session_id).unwrap();
+    let hub = state
+        .registry
+        .ensure_hub_for_session(session_uuid, &agent_server.socket_path())
+        .await
+        .unwrap();
+
+    let mut owner = hub.subscribe().await.unwrap();
+    let collaborator = hub.subscribe().await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/connections/{}/disconnect",
+                    collaborator.client_id
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let disconnected = response_json(response).await;
+    assert_eq!(disconnected["connection_counts"]["total_clients"], 1);
+    assert_eq!(disconnected["presence_state"], "connected");
+    let remaining_connections = disconnected["connections"].as_array().unwrap();
+    assert_eq!(remaining_connections.len(), 1);
+    assert_eq!(remaining_connections[0]["connection_id"], owner.client_id);
+
+    assert_eq!(
+        collaborator.termination_rx.await.unwrap(),
+        crate::session_hub::SessionTerminationReason::DisconnectedByOwner
+    );
+    assert!(matches!(
+        owner.termination_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
+async fn disconnect_all_route_marks_last_live_attachment_idle() {
+    let (app, token, state, agent_server) = test_router_with_live_agent_state().await;
+
+    let created = create_session_via_api(&app, &token).await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = uuid::Uuid::parse_str(&session_id).unwrap();
+    let hub = state
+        .registry
+        .ensure_hub_for_session(session_uuid, &agent_server.socket_path())
+        .await
+        .unwrap();
+
+    let owner = hub.subscribe().await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/sessions/{session_id}/connections/disconnect-all"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let disconnected = response_json(response).await;
+    assert_eq!(disconnected["state"], "idle");
+    assert_eq!(disconnected["presence_state"], "idle");
+    assert_eq!(disconnected["connection_counts"]["total_clients"], 0);
+    assert!(disconnected["connections"].as_array().unwrap().is_empty());
+    assert!(disconnected["idle"]["idle_since"].is_string());
+    assert!(disconnected["idle"]["idle_deadline"].is_string());
+
+    assert_eq!(
+        owner.termination_rx.await.unwrap(),
+        crate::session_hub::SessionTerminationReason::DisconnectedByOwner
+    );
+}
+
+async fn create_session_via_api(app: &Router, token: &str) -> serde_json::Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "template_id": "default",
+                        "viewport": { "width": 1280, "height": 720 },
+                        "idle_timeout_sec": 300
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    response_json(response).await
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions/kill.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/kill.rs
@@ -1,0 +1,222 @@
+use super::*;
+use crate::session_hub::SessionTerminationReason;
+
+#[tokio::test]
+async fn explicit_kill_route_stops_session_and_terminates_live_clients() {
+    let (app, token, state, agent_server) = test_router_with_live_agent_state().await;
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = Uuid::parse_str(&session_id).unwrap();
+
+    let hub = state
+        .registry
+        .ensure_hub_for_session(session_uuid, &agent_server.socket_path())
+        .await
+        .unwrap();
+    let live_client = hub.subscribe().await.unwrap();
+    hub.set_mcp_owner(1280, 720).await;
+
+    let kill_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/kill"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(kill_response.status(), StatusCode::OK);
+    let killed = response_json(kill_response).await;
+    assert_eq!(killed["state"], "stopped");
+    assert_eq!(killed["status"]["runtime_state"], "stopped");
+    assert_eq!(killed["status"]["presence_state"], "empty");
+    assert_eq!(killed["status"]["stop_eligibility"]["allowed"], true);
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
+    assert_eq!(
+        live_client.termination_rx.await.unwrap(),
+        SessionTerminationReason::SessionKilled
+    );
+}
+
+#[tokio::test]
+async fn kill_route_cancels_active_session_workloads() {
+    let (app, token, state) = test_router_with_state();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = Uuid::parse_str(&session_id).unwrap();
+
+    let standalone_task = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/automation-tasks")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "display_name": "kill-standalone-task",
+                            "executor": "playwright",
+                            "session": {
+                                "existing_session_id": session_id,
+                            },
+                            "input": {
+                                "step": "kill-me",
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let standalone_task_id = Uuid::parse_str(standalone_task["id"].as_str().unwrap()).unwrap();
+
+    let workflow = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/workflows")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "kill-workflow",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let workflow_id = workflow["id"].as_str().unwrap();
+
+    let workflow_version = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/workflows/{workflow_id}/versions"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "version": "v1",
+                        "executor": "playwright",
+                        "entrypoint": "workflows/kill.ts"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(workflow_version.status(), StatusCode::CREATED);
+
+    let workflow_run = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/workflow-runs")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "workflow_id": workflow_id,
+                            "version": "v1",
+                            "session": {
+                                "existing_session_id": session_id,
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let workflow_run_id = Uuid::parse_str(workflow_run["id"].as_str().unwrap()).unwrap();
+
+    let kill_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/kill"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(kill_response.status(), StatusCode::OK);
+    let killed = response_json(kill_response).await;
+    assert_eq!(killed["state"], "stopped");
+
+    let owner = AuthenticatedPrincipal {
+        subject: created["owner"]["subject"].as_str().unwrap().to_string(),
+        issuer: created["owner"]["issuer"].as_str().unwrap().to_string(),
+        display_name: None,
+        client_id: None,
+    };
+    let standalone_task = state
+        .session_store
+        .get_automation_task_for_owner(&owner, standalone_task_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(standalone_task.session_id, session_uuid);
+    assert_eq!(standalone_task.state.as_str(), "cancelled");
+
+    let workflow_run = state
+        .session_store
+        .get_workflow_run_for_owner(&owner, workflow_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(workflow_run.session_id, session_uuid);
+    assert_eq!(workflow_run.state.as_str(), "cancelled");
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions/stop.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/stop.rs
@@ -1,0 +1,250 @@
+use super::*;
+use crate::session_control::{SessionRecordingFormat, SessionRecordingTerminationReason};
+
+fn blocker_kinds(value: &Value) -> Vec<&str> {
+    value["session"]["status"]["stop_eligibility"]["blockers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|blocker| blocker["kind"].as_str())
+        .collect()
+}
+
+#[tokio::test]
+async fn explicit_stop_route_stops_unused_session() {
+    let (app, token) = test_router();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+
+    let stop_response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/stop"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(stop_response.status(), StatusCode::OK);
+    let stopped = response_json(stop_response).await;
+    assert_eq!(stopped["state"], "stopped");
+    assert_eq!(stopped["status"]["runtime_state"], "stopped");
+    assert_eq!(stopped["status"]["presence_state"], "empty");
+    assert_eq!(stopped["status"]["stop_eligibility"]["allowed"], true);
+}
+
+#[tokio::test]
+async fn stop_routes_report_execution_and_recording_blockers() {
+    let (app, token, state) = test_router_with_state();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = Uuid::parse_str(&session_id).unwrap();
+
+    let automation_task = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/automation-tasks")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "display_name": "stop-blocker-task",
+                        "executor": "playwright",
+                        "session": {
+                            "existing_session_id": session_id,
+                        },
+                        "input": {
+                            "step": "block-stop",
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(automation_task.status(), StatusCode::CREATED);
+
+    let workflow = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/workflows")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "stop-blocker-workflow",
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let workflow_id = workflow["id"].as_str().unwrap();
+
+    let workflow_version = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/workflows/{workflow_id}/versions"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "version": "v1",
+                        "executor": "playwright",
+                        "entrypoint": "workflows/stop-blocker.ts"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(workflow_version.status(), StatusCode::CREATED);
+
+    let workflow_run = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/workflow-runs")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "workflow_id": workflow_id,
+                        "version": "v1",
+                        "session": {
+                            "existing_session_id": session_id,
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(workflow_run.status(), StatusCode::CREATED);
+
+    let recording = state
+        .session_store
+        .create_recording_for_session(session_uuid, SessionRecordingFormat::Webm, None)
+        .await
+        .unwrap();
+    let finalizing = state
+        .session_store
+        .stop_recording_for_session(
+            session_uuid,
+            recording.id,
+            SessionRecordingTerminationReason::SessionStop,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(finalizing.state.as_str(), "finalizing");
+
+    let session = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/sessions/{session_id}"))
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(session["status"]["stop_eligibility"]["allowed"], false);
+    let session_wrapper = json!({ "session": session.clone() });
+    let session_blockers = blocker_kinds(&session_wrapper);
+    assert!(session_blockers.contains(&"automation_tasks"));
+    assert!(session_blockers.contains(&"workflow_runs"));
+    assert!(session_blockers.contains(&"recording_activity"));
+
+    let stop_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/stop"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stop_response.status(), StatusCode::CONFLICT);
+    let stop_body = response_json(stop_response).await;
+    assert_eq!(stop_body["session"]["id"], session_id);
+    assert_eq!(
+        stop_body["session"]["status"]["stop_eligibility"]["allowed"],
+        false
+    );
+    let stop_blockers = blocker_kinds(&stop_body);
+    assert!(stop_blockers.contains(&"automation_tasks"));
+    assert!(stop_blockers.contains(&"workflow_runs"));
+    assert!(stop_blockers.contains(&"recording_activity"));
+
+    let delete_response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/v1/sessions/{session_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delete_response.status(), StatusCode::CONFLICT);
+    let delete_body = response_json(delete_response).await;
+    assert_eq!(delete_body["session"]["id"], session_id);
+    let delete_blockers = blocker_kinds(&delete_body);
+    assert!(delete_blockers.contains(&"automation_tasks"));
+    assert!(delete_blockers.contains(&"workflow_runs"));
+    assert!(delete_blockers.contains(&"recording_activity"));
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions/visibility.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/visibility.rs
@@ -164,8 +164,8 @@ async fn rejects_session_scoped_runtime_routes_for_unknown_or_foreign_sessions_b
 }
 
 #[tokio::test]
-async fn rejects_session_scoped_runtime_routes_for_stopped_sessions() {
-    let (app, token) = test_router();
+async fn session_status_reports_stopped_sessions_without_runtime_side_effects() {
+    let (app, token, state) = test_router_with_state();
 
     let created = response_json(
         app.clone()
@@ -183,6 +183,7 @@ async fn rejects_session_scoped_runtime_routes_for_stopped_sessions() {
     )
     .await;
     let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = Uuid::parse_str(&session_id).unwrap();
 
     let delete_response = app
         .clone()
@@ -197,6 +198,11 @@ async fn rejects_session_scoped_runtime_routes_for_stopped_sessions() {
         .await
         .unwrap();
     assert_eq!(delete_response.status(), StatusCode::OK);
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
 
     let status_response = app
         .oneshot(
@@ -208,10 +214,95 @@ async fn rejects_session_scoped_runtime_routes_for_stopped_sessions() {
         )
         .await
         .unwrap();
-    assert_eq!(status_response.status(), StatusCode::CONFLICT);
+    assert_eq!(status_response.status(), StatusCode::OK);
     let body = response_json(status_response).await;
-    assert!(body["error"]
-        .as_str()
-        .unwrap()
-        .contains("runtime-compatible state"));
+    assert_eq!(body["state"], "stopped");
+    assert_eq!(body["runtime_state"], "stopped");
+    assert_eq!(body["presence_state"], "empty");
+    assert_eq!(body["connection_counts"]["total_clients"], 0);
+    assert_eq!(body["connection_counts"]["interactive_clients"], 0);
+    assert_eq!(body["connection_counts"]["automation_clients"], 0);
+    assert_eq!(body["stop_eligibility"]["allowed"], true);
+    assert_eq!(body["browser_clients"], 0);
+    assert_eq!(body["viewer_clients"], 0);
+    assert_eq!(body["recorder_clients"], 0);
+    assert_eq!(body["mcp_owner"], false);
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
+}
+
+#[tokio::test]
+async fn session_resource_and_status_reads_do_not_create_live_hubs() {
+    let (app, token, state) = test_router_with_state();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+    let session_uuid = Uuid::parse_str(&session_id).unwrap();
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
+
+    let get_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let get_body = response_json(get_response).await;
+    assert_eq!(get_body["status"]["runtime_state"], "not_started");
+    assert_eq!(get_body["status"]["presence_state"], "empty");
+    assert_eq!(get_body["status"]["connection_counts"]["total_clients"], 0);
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
+
+    let status_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}/status"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status_response.status(), StatusCode::OK);
+    let status_body = response_json(status_response).await;
+    assert_eq!(status_body["state"], "ready");
+    assert_eq!(status_body["runtime_state"], "not_started");
+    assert_eq!(status_body["presence_state"], "empty");
+    assert_eq!(status_body["connection_counts"]["total_clients"], 0);
+    assert_eq!(status_body["browser_clients"], 0);
+    assert!(state
+        .registry
+        .telemetry_snapshot_if_live(session_uuid)
+        .await
+        .is_none());
 }

--- a/code/apps/bpane-gateway/src/api/tests/support/router.rs
+++ b/code/apps/bpane-gateway/src/api/tests/support/router.rs
@@ -161,6 +161,12 @@ pub(crate) fn test_router_with_workflow_lifecycle(
 }
 
 pub(crate) async fn test_router_with_live_agent() -> (Router, String, TestAgentServer) {
+    let (router, token, _, agent_server) = test_router_with_live_agent_state().await;
+    (router, token, agent_server)
+}
+
+pub(crate) async fn test_router_with_live_agent_state(
+) -> (Router, String, Arc<ApiState>, TestAgentServer) {
     let agent_server = TestAgentServer::start().await;
     let auth_validator = Arc::new(AuthValidator::from_hmac_secret(vec![7; 32]));
     let token = auth_validator
@@ -200,7 +206,7 @@ pub(crate) async fn test_router_with_live_agent() -> (Router, String, TestAgentS
         public_gateway_url: "https://localhost:4433".to_string(),
         default_owner_mode: SessionOwnerMode::Collaborative,
     });
-    (build_api_router(state), token, agent_server)
+    (build_api_router(state.clone()), token, state, agent_server)
 }
 
 pub(crate) async fn test_router_with_docker_pool() -> (Router, String) {

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -25,7 +25,7 @@ use crate::session_control::{
     SessionRecordingFormat, SessionRecordingMode, SessionResource, SessionStatusSummary,
     SessionStore,
 };
-use crate::session_hub::SessionTelemetrySnapshot;
+use crate::session_hub::{SessionConnectionTelemetryRole, SessionTelemetrySnapshot};
 use crate::session_manager::SessionManager;
 use crate::session_registry::SessionRegistry;
 use crate::workflow::{
@@ -93,6 +93,7 @@ pub(super) struct SessionStatus {
     pub(super) state: SessionLifecycleState,
     #[serde(flatten)]
     pub(super) summary: SessionStatusSummary,
+    pub(super) connections: Vec<SessionConnectionInfo>,
     pub(super) browser_clients: u32,
     pub(super) viewer_clients: u32,
     pub(super) recorder_clients: u32,
@@ -104,6 +105,30 @@ pub(super) struct SessionStatus {
     pub(super) recording: SessionRecordingStatus,
     pub(super) playback: SessionRecordingPlaybackResource,
     pub(super) telemetry: SessionTelemetry,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum SessionConnectionRole {
+    Owner,
+    Viewer,
+    Recorder,
+}
+
+impl From<SessionConnectionTelemetryRole> for SessionConnectionRole {
+    fn from(value: SessionConnectionTelemetryRole) -> Self {
+        match value {
+            SessionConnectionTelemetryRole::Owner => Self::Owner,
+            SessionConnectionTelemetryRole::Viewer => Self::Viewer,
+            SessionConnectionTelemetryRole::Recorder => Self::Recorder,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct SessionConnectionInfo {
+    pub(super) connection_id: u64,
+    pub(super) role: SessionConnectionRole,
 }
 
 #[derive(Serialize)]

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -20,8 +20,8 @@ use crate::recording::{
 use crate::recording_lifecycle::RecordingLifecycleManager;
 use crate::session_access::{SessionAutomationAccessTokenManager, SessionConnectTicketManager};
 use crate::session_control::{
-    CreateSessionRequest, SessionConnectInfo, SessionOwnerMode, SessionRecordingFormat,
-    SessionRecordingMode, SessionStore,
+    CreateSessionRequest, SessionConnectInfo, SessionLifecycleState, SessionOwnerMode,
+    SessionRecordingFormat, SessionRecordingMode, SessionStatusSummary, SessionStore,
 };
 use crate::session_hub::SessionTelemetrySnapshot;
 use crate::session_manager::SessionManager;
@@ -88,6 +88,9 @@ pub(super) const WORKFLOW_RUN_WORKSPACE_ID_HEADER: &str = "x-bpane-workflow-work
 
 #[derive(Serialize)]
 pub(super) struct SessionStatus {
+    pub(super) state: SessionLifecycleState,
+    #[serde(flatten)]
+    pub(super) summary: SessionStatusSummary,
     pub(super) browser_clients: u32,
     pub(super) viewer_clients: u32,
     pub(super) recorder_clients: u32,

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::response::IntoResponse;
 use axum::Json;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
@@ -21,7 +22,8 @@ use crate::recording_lifecycle::RecordingLifecycleManager;
 use crate::session_access::{SessionAutomationAccessTokenManager, SessionConnectTicketManager};
 use crate::session_control::{
     CreateSessionRequest, SessionConnectInfo, SessionLifecycleState, SessionOwnerMode,
-    SessionRecordingFormat, SessionRecordingMode, SessionStatusSummary, SessionStore,
+    SessionRecordingFormat, SessionRecordingMode, SessionResource, SessionStatusSummary,
+    SessionStore,
 };
 use crate::session_hub::SessionTelemetrySnapshot;
 use crate::session_manager::SessionManager;
@@ -102,6 +104,18 @@ pub(super) struct SessionStatus {
     pub(super) recording: SessionRecordingStatus,
     pub(super) playback: SessionRecordingPlaybackResource,
     pub(super) telemetry: SessionTelemetry,
+}
+
+#[derive(Serialize)]
+pub(super) struct SessionStopConflictResponse {
+    pub(super) error: String,
+    pub(super) session: SessionResource,
+}
+
+impl IntoResponse for SessionStopConflictResponse {
+    fn into_response(self) -> axum::response::Response {
+        Json(self).into_response()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/code/apps/bpane-gateway/src/runtime_manager.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager.rs
@@ -256,6 +256,18 @@ impl SessionRuntimeManager {
         }
     }
 
+    pub async fn describe_session_runtime_assignment_status(
+        &self,
+        session_id: Uuid,
+    ) -> Option<RuntimeAssignmentStatus> {
+        match &self.backend {
+            RuntimeBackend::StaticSingle(manager) => {
+                manager.describe_assignment_status(session_id).await
+            }
+            RuntimeBackend::Docker(manager) => manager.describe_assignment_status(session_id).await,
+        }
+    }
+
     pub async fn resolve(
         &self,
         session_id: Uuid,

--- a/code/apps/bpane-gateway/src/runtime_manager/docker.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager/docker.rs
@@ -120,6 +120,18 @@ impl DockerRuntimeManager {
             cdp_endpoint: Some(self.cdp_endpoint_for_session(session_id)),
         }
     }
+
+    pub(super) async fn describe_assignment_status(
+        &self,
+        session_id: Uuid,
+    ) -> Option<RuntimeAssignmentStatus> {
+        let leases = self.leases.lock().await;
+        match leases.get(&session_id) {
+            Some(DockerLeaseState::Starting { .. }) => Some(RuntimeAssignmentStatus::Starting),
+            Some(DockerLeaseState::Ready(_)) => Some(RuntimeAssignmentStatus::Ready),
+            None => None,
+        }
+    }
 }
 
 impl DockerLeaseState {

--- a/code/apps/bpane-gateway/src/runtime_manager/static_single.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager/static_single.rs
@@ -36,6 +36,17 @@ impl StaticSingleRuntimeManager {
         }
     }
 
+    pub(super) async fn describe_assignment_status(
+        &self,
+        session_id: Uuid,
+    ) -> Option<RuntimeAssignmentStatus> {
+        let active = self.active.lock().await;
+        active
+            .as_ref()
+            .filter(|lease| lease.session_id == session_id)
+            .map(|_| RuntimeAssignmentStatus::Ready)
+    }
+
     pub(super) async fn resolve(
         self: &Arc<Self>,
         session_id: Uuid,

--- a/code/apps/bpane-gateway/src/session_control/in_memory/workflow_runs/queries.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/workflow_runs/queries.rs
@@ -1,6 +1,28 @@
 use super::super::*;
 
 impl InMemorySessionStore {
+    pub(in crate::session_control) async fn list_workflow_runs_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredWorkflowRun>, SessionStoreError> {
+        let mut runs = self
+            .workflow_runs
+            .lock()
+            .await
+            .iter()
+            .filter(|run| {
+                run.owner_subject == principal.subject && run.owner_issuer == principal.issuer
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        runs.sort_by(|left, right| {
+            left.created_at
+                .cmp(&right.created_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+        Ok(runs)
+    }
+
     pub(in crate::session_control) async fn create_workflow_run(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/postgres/workflow_runs.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/workflow_runs.rs
@@ -25,6 +25,15 @@ impl PostgresSessionStore {
             .await
     }
 
+    pub(in crate::session_control) async fn list_workflow_runs_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredWorkflowRun>, SessionStoreError> {
+        self.workflow_run_repository()
+            .list_workflow_runs_for_owner(principal)
+            .await
+    }
+
     pub(in crate::session_control) async fn get_workflow_run_for_owner(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/postgres/workflow_runs/queries/lookup.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/workflow_runs/queries/lookup.rs
@@ -1,6 +1,59 @@
 use super::*;
 
 impl WorkflowRunRepository<'_> {
+    pub(in crate::session_control) async fn list_workflow_runs_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredWorkflowRun>, SessionStoreError> {
+        let rows = self
+            .store
+            .db
+            .client()
+            .await?
+            .query(
+                r#"
+                SELECT
+                    id,
+                    owner_subject,
+                    owner_issuer,
+                    workflow_definition_id,
+                    workflow_definition_version_id,
+                    workflow_version,
+                    session_id,
+                    automation_task_id,
+                    state,
+                    source_system,
+                    source_reference,
+                    client_request_id,
+                    create_request_fingerprint,
+                    source_snapshot,
+                    extensions,
+                    credential_bindings,
+                    workspace_inputs,
+                    produced_files,
+                    input,
+                    output,
+                    error,
+                    artifact_refs,
+                    labels,
+                    started_at,
+                    completed_at,
+                    created_at,
+                    updated_at
+                FROM control_workflow_runs
+                WHERE owner_subject = $1
+                  AND owner_issuer = $2
+                ORDER BY created_at, id
+                "#,
+                &[&principal.subject, &principal.issuer],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to list workflow runs: {error}"))
+            })?;
+        rows.iter().map(row_to_stored_workflow_run).collect()
+    }
+
     pub(in crate::session_control) async fn get_workflow_run_for_owner(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/store/workflows/runs.rs
+++ b/code/apps/bpane-gateway/src/session_control/store/workflows/runs.rs
@@ -1,6 +1,20 @@
 use super::super::*;
 
 impl SessionStore {
+    pub async fn list_workflow_runs_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredWorkflowRun>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.list_workflow_runs_for_owner(principal).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.list_workflow_runs_for_owner(principal).await
+            }
+        }
+    }
+
     pub async fn create_workflow_run(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/types/recordings.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/recordings.rs
@@ -109,6 +109,7 @@ impl FromStr for SessionRecordingState {
 pub enum SessionRecordingTerminationReason {
     ManualStop,
     SessionStop,
+    SessionKill,
     IdleStop,
     GatewayRestart,
     WorkerExit,
@@ -119,6 +120,7 @@ impl SessionRecordingTerminationReason {
         match self {
             Self::ManualStop => "manual_stop",
             Self::SessionStop => "session_stop",
+            Self::SessionKill => "session_kill",
             Self::IdleStop => "idle_stop",
             Self::GatewayRestart => "gateway_restart",
             Self::WorkerExit => "worker_exit",
@@ -133,6 +135,7 @@ impl FromStr for SessionRecordingTerminationReason {
         match value {
             "manual_stop" => Ok(Self::ManualStop),
             "session_stop" => Ok(Self::SessionStop),
+            "session_kill" => Ok(Self::SessionKill),
             "idle_stop" => Ok(Self::IdleStop),
             "gateway_restart" => Ok(Self::GatewayRestart),
             "worker_exit" => Ok(Self::WorkerExit),

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -176,6 +176,73 @@ impl From<SessionRuntimeAccess> for SessionRuntimeInfo {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRuntimeState {
+    NotStarted,
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionPresenceState {
+    Empty,
+    Connected,
+    AutomationOwned,
+    RecordingOnly,
+    Idle,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SessionConnectionCounts {
+    pub interactive_clients: u32,
+    pub owner_clients: u32,
+    pub viewer_clients: u32,
+    pub recorder_clients: u32,
+    pub automation_clients: u32,
+    pub total_clients: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStopBlockerKind {
+    OwnerClients,
+    ViewerClients,
+    RecorderClients,
+    AutomationOwner,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionStopBlocker {
+    pub kind: SessionStopBlockerKind,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct SessionStopEligibility {
+    pub allowed: bool,
+    pub blockers: Vec<SessionStopBlocker>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionIdleStatus {
+    pub idle_timeout_sec: Option<u32>,
+    pub idle_since: Option<DateTime<Utc>>,
+    pub idle_deadline: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionStatusSummary {
+    pub runtime_state: SessionRuntimeState,
+    pub presence_state: SessionPresenceState,
+    pub connection_counts: SessionConnectionCounts,
+    pub stop_eligibility: SessionStopEligibility,
+    pub idle: SessionIdleStatus,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SessionResource {
     pub id: Uuid,
@@ -193,6 +260,7 @@ pub struct SessionResource {
     pub recording: crate::session_control::SessionRecordingPolicy,
     pub connect: SessionConnectInfo,
     pub runtime: SessionRuntimeInfo,
+    pub status: SessionStatusSummary,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub stopped_at: Option<DateTime<Utc>>,
@@ -258,6 +326,7 @@ impl StoredSession {
         &self,
         public_gateway_url: &str,
         runtime: SessionRuntimeInfo,
+        status: SessionStatusSummary,
         state_override: Option<SessionLifecycleState>,
     ) -> SessionResource {
         SessionResource {
@@ -286,6 +355,7 @@ impl StoredSession {
                 compatibility_mode: runtime.compatibility_mode.clone(),
             },
             runtime,
+            status,
             created_at: self.created_at,
             updated_at: self.updated_at,
             stopped_at: self.stopped_at,

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -213,6 +213,9 @@ pub enum SessionStopBlockerKind {
     ViewerClients,
     RecorderClients,
     AutomationOwner,
+    RecordingActivity,
+    AutomationTasks,
+    WorkflowRuns,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/code/apps/bpane-gateway/src/session_hub.rs
+++ b/code/apps/bpane-gateway/src/session_hub.rs
@@ -17,7 +17,9 @@ mod telemetry;
 mod types;
 
 pub use self::telemetry::SessionTelemetrySnapshot;
-pub use self::types::{BrowserClientRole, ClientHandle, ResizeResult, SubscribeError};
+pub use self::types::{
+    BrowserClientRole, ClientHandle, ResizeResult, SessionTerminationReason, SubscribeError,
+};
 
 /// Broadcast channel capacity. At 30fps, 1024 frames is ~34 seconds of buffer.
 const BROADCAST_CAPACITY: usize = 1024;
@@ -36,6 +38,8 @@ pub struct SessionHub {
     connected_clients: Mutex<Vec<u64>>,
     client_roles: RwLock<HashMap<u64, BrowserClientRole>>,
     client_control_txs: Mutex<HashMap<u64, mpsc::Sender<ControlMessage>>>,
+    client_termination_txs:
+        Mutex<HashMap<u64, tokio::sync::oneshot::Sender<SessionTerminationReason>>>,
     client_counter: AtomicU64,
     client_count: AtomicU32,
     owner_id: AtomicU64,
@@ -104,6 +108,7 @@ impl SessionHub {
             connected_clients: Mutex::new(Vec::new()),
             client_roles: RwLock::new(HashMap::new()),
             client_control_txs: Mutex::new(HashMap::new()),
+            client_termination_txs: Mutex::new(HashMap::new()),
             client_counter: AtomicU64::new(0),
             client_count: AtomicU32::new(0),
             owner_id: AtomicU64::new(0),
@@ -149,6 +154,15 @@ impl SessionHub {
     /// Called when a client disconnects.
     pub async fn unsubscribe(&self, client_id: u64) {
         membership::unsubscribe(self, client_id).await;
+    }
+
+    #[cfg(test)]
+    pub async fn terminate_client(&self, client_id: u64, reason: SessionTerminationReason) -> bool {
+        membership::terminate_client(self, client_id, reason).await
+    }
+
+    pub async fn terminate_all_clients(&self, reason: SessionTerminationReason) -> usize {
+        membership::terminate_all_clients(self, reason).await
     }
 
     pub fn is_browser_owner(&self, client_id: u64) -> bool {

--- a/code/apps/bpane-gateway/src/session_hub.rs
+++ b/code/apps/bpane-gateway/src/session_hub.rs
@@ -16,7 +16,9 @@ mod refresh;
 mod telemetry;
 mod types;
 
-pub use self::telemetry::SessionTelemetrySnapshot;
+#[cfg(test)]
+pub use self::telemetry::SessionConnectionTelemetry;
+pub use self::telemetry::{SessionConnectionTelemetryRole, SessionTelemetrySnapshot};
 pub use self::types::{
     BrowserClientRole, ClientHandle, ResizeResult, SessionTerminationReason, SubscribeError,
 };
@@ -156,7 +158,6 @@ impl SessionHub {
         membership::unsubscribe(self, client_id).await;
     }
 
-    #[cfg(test)]
     pub async fn terminate_client(&self, client_id: u64, reason: SessionTerminationReason) -> bool {
         membership::terminate_client(self, client_id, reason).await
     }
@@ -222,7 +223,7 @@ impl SessionHub {
 
     pub async fn telemetry_snapshot(&self) -> SessionTelemetrySnapshot {
         let resolution = self.current_resolution().await;
-        telemetry::snapshot(self, resolution)
+        telemetry::snapshot(self, resolution).await
     }
 
     fn record_join_latency(&self, elapsed: std::time::Duration) {

--- a/code/apps/bpane-gateway/src/session_hub.rs
+++ b/code/apps/bpane-gateway/src/session_hub.rs
@@ -49,9 +49,12 @@ pub struct SessionHub {
     cached_session_ready: Arc<Mutex<Option<Arc<Frame>>>>,
     cached_keyframe: Arc<Mutex<Option<Arc<Frame>>>>,
     cached_grid_config: Arc<Mutex<Option<Arc<Frame>>>>,
-    /// When true, MCP agent owns the session — all browser clients are viewers.
+    /// When true, MCP automation is active for the session.
     mcp_is_owner: AtomicBool,
-    /// Resolution set by the MCP agent (used for ResolutionLocked).
+    /// When true, the MCP agent was the initial active connector and controls
+    /// the session resolution until MCP ownership is cleared.
+    mcp_controls_resolution: AtomicBool,
+    /// Resolution seeded by the MCP agent when it controls resolution.
     mcp_resolution: Mutex<Option<(u16, u16)>>,
     joins_accepted: AtomicU64,
     joins_rejected_viewer_cap: AtomicU64,
@@ -116,6 +119,7 @@ impl SessionHub {
             owner_id: AtomicU64::new(0),
             active,
             mcp_is_owner: AtomicBool::new(false),
+            mcp_controls_resolution: AtomicBool::new(false),
             mcp_resolution: Mutex::new(None),
             cached_session_ready,
             cached_keyframe,
@@ -188,9 +192,11 @@ impl SessionHub {
         refresh::request_full_refresh(&self.cached_grid_config, &self.to_agent).await
     }
 
-    /// Register the MCP agent as session owner with the given resolution.
-    /// Sends a ResolutionRequest to the host agent.
-    /// All browser clients will be treated as viewers with locked resolution.
+    /// Register MCP automation as active for this session.
+    ///
+    /// If no interactive browser client has joined yet, MCP seeds the initial
+    /// resolution. Existing browser clients keep their current input and resize
+    /// policy.
     pub async fn set_mcp_owner(&self, width: u16, height: u16) {
         policy::set_mcp_owner(self, width, height).await;
     }

--- a/code/apps/bpane-gateway/src/session_hub/membership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/membership.rs
@@ -4,10 +4,12 @@ use std::time::Instant;
 
 use bpane_protocol::frame::Frame;
 use bpane_protocol::ControlMessage;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::debug;
 
-use super::{BrowserClientRole, ClientHandle, SessionHub, SubscribeError};
+use super::{
+    BrowserClientRole, ClientHandle, SessionHub, SessionTerminationReason, SubscribeError,
+};
 
 pub(super) async fn subscribe(
     hub: &SessionHub,
@@ -23,6 +25,7 @@ pub(super) async fn subscribe(
     let is_resize_owner =
         client_role == BrowserClientRole::Interactive && !mcp_is_owner && current_owner_id == 0;
     let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(8);
+    let (termination_tx, termination_rx) = oneshot::channel::<SessionTerminationReason>();
 
     let is_owner = if client_role == BrowserClientRole::Recorder || mcp_is_owner {
         false
@@ -72,6 +75,10 @@ pub(super) async fn subscribe(
         .lock()
         .await
         .insert(client_id, control_tx);
+    hub.client_termination_txs
+        .lock()
+        .await
+        .insert(client_id, termination_tx);
 
     let initial_frames = gather_initial_frames(hub).await;
     let initial_access_state = super::policy::initial_access_state(hub, client_id).await;
@@ -95,6 +102,7 @@ pub(super) async fn subscribe(
         initial_frames,
         initial_access_state,
         control_rx,
+        termination_rx,
     })
 }
 
@@ -134,7 +142,37 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
 
     hub.client_roles.write().unwrap().remove(&client_id);
     hub.client_control_txs.lock().await.remove(&client_id);
+    hub.client_termination_txs.lock().await.remove(&client_id);
     super::policy::notify_client_access_states(hub, &remaining_clients, None).await;
+}
+
+#[cfg(test)]
+pub(super) async fn terminate_client(
+    hub: &SessionHub,
+    client_id: u64,
+    reason: SessionTerminationReason,
+) -> bool {
+    let Some(tx) = hub.client_termination_txs.lock().await.remove(&client_id) else {
+        return false;
+    };
+    tx.send(reason).is_ok()
+}
+
+pub(super) async fn terminate_all_clients(
+    hub: &SessionHub,
+    reason: SessionTerminationReason,
+) -> usize {
+    let termination_txs = {
+        let mut termination_txs = hub.client_termination_txs.lock().await;
+        termination_txs.drain().collect::<Vec<_>>()
+    };
+    let mut terminated = 0;
+    for (_, tx) in termination_txs {
+        if tx.send(reason).is_ok() {
+            terminated += 1;
+        }
+    }
+    terminated
 }
 
 async fn gather_initial_frames(hub: &SessionHub) -> Vec<Arc<Frame>> {

--- a/code/apps/bpane-gateway/src/session_hub/membership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/membership.rs
@@ -17,17 +17,16 @@ pub(super) async fn subscribe(
 ) -> Result<ClientHandle, SubscribeError> {
     let join_started = Instant::now();
     let client_id = hub.client_counter.fetch_add(1, Ordering::Relaxed) + 1;
-    let mcp_is_owner = hub.mcp_is_owner.load(Ordering::Relaxed);
     let mut connected_clients = hub.connected_clients.lock().await;
     let prev_count = connected_clients.len() as u32;
     let current_owner_id = hub.owner_id.load(Ordering::Relaxed);
     let exclusive_browser_owner = hub.exclusive_browser_owner;
-    let is_resize_owner =
-        client_role == BrowserClientRole::Interactive && !mcp_is_owner && current_owner_id == 0;
+    let should_claim_browser_owner =
+        client_role == BrowserClientRole::Interactive && current_owner_id == 0;
     let (control_tx, control_rx) = mpsc::channel::<ControlMessage>(8);
     let (termination_tx, termination_rx) = oneshot::channel::<SessionTerminationReason>();
 
-    let is_owner = if client_role == BrowserClientRole::Recorder || mcp_is_owner {
+    let is_owner = if client_role == BrowserClientRole::Recorder {
         false
     } else if !exclusive_browser_owner {
         true
@@ -36,7 +35,7 @@ pub(super) async fn subscribe(
     };
 
     if client_role == BrowserClientRole::Interactive && !is_owner {
-        let owner_connected = !mcp_is_owner && current_owner_id != 0 && prev_count > 0;
+        let owner_connected = current_owner_id != 0 && prev_count > 0;
         let current_viewers = {
             let roles = hub.client_roles.read().unwrap();
             connected_clients
@@ -59,7 +58,7 @@ pub(super) async fn subscribe(
     }
 
     connected_clients.push(client_id);
-    if is_resize_owner {
+    if should_claim_browser_owner {
         hub.owner_id.store(client_id, Ordering::Relaxed);
     }
     hub.client_count
@@ -80,10 +79,11 @@ pub(super) async fn subscribe(
         .await
         .insert(client_id, termination_tx);
 
+    let from_host = hub.broadcast_tx.subscribe();
     let initial_frames = gather_initial_frames(hub).await;
     let initial_access_state = super::policy::initial_access_state(hub, client_id).await;
 
-    if prev_count > 0 {
+    if prev_count > 0 || should_request_automation_repaint(hub, client_role) {
         let tiles_requested = hub.request_full_refresh().await;
         if tiles_requested > 0 {
             hub.record_refresh_burst(tiles_requested);
@@ -94,7 +94,7 @@ pub(super) async fn subscribe(
     hub.joins_accepted.fetch_add(1, Ordering::Relaxed);
 
     Ok(ClientHandle {
-        from_host: hub.broadcast_tx.subscribe(),
+        from_host,
         to_host: hub.to_agent.clone(),
         client_id,
         is_owner,
@@ -106,6 +106,10 @@ pub(super) async fn subscribe(
     })
 }
 
+fn should_request_automation_repaint(hub: &SessionHub, client_role: BrowserClientRole) -> bool {
+    client_role == BrowserClientRole::Interactive && hub.mcp_is_owner.load(Ordering::Relaxed)
+}
+
 pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
     let mut connected_clients = hub.connected_clients.lock().await;
     connected_clients.retain(|id| *id != client_id);
@@ -113,9 +117,7 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
         .store(connected_clients.len() as u32, Ordering::Relaxed);
 
     let remaining_clients = connected_clients.clone();
-    let next_owner = if hub.mcp_is_owner.load(Ordering::Relaxed) {
-        0
-    } else {
+    let next_owner = {
         let roles = hub.client_roles.read().unwrap();
         connected_clients
             .iter()
@@ -131,10 +133,7 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
                 next_owner, "promoted existing viewer to session owner"
             );
         }
-    } else if hub.owner_id.load(Ordering::Relaxed) == 0
-        && !hub.mcp_is_owner.load(Ordering::Relaxed)
-        && next_owner != 0
-    {
+    } else if hub.owner_id.load(Ordering::Relaxed) == 0 && next_owner != 0 {
         hub.owner_id.store(next_owner, Ordering::Relaxed);
         debug!(client_id, next_owner, "restored missing session owner");
     }

--- a/code/apps/bpane-gateway/src/session_hub/membership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/membership.rs
@@ -146,7 +146,6 @@ pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {
     super::policy::notify_client_access_states(hub, &remaining_clients, None).await;
 }
 
-#[cfg(test)]
 pub(super) async fn terminate_client(
     hub: &SessionHub,
     client_id: u64,

--- a/code/apps/bpane-gateway/src/session_hub/policy.rs
+++ b/code/apps/bpane-gateway/src/session_hub/policy.rs
@@ -18,9 +18,6 @@ pub(super) fn is_browser_owner(hub: &SessionHub, client_id: u64) -> bool {
     if client_role(hub, client_id) == BrowserClientRole::Recorder {
         return false;
     }
-    if hub.mcp_is_owner() {
-        return false;
-    }
     if !hub.exclusive_browser_owner {
         return true;
     }
@@ -32,7 +29,7 @@ pub(super) fn is_resize_owner(hub: &SessionHub, client_id: u64) -> bool {
     if client_role(hub, client_id) == BrowserClientRole::Recorder {
         return false;
     }
-    if hub.mcp_is_owner() {
+    if hub.mcp_controls_resolution.load(Ordering::Relaxed) {
         return false;
     }
     let owner_id = hub.owner_id.load(Ordering::Relaxed);
@@ -45,13 +42,6 @@ pub(super) async fn request_resize(
     width: u16,
     height: u16,
 ) -> ResizeResult {
-    if hub.mcp_is_owner.load(Ordering::Relaxed) {
-        notify_client_access_states(hub, &[client_id], None).await;
-        if let Some((w, h)) = *hub.mcp_resolution.lock().await {
-            return ResizeResult::Locked(w, h);
-        }
-    }
-
     if is_resize_owner(hub, client_id) {
         let result = forward_resize_request(
             &hub.to_agent,
@@ -68,35 +58,51 @@ pub(super) async fn request_resize(
     }
 
     notify_client_access_states(hub, &[client_id], None).await;
-    let (cur_w, cur_h) = *hub.current_resolution.lock().await;
-    if cur_w > 0 && cur_h > 0 {
-        ResizeResult::Locked(cur_w, cur_h)
+    if let Some((locked_width, locked_height)) = resolve_locked_resolution(hub, None).await {
+        ResizeResult::Locked(locked_width, locked_height)
     } else {
         ResizeResult::Locked(0, 0)
     }
 }
 
 pub(super) async fn set_mcp_owner(hub: &SessionHub, width: u16, height: u16) {
-    *hub.mcp_resolution.lock().await = Some((width, height));
+    let interactive_clients = connected_interactive_client_ids(hub).await;
+    let was_controlling_resolution = hub.mcp_controls_resolution.load(Ordering::Relaxed);
+    let should_control_resolution = was_controlling_resolution || interactive_clients.is_empty();
     hub.mcp_is_owner.store(true, Ordering::Relaxed);
 
-    let msg = ControlMessage::ResolutionRequest { width, height };
-    if hub.to_agent.send(msg.to_frame()).await.is_err() {
-        warn!("failed to send MCP resolution request to agent");
+    if should_control_resolution {
+        *hub.mcp_resolution.lock().await = Some((width, height));
+        hub.mcp_controls_resolution.store(true, Ordering::Relaxed);
+
+        let msg = ControlMessage::ResolutionRequest { width, height };
+        if hub.to_agent.send(msg.to_frame()).await.is_err() {
+            warn!("failed to send MCP resolution request to agent");
+        }
+    } else {
+        hub.mcp_controls_resolution.store(false, Ordering::Relaxed);
+        *hub.mcp_resolution.lock().await = None;
     }
 
     let client_ids = hub.connected_clients.lock().await.clone();
-    notify_client_access_states(hub, &client_ids, Some((width, height))).await;
+    let locked_resolution_override = should_control_resolution.then_some((width, height));
+    notify_client_access_states(hub, &client_ids, locked_resolution_override).await;
 
-    info!(width, height, "MCP agent registered as session owner");
+    info!(
+        width,
+        height,
+        controls_resolution = should_control_resolution,
+        "MCP agent registered as session automation owner"
+    );
 }
 
 pub(super) async fn clear_mcp_owner(hub: &SessionHub) {
     hub.mcp_is_owner.store(false, Ordering::Relaxed);
+    hub.mcp_controls_resolution.store(false, Ordering::Relaxed);
     *hub.mcp_resolution.lock().await = None;
     let client_ids = hub.connected_clients.lock().await.clone();
     if hub.owner_id.load(Ordering::Relaxed) == 0 {
-        if let Some(next_owner) = client_ids.first().copied() {
+        if let Some(next_owner) = first_interactive_client(hub, &client_ids) {
             hub.owner_id.store(next_owner, Ordering::Relaxed);
         }
     }
@@ -208,7 +214,7 @@ async fn resolve_locked_resolution(
     hub: &SessionHub,
     locked_resolution_override: Option<(u16, u16)>,
 ) -> Option<(u16, u16)> {
-    if hub.mcp_is_owner() {
+    if hub.mcp_controls_resolution.load(Ordering::Relaxed) {
         return *hub.mcp_resolution.lock().await;
     }
 
@@ -227,4 +233,21 @@ async fn resolve_locked_resolution(
 async fn cached_session_ready_message(hub: &SessionHub) -> Option<ControlMessage> {
     let frame = hub.cached_session_ready.lock().await.clone()?;
     ControlMessage::decode(&frame.payload).ok()
+}
+
+async fn connected_interactive_client_ids(hub: &SessionHub) -> Vec<u64> {
+    let client_ids = hub.connected_clients.lock().await.clone();
+    let roles = hub.client_roles.read().unwrap();
+    client_ids
+        .into_iter()
+        .filter(|client_id| roles.get(client_id) == Some(&BrowserClientRole::Interactive))
+        .collect()
+}
+
+fn first_interactive_client(hub: &SessionHub, client_ids: &[u64]) -> Option<u64> {
+    let roles = hub.client_roles.read().unwrap();
+    client_ids
+        .iter()
+        .copied()
+        .find(|client_id| roles.get(client_id) == Some(&BrowserClientRole::Interactive))
 }

--- a/code/apps/bpane-gateway/src/session_hub/telemetry.rs
+++ b/code/apps/bpane-gateway/src/session_hub/telemetry.rs
@@ -1,9 +1,22 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
-use super::SessionHub;
+use super::{BrowserClientRole, SessionHub};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionConnectionTelemetryRole {
+    Owner,
+    Viewer,
+    Recorder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionConnectionTelemetry {
+    pub connection_id: u64,
+    pub role: SessionConnectionTelemetryRole,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct SessionTelemetrySnapshot {
     pub browser_clients: u32,
     pub viewer_clients: u32,
@@ -22,6 +35,7 @@ pub struct SessionTelemetrySnapshot {
     pub full_refresh_tiles_requested: u64,
     pub last_full_refresh_tiles: u64,
     pub max_full_refresh_tiles: u64,
+    pub connections: Vec<SessionConnectionTelemetry>,
     pub egress_send_stream_lock_acquires_total: u64,
     pub egress_send_stream_lock_wait_us_total: u64,
     pub egress_send_stream_lock_wait_us_average: f64,
@@ -30,10 +44,11 @@ pub struct SessionTelemetrySnapshot {
     pub egress_lagged_frames_total: u64,
 }
 
-pub(super) fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelemetrySnapshot {
+pub(super) async fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelemetrySnapshot {
     let browser_clients = hub.client_count();
     let viewer_clients = hub.viewer_count();
     let recorder_clients = hub.recorder_count();
+    let connections = snapshot_connections(hub).await;
     let joins_accepted = hub.joins_accepted.load(Ordering::Relaxed);
     let total_join_latency_ms = hub.total_join_latency_ms.load(Ordering::Relaxed);
     let egress_send_stream_lock_acquires_total = hub
@@ -65,6 +80,7 @@ pub(super) fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelem
         full_refresh_tiles_requested: hub.full_refresh_tiles_requested.load(Ordering::Relaxed),
         last_full_refresh_tiles: hub.last_full_refresh_tiles.load(Ordering::Relaxed),
         max_full_refresh_tiles: hub.max_full_refresh_tiles.load(Ordering::Relaxed),
+        connections,
         egress_send_stream_lock_acquires_total,
         egress_send_stream_lock_wait_us_total,
         egress_send_stream_lock_wait_us_average: if egress_send_stream_lock_acquires_total == 0 {
@@ -79,6 +95,31 @@ pub(super) fn snapshot(hub: &SessionHub, resolution: (u16, u16)) -> SessionTelem
         egress_lagged_receives_total: hub.egress_lagged_receives_total.load(Ordering::Relaxed),
         egress_lagged_frames_total: hub.egress_lagged_frames_total.load(Ordering::Relaxed),
     }
+}
+
+async fn snapshot_connections(hub: &SessionHub) -> Vec<SessionConnectionTelemetry> {
+    let connected_clients = hub.connected_clients.lock().await.clone();
+    let roles = hub.client_roles.read().unwrap();
+    connected_clients
+        .into_iter()
+        .map(|connection_id| {
+            let role = match roles.get(&connection_id).copied() {
+                Some(BrowserClientRole::Recorder) => SessionConnectionTelemetryRole::Recorder,
+                Some(BrowserClientRole::Interactive) => {
+                    if hub.is_browser_owner(connection_id) {
+                        SessionConnectionTelemetryRole::Owner
+                    } else {
+                        SessionConnectionTelemetryRole::Viewer
+                    }
+                }
+                None => SessionConnectionTelemetryRole::Viewer,
+            };
+            SessionConnectionTelemetry {
+                connection_id,
+                role,
+            }
+        })
+        .collect()
 }
 
 pub(super) fn record_join_latency(hub: &SessionHub, elapsed: Duration) {

--- a/code/apps/bpane-gateway/src/session_hub/tests.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests.rs
@@ -45,6 +45,17 @@ async fn mock_agent(sock_path: &str) -> tokio::task::JoinHandle<()> {
                                 height: u16::from_le_bytes([frame.payload[3], frame.payload[4]]),
                             };
                             stream.write_all(&ack.to_frame().encode()).await.unwrap();
+                        } else if frame.channel == ChannelId::Tiles {
+                            if let Ok(TileMessage::CacheMiss { col, row, .. }) =
+                                TileMessage::decode(&frame.payload)
+                            {
+                                let fill = TileMessage::Fill {
+                                    col,
+                                    row,
+                                    rgba: 0xFF00_0000,
+                                };
+                                stream.write_all(&fill.to_frame().encode()).await.unwrap();
+                            }
                         }
                     }
                     Ok(None) => break,

--- a/code/apps/bpane-gateway/src/session_hub/tests.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests.rs
@@ -10,6 +10,7 @@ mod lifecycle;
 mod mcp;
 mod ownership;
 mod telemetry;
+mod termination;
 
 async fn mock_agent(sock_path: &str) -> tokio::task::JoinHandle<()> {
     let listener = UnixListener::bind(sock_path).unwrap();

--- a/code/apps/bpane-gateway/src/session_hub/tests/mcp.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/mcp.rs
@@ -1,9 +1,12 @@
 use std::sync::Arc;
 
+use bpane_protocol::frame::Frame;
+
 use super::*;
+use crate::session_hub::ClientHandle;
 
 #[tokio::test]
-async fn mcp_owner_blocks_browser_resize() {
+async fn mcp_owner_preserves_existing_browser_resize_owner() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("test.sock");
     let sock_str = sock.to_str().unwrap();
@@ -17,14 +20,16 @@ async fn mcp_owner_blocks_browser_resize() {
     hub.set_mcp_owner(1920, 1080).await;
     assert!(hub.mcp_is_owner());
 
-    match hub.request_resize(browser.client_id, 800, 600).await {
-        ResizeResult::Locked(width, height) => assert_eq!((width, height), (1920, 1080)),
-        ResizeResult::Applied => panic!("expected Locked when MCP is owner"),
-    }
+    assert!(browser.is_owner);
+    assert!(hub.is_browser_owner(browser.client_id));
+    assert!(matches!(
+        hub.request_resize(browser.client_id, 800, 600).await,
+        ResizeResult::Applied
+    ));
 }
 
 #[tokio::test]
-async fn clear_mcp_owner_restores_normal_behavior() {
+async fn clear_mcp_owner_restores_normal_behavior_after_mcp_seeded_resolution() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("test.sock");
     let sock_str = sock.to_str().unwrap();
@@ -33,18 +38,16 @@ async fn clear_mcp_owner_restores_normal_behavior() {
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
     let hub = Arc::new(SessionHub::new(sock_str, 10, false).await.unwrap());
-    let mut browser = hub.subscribe().await.unwrap();
-
     hub.set_mcp_owner(1920, 1080).await;
+    let mut browser = hub.subscribe().await.unwrap();
+    assert!(browser.is_owner);
     assert_eq!(
-        tokio::time::timeout(std::time::Duration::from_secs(1), browser.control_rx.recv(),)
-            .await
-            .unwrap(),
         Some(ControlMessage::ClientAccessState {
-            flags: ClientAccessFlags::VIEW_ONLY | ClientAccessFlags::RESIZE_LOCKED,
+            flags: ClientAccessFlags::RESIZE_LOCKED,
             width: 1920,
             height: 1080,
-        })
+        }),
+        browser.initial_access_state
     );
 
     hub.clear_mcp_owner().await;
@@ -66,7 +69,7 @@ async fn clear_mcp_owner_restores_normal_behavior() {
 }
 
 #[tokio::test]
-async fn subscriber_under_mcp_is_not_owner() {
+async fn subscriber_under_mcp_remains_interactive_but_resize_locked_when_mcp_connected_first() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("test.sock");
     let sock_str = sock.to_str().unwrap();
@@ -78,13 +81,81 @@ async fn subscriber_under_mcp_is_not_owner() {
     hub.set_mcp_owner(1280, 720).await;
 
     let browser = hub.subscribe().await.unwrap();
-    assert!(!browser.is_owner);
+    assert!(browser.is_owner);
+    assert!(hub.is_browser_owner(browser.client_id));
     assert_eq!(
         browser.initial_access_state,
         Some(ControlMessage::ClientAccessState {
-            flags: ClientAccessFlags::VIEW_ONLY | ClientAccessFlags::RESIZE_LOCKED,
+            flags: ClientAccessFlags::RESIZE_LOCKED,
             width: 1280,
             height: 720,
         })
     );
+    match hub.request_resize(browser.client_id, 800, 600).await {
+        ResizeResult::Locked(width, height) => assert_eq!((width, height), (1280, 720)),
+        ResizeResult::Applied => panic!("expected Locked while MCP controls resolution"),
+    }
+
+    let snapshot = hub.telemetry_snapshot().await;
+    assert!(snapshot.mcp_owner);
+    assert_eq!(snapshot.viewer_clients, 0);
+}
+
+#[tokio::test]
+async fn first_browser_under_mcp_gets_full_repaint_after_lock_state() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = SessionHub::new(sock_str, 10, false).await.unwrap();
+    hub.set_mcp_owner(1280, 720).await;
+    *hub.cached_grid_config.lock().await = Some(Arc::new(
+        TileMessage::GridConfig {
+            tile_size: 64,
+            cols: 2,
+            rows: 1,
+            screen_w: 128,
+            screen_h: 64,
+        }
+        .to_frame(),
+    ));
+
+    let mut browser = hub.subscribe().await.unwrap();
+    assert_eq!(
+        browser.initial_access_state,
+        Some(ControlMessage::ClientAccessState {
+            flags: ClientAccessFlags::RESIZE_LOCKED,
+            width: 1280,
+            height: 720,
+        })
+    );
+
+    let repaint = next_tile_frame(&mut browser).await;
+    assert_eq!(repaint.channel, ChannelId::Tiles);
+    assert!(matches!(
+        TileMessage::decode(&repaint.payload).unwrap(),
+        TileMessage::Fill { .. }
+    ));
+
+    let snapshot = hub.telemetry_snapshot().await;
+    assert_eq!(snapshot.full_refresh_requests, 1);
+    assert_eq!(snapshot.full_refresh_tiles_requested, 2);
+}
+
+async fn next_tile_frame(handle: &mut ClientHandle) -> Arc<Frame> {
+    for _ in 0..4 {
+        let frame =
+            tokio::time::timeout(std::time::Duration::from_secs(1), handle.from_host.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        if frame.channel == ChannelId::Tiles {
+            return frame;
+        }
+    }
+
+    panic!("did not receive a tile repaint frame");
 }

--- a/code/apps/bpane-gateway/src/session_hub/tests/termination.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/termination.rs
@@ -58,3 +58,9 @@ async fn terminate_client_targets_only_the_requested_subscriber() {
         Err(tokio::sync::oneshot::error::TryRecvError::Empty)
     ));
 }
+
+#[test]
+fn disconnect_reason_transitions_to_idle_but_kill_does_not() {
+    assert!(SessionTerminationReason::DisconnectedByOwner.transitions_to_idle());
+    assert!(!SessionTerminationReason::SessionKilled.transitions_to_idle());
+}

--- a/code/apps/bpane-gateway/src/session_hub/tests/termination.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/termination.rs
@@ -1,0 +1,60 @@
+use super::*;
+use crate::session_hub::SessionTerminationReason;
+
+#[tokio::test]
+async fn terminate_all_clients_notifies_live_subscribers() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = SessionHub::new(sock_str, 10, false).await.unwrap();
+    let owner = hub.subscribe().await.unwrap();
+    let collaborator = hub.subscribe().await.unwrap();
+
+    assert_eq!(
+        hub.terminate_all_clients(SessionTerminationReason::SessionKilled)
+            .await,
+        2
+    );
+    assert_eq!(
+        owner.termination_rx.await.unwrap(),
+        SessionTerminationReason::SessionKilled
+    );
+    assert_eq!(
+        collaborator.termination_rx.await.unwrap(),
+        SessionTerminationReason::SessionKilled
+    );
+}
+
+#[tokio::test]
+async fn terminate_client_targets_only_the_requested_subscriber() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = SessionHub::new(sock_str, 10, false).await.unwrap();
+    let mut owner = hub.subscribe().await.unwrap();
+    let collaborator = hub.subscribe().await.unwrap();
+
+    assert!(
+        hub.terminate_client(
+            collaborator.client_id,
+            SessionTerminationReason::SessionKilled
+        )
+        .await
+    );
+    assert_eq!(
+        collaborator.termination_rx.await.unwrap(),
+        SessionTerminationReason::SessionKilled
+    );
+    assert!(matches!(
+        owner.termination_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+    ));
+}

--- a/code/apps/bpane-gateway/src/session_hub/types.rs
+++ b/code/apps/bpane-gateway/src/session_hub/types.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bpane_protocol::frame::Frame;
 use bpane_protocol::ControlMessage;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BrowserClientRole {
@@ -53,6 +53,27 @@ pub struct ClientHandle {
     pub initial_access_state: Option<ControlMessage>,
     /// Direct per-client gateway control updates (promotion, lock changes, etc.).
     pub control_rx: mpsc::Receiver<ControlMessage>,
+    /// One-shot gateway termination signal for this live client transport.
+    pub termination_rx: oneshot::Receiver<SessionTerminationReason>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionTerminationReason {
+    SessionKilled,
+}
+
+impl SessionTerminationReason {
+    pub fn close_reason_bytes(self) -> &'static [u8] {
+        match self {
+            Self::SessionKilled => b"session force killed by owner",
+        }
+    }
+
+    pub fn transitions_to_idle(self) -> bool {
+        match self {
+            Self::SessionKilled => false,
+        }
+    }
 }
 
 /// Result of a resize request.

--- a/code/apps/bpane-gateway/src/session_hub/types.rs
+++ b/code/apps/bpane-gateway/src/session_hub/types.rs
@@ -60,18 +60,21 @@ pub struct ClientHandle {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SessionTerminationReason {
     SessionKilled,
+    DisconnectedByOwner,
 }
 
 impl SessionTerminationReason {
     pub fn close_reason_bytes(self) -> &'static [u8] {
         match self {
             Self::SessionKilled => b"session force killed by owner",
+            Self::DisconnectedByOwner => b"session connection disconnected by owner",
         }
     }
 
     pub fn transitions_to_idle(self) -> bool {
         match self {
             Self::SessionKilled => false,
+            Self::DisconnectedByOwner => true,
         }
     }
 }

--- a/code/apps/bpane-gateway/src/session_manager.rs
+++ b/code/apps/bpane-gateway/src/session_manager.rs
@@ -48,6 +48,15 @@ impl SessionManager {
         self.inner.describe_session_runtime(session_id)
     }
 
+    pub async fn describe_session_runtime_assignment_status(
+        &self,
+        session_id: Uuid,
+    ) -> Option<SessionRuntimeAssignmentStatus> {
+        self.inner
+            .describe_session_runtime_assignment_status(session_id)
+            .await
+    }
+
     pub async fn resolve(&self, session_id: Uuid) -> Result<SessionRuntime, SessionManagerError> {
         self.inner.resolve(session_id).await
     }

--- a/code/apps/bpane-gateway/src/session_registry.rs
+++ b/code/apps/bpane-gateway/src/session_registry.rs
@@ -52,6 +52,34 @@ impl SessionRegistry {
         Some(hub.telemetry_snapshot().await)
     }
 
+    pub fn empty_telemetry_snapshot(&self) -> SessionTelemetrySnapshot {
+        SessionTelemetrySnapshot {
+            browser_clients: 0,
+            viewer_clients: 0,
+            recorder_clients: 0,
+            max_viewers: self.max_viewers,
+            viewer_slots_remaining: self.max_viewers,
+            exclusive_browser_owner: self.exclusive_browser_owner,
+            mcp_owner: false,
+            resolution: (0, 0),
+            joins_accepted: 0,
+            joins_rejected_viewer_cap: 0,
+            last_join_latency_ms: 0,
+            average_join_latency_ms: 0.0,
+            max_join_latency_ms: 0,
+            full_refresh_requests: 0,
+            full_refresh_tiles_requested: 0,
+            last_full_refresh_tiles: 0,
+            max_full_refresh_tiles: 0,
+            egress_send_stream_lock_acquires_total: 0,
+            egress_send_stream_lock_wait_us_total: 0,
+            egress_send_stream_lock_wait_us_average: 0.0,
+            egress_send_stream_lock_wait_us_max: 0,
+            egress_lagged_receives_total: 0,
+            egress_lagged_frames_total: 0,
+        }
+    }
+
     async fn insert_or_get_live_hub(
         &self,
         session_id: Uuid,

--- a/code/apps/bpane-gateway/src/session_registry.rs
+++ b/code/apps/bpane-gateway/src/session_registry.rs
@@ -71,6 +71,7 @@ impl SessionRegistry {
             full_refresh_tiles_requested: 0,
             last_full_refresh_tiles: 0,
             max_full_refresh_tiles: 0,
+            connections: Vec::new(),
             egress_send_stream_lock_acquires_total: 0,
             egress_send_stream_lock_wait_us_total: 0,
             egress_send_stream_lock_wait_us_average: 0.0,
@@ -218,6 +219,48 @@ impl SessionRegistry {
             return 0;
         };
         hub.terminate_all_clients(reason).await
+    }
+
+    pub async fn disconnect_session_client(
+        &self,
+        session_id: Uuid,
+        client_id: u64,
+        reason: SessionTerminationReason,
+    ) -> bool {
+        let Some(hub) = self.lookup_live_hub(session_id).await else {
+            return false;
+        };
+        let terminated = hub.terminate_client(client_id, reason).await;
+        if terminated {
+            hub.unsubscribe(client_id).await;
+        }
+        terminated
+    }
+
+    pub async fn disconnect_all_session_clients(
+        &self,
+        session_id: Uuid,
+        reason: SessionTerminationReason,
+    ) -> usize {
+        let Some(hub) = self.lookup_live_hub(session_id).await else {
+            return 0;
+        };
+
+        let client_ids = hub
+            .telemetry_snapshot()
+            .await
+            .connections
+            .into_iter()
+            .map(|connection| connection.connection_id)
+            .collect::<Vec<_>>();
+        let mut disconnected = 0;
+        for client_id in client_ids {
+            if hub.terminate_client(client_id, reason).await {
+                hub.unsubscribe(client_id).await;
+                disconnected += 1;
+            }
+        }
+        disconnected
     }
 }
 

--- a/code/apps/bpane-gateway/src/session_registry.rs
+++ b/code/apps/bpane-gateway/src/session_registry.rs
@@ -6,7 +6,7 @@ use tracing::{debug, warn};
 use uuid::Uuid;
 
 use crate::session_hub::SessionTelemetrySnapshot;
-use crate::session_hub::{BrowserClientRole, ClientHandle, SessionHub};
+use crate::session_hub::{BrowserClientRole, ClientHandle, SessionHub, SessionTerminationReason};
 
 /// Maps agent socket paths to active SessionHubs.
 ///
@@ -207,6 +207,17 @@ impl SessionRegistry {
         if removed.is_some() {
             debug!(%session_id, "removed session hub from registry");
         }
+    }
+
+    pub async fn terminate_session_clients(
+        &self,
+        session_id: Uuid,
+        reason: SessionTerminationReason,
+    ) -> usize {
+        let Some(hub) = self.lookup_live_hub(session_id).await else {
+            return 0;
+        };
+        hub.terminate_all_clients(reason).await
     }
 }
 

--- a/code/apps/bpane-gateway/src/transport/session_task.rs
+++ b/code/apps/bpane-gateway/src/transport/session_task.rs
@@ -59,6 +59,7 @@ pub(super) async fn handle_session(context: SessionTaskContext) -> anyhow::Resul
     let client_role = client_handle.client_role;
     let initial_access_state = client_handle.initial_access_state;
     let control_rx = client_handle.control_rx;
+    let termination_rx = client_handle.termination_rx;
     let from_host = client_handle.from_host;
     let to_host = client_handle.to_host;
     let initial_frames = client_handle.initial_frames;
@@ -116,6 +117,9 @@ pub(super) async fn handle_session(context: SessionTaskContext) -> anyhow::Resul
         spawn_direct_control_task(session.clone(), send_stream.clone(), control_rx);
 
     let gateway_pinger = spawn_gateway_pinger(session.clone(), send_stream.clone());
+    let mut close_reason: &[u8] = b"session ended";
+    let mut should_transition_to_idle = true;
+    let mut termination_rx = termination_rx;
 
     if recorder_role_suppresses_bitrate_feedback(client_role) {
         tokio::select! {
@@ -123,6 +127,13 @@ pub(super) async fn handle_session(context: SessionTaskContext) -> anyhow::Resul
             _ = browser_to_agent => {}
             _ = direct_control_task => {}
             _ = gateway_pinger => {}
+            reason = &mut termination_rx => {
+                if let Ok(reason) = reason {
+                    close_reason = reason.close_reason_bytes();
+                    should_transition_to_idle = reason.transitions_to_idle();
+                    session.deactivate();
+                }
+            }
         }
     } else {
         let bitrate_hint_task = spawn_bitrate_hint_task(
@@ -138,38 +149,48 @@ pub(super) async fn handle_session(context: SessionTaskContext) -> anyhow::Resul
             _ = direct_control_task => {}
             _ = gateway_pinger => {}
             _ = bitrate_hint_task => {}
+            reason = &mut termination_rx => {
+                if let Ok(reason) = reason {
+                    close_reason = reason.close_reason_bytes();
+                    should_transition_to_idle = reason.transitions_to_idle();
+                    session.deactivate();
+                }
+            }
         }
     }
 
     session.deactivate();
     registry.leave(routed_session_id, client_id).await;
-    if let Some(snapshot) = registry.telemetry_snapshot_if_live(routed_session_id).await {
-        if snapshot.browser_clients == 0 && snapshot.viewer_clients == 0 && !snapshot.mcp_owner {
+    if should_transition_to_idle {
+        if let Some(snapshot) = registry.telemetry_snapshot_if_live(routed_session_id).await {
+            if snapshot.browser_clients == 0 && snapshot.viewer_clients == 0 && !snapshot.mcp_owner
+            {
+                let _ = session_store.mark_session_idle(routed_session_id).await;
+                session_manager.mark_session_idle(routed_session_id).await;
+                schedule_idle_session_stop(
+                    routed_session_id,
+                    idle_stop_timeout,
+                    registry.clone(),
+                    session_store.clone(),
+                    session_manager.clone(),
+                    recording_lifecycle.clone(),
+                );
+            }
+        } else {
             let _ = session_store.mark_session_idle(routed_session_id).await;
             session_manager.mark_session_idle(routed_session_id).await;
             schedule_idle_session_stop(
                 routed_session_id,
                 idle_stop_timeout,
                 registry.clone(),
-                session_store.clone(),
+                session_store,
                 session_manager.clone(),
-                recording_lifecycle.clone(),
+                recording_lifecycle,
             );
         }
-    } else {
-        let _ = session_store.mark_session_idle(routed_session_id).await;
-        session_manager.mark_session_idle(routed_session_id).await;
-        schedule_idle_session_stop(
-            routed_session_id,
-            idle_stop_timeout,
-            registry.clone(),
-            session_store,
-            session_manager.clone(),
-            recording_lifecycle,
-        );
     }
 
-    connection.close(wtransport::VarInt::from_u32(0), b"session ended");
+    connection.close(wtransport::VarInt::from_u32(0), close_reason);
 
     Ok(())
 }

--- a/code/apps/bpane-gateway/tests/compose_api_surface/session_churn.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/session_churn.rs
@@ -68,10 +68,20 @@ pub async fn run(harness: &ComposeHarness) -> Result<()> {
         let stopped_status = harness
             .get_json_outcome(&format!("/api/v1/sessions/{session_id}/status"))
             .await?;
-        if stopped_status.status != StatusCode::CONFLICT {
+        if stopped_status.status != StatusCode::OK {
             return Err(anyhow!(
                 "stopped session status returned unexpected status {} {}",
                 stopped_status.status,
+                stopped_status.body
+            ));
+        }
+        if stopped_status.body["state"] != json!("stopped")
+            || stopped_status.body["runtime_state"] != json!("stopped")
+            || stopped_status.body["presence_state"] != json!("empty")
+            || stopped_status.body["connection_counts"]["total_clients"] != json!(0)
+        {
+            return Err(anyhow!(
+                "stopped session status did not expose the expected lifecycle snapshot: {}",
                 stopped_status.body
             ));
         }

--- a/code/apps/bpane-gateway/tests/compose_api_surface/workflow_run_controls.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/workflow_run_controls.rs
@@ -102,17 +102,18 @@ pub async fn run(harness: &ComposeHarness) -> Result<()> {
         return Err(anyhow!("workflow run log append did not persist"));
     }
 
-    let mut upload_headers = Vec::new();
-    upload_headers.push((
-        "x-bpane-workflow-workspace-id",
-        output_workspace_id.as_str(),
-    ));
-    upload_headers.push(("x-bpane-file-name", "compose-e2e-produced.txt"));
-    upload_headers.push((
-        "x-bpane-file-provenance",
-        "{\"origin\":\"bpane-gateway-compose-e2e\",\"kind\":\"produced_file\"}",
-    ));
-    upload_headers.push(("x-bpane-automation-access-token", automation_token.as_str()));
+    let upload_headers = vec![
+        (
+            "x-bpane-workflow-workspace-id",
+            output_workspace_id.as_str(),
+        ),
+        ("x-bpane-file-name", "compose-e2e-produced.txt"),
+        (
+            "x-bpane-file-provenance",
+            "{\"origin\":\"bpane-gateway-compose-e2e\",\"kind\":\"produced_file\"}",
+        ),
+        ("x-bpane-automation-access-token", automation_token.as_str()),
+    ];
     let uploaded_file = harness
         .post_bytes(
             &format!("/api/v1/workflow-runs/{controlled_run_id}/produced-files"),

--- a/code/apps/bpane-host/src/cdp_video.rs
+++ b/code/apps/bpane-host/src/cdp_video.rs
@@ -63,6 +63,10 @@ pub struct PageHintState {
     pub scroll_delta_y: i32,
     pub visible: bool,
     pub focused: bool,
+    /// Multiple CDP page targets reported themselves as visible and focused.
+    /// In that state we can still use the hint for visual classification, but
+    /// input must fall back to the real browser window instead of one target.
+    pub focus_ambiguous: bool,
     pub update_seq: u64,
 }
 
@@ -78,6 +82,7 @@ impl Default for PageHintState {
             scroll_delta_y: 0,
             visible: false,
             focused: false,
+            focus_ambiguous: false,
             update_seq: 0,
         }
     }
@@ -197,7 +202,7 @@ impl BrowserCdpHandle {
 }
 
 fn can_dispatch_direct_wheel(hint: &PageHintState) -> bool {
-    hint.visible && hint.focused
+    hint.visible && hint.focused && !hint.focus_ambiguous
 }
 
 fn should_switch_to_focused_target(
@@ -873,6 +878,21 @@ pub fn spawn_video_hint_task(shared: Arc<Mutex<PageHintState>>) -> BrowserCdpHan
                 continue;
             }
 
+            if let Some(active_url) = current_active_page_target_url(&http, debug_port).await {
+                if ws_url.as_deref() != Some(active_url.as_str()) {
+                    debug!(
+                        from_target = ws_url.as_deref().unwrap_or("<unknown>"),
+                        to_target = %active_url,
+                        "cdp switching to active page target"
+                    );
+                    ws_stream = None;
+                    prefetched_hint = None;
+                    force_target_refresh = true;
+                    set_shared_state(&shared, PageHintState::default());
+                    continue;
+                }
+            }
+
             let Some(mut hint) = (match prefetched_hint.take() {
                 Some(hint) => Some(hint),
                 None => evaluate_page_hint(stream, &video_probe_js, &mut request_id).await,
@@ -996,6 +1016,11 @@ async fn fetch_targets(http: &reqwest::Client, port: u16) -> Option<Vec<DevTools
         .ok()
 }
 
+async fn current_active_page_target_url(http: &reqwest::Client, port: u16) -> Option<String> {
+    let targets = fetch_targets(http, port).await?;
+    active_page_target_url(&targets).map(str::to_string)
+}
+
 fn score_target(target: &DevToolsTarget) -> i32 {
     let mut score = 0i32;
     match target.target_type.as_str() {
@@ -1058,10 +1083,22 @@ fn is_ignored_target(target: &DevToolsTarget) -> bool {
     title == "devtools" || title.starts_with("devtools -")
 }
 
+fn active_page_target_url(targets: &[DevToolsTarget]) -> Option<&str> {
+    targets
+        .iter()
+        .find(|target| {
+            target.target_type == "page"
+                && target.web_socket_debugger_url.is_some()
+                && !is_ignored_target(target)
+        })
+        .and_then(|target| target.web_socket_debugger_url.as_deref())
+}
+
 fn ordered_target_candidates<'a>(
     targets: &'a [DevToolsTarget],
     current_ws_url: Option<&str>,
 ) -> Vec<&'a DevToolsTarget> {
+    let active_ws_url = active_page_target_url(targets);
     let mut candidates: Vec<(usize, &DevToolsTarget)> = targets
         .iter()
         .enumerate()
@@ -1071,19 +1108,46 @@ fn ordered_target_candidates<'a>(
         .collect();
 
     candidates.sort_by(|(left_idx, left), (right_idx, right)| {
+        let left_active = active_ws_url
+            .map(|url| left.web_socket_debugger_url.as_deref() == Some(url))
+            .unwrap_or(false);
+        let right_active = active_ws_url
+            .map(|url| right.web_socket_debugger_url.as_deref() == Some(url))
+            .unwrap_or(false);
         let left_current = current_ws_url
             .map(|url| left.web_socket_debugger_url.as_deref() == Some(url))
             .unwrap_or(false);
         let right_current = current_ws_url
             .map(|url| right.web_socket_debugger_url.as_deref() == Some(url))
             .unwrap_or(false);
-        right_current
-            .cmp(&left_current)
+        right_active
+            .cmp(&left_active)
+            .then_with(|| right_current.cmp(&left_current))
             .then_with(|| score_target(right).cmp(&score_target(left)))
             .then_with(|| left_idx.cmp(right_idx))
     });
 
     candidates.into_iter().map(|(_, target)| target).collect()
+}
+
+fn selected_focus_is_ambiguous(
+    focused_count: usize,
+    active_ws_url: Option<&str>,
+    selected_url: &str,
+) -> bool {
+    focused_count > 1 && active_ws_url != Some(selected_url)
+}
+
+fn visible_fallback_focus_is_ambiguous(active_ws_url: Option<&str>, selected_url: &str) -> bool {
+    active_ws_url.is_some() && active_ws_url != Some(selected_url)
+}
+
+struct CandidateStream {
+    url: String,
+    stream: CdpWsStream,
+    hint: PageHintState,
+    title: String,
+    url_hint: String,
 }
 
 async fn connect_visible_target_stream(
@@ -1094,8 +1158,10 @@ async fn connect_visible_target_stream(
     request_id: &mut u64,
 ) -> Option<(String, CdpWsStream, PageHintState)> {
     let targets = fetch_targets(http, port).await?;
+    let active_ws_url = active_page_target_url(&targets).map(str::to_string);
     let candidates = ordered_target_candidates(&targets, current_ws_url);
-    let mut visible_fallback: Option<(String, CdpWsStream, PageHintState, String, String)> = None;
+    let mut focused_candidates: Vec<CandidateStream> = Vec::new();
+    let mut visible_fallback: Option<CandidateStream> = None;
 
     for target in candidates {
         let Some(url) = target.web_socket_debugger_url.as_deref() else {
@@ -1120,24 +1186,70 @@ async fn connect_visible_target_stream(
             continue;
         }
         if hint.focused {
-            debug!(
-                target = %url,
-                focused = hint.focused,
-                title = title,
-                url_hint = url_hint,
-                "cdp selected focused target"
-            );
-            return Some((url.to_string(), stream, hint));
+            focused_candidates.push(CandidateStream {
+                url: url.to_string(),
+                stream,
+                hint,
+                title,
+                url_hint,
+            });
+            continue;
         }
         if visible_fallback.is_none() {
-            visible_fallback = Some((url.to_string(), stream, hint, title, url_hint));
+            visible_fallback = Some(CandidateStream {
+                url: url.to_string(),
+                stream,
+                hint,
+                title,
+                url_hint,
+            });
         }
     }
 
-    if let Some((url, stream, hint, title, url_hint)) = visible_fallback {
+    if !focused_candidates.is_empty() {
+        let focused_count = focused_candidates.len();
+        let selected_idx = focused_candidates
+            .iter()
+            .position(|candidate| active_ws_url.as_deref() == Some(candidate.url.as_str()))
+            .or_else(|| {
+                focused_candidates
+                    .iter()
+                    .position(|candidate| current_ws_url == Some(candidate.url.as_str()))
+            })
+            .unwrap_or(0);
+        let CandidateStream {
+            url,
+            stream,
+            mut hint,
+            title,
+            url_hint,
+        } = focused_candidates.swap_remove(selected_idx);
+        hint.focus_ambiguous =
+            selected_focus_is_ambiguous(focused_count, active_ws_url.as_deref(), &url);
         debug!(
             target = %url,
             focused = hint.focused,
+            focus_ambiguous = hint.focus_ambiguous,
+            title = title,
+            url_hint = url_hint,
+            "cdp selected focused target"
+        );
+        return Some((url, stream, hint));
+    }
+
+    if let Some(CandidateStream {
+        url,
+        stream,
+        mut hint,
+        title,
+        url_hint,
+    }) = visible_fallback
+    {
+        hint.focus_ambiguous = visible_fallback_focus_is_ambiguous(active_ws_url.as_deref(), &url);
+        debug!(
+            target = %url,
+            focused = hint.focused,
+            focus_ambiguous = hint.focus_ambiguous,
             title = title,
             url_hint = url_hint,
             "cdp selected visible fallback target"
@@ -1577,6 +1689,10 @@ fn parse_page_hint(raw: &Value) -> PageHintState {
             .unwrap_or(0);
         let visible = obj.get("visible").and_then(parse_bool).unwrap_or(false);
         let focused = obj.get("focused").and_then(parse_bool).unwrap_or(false);
+        let focus_ambiguous = obj
+            .get("focusAmbiguous")
+            .and_then(parse_bool)
+            .unwrap_or(false);
         let video_region = obj
             .get("region")
             .and_then(|value| parse_region(value, region_kind))
@@ -1593,6 +1709,7 @@ fn parse_page_hint(raw: &Value) -> PageHintState {
             scroll_delta_y,
             visible,
             focused,
+            focus_ambiguous,
             update_seq: 0,
         };
     }
@@ -1895,7 +2012,7 @@ async fn handle_text_command(
         Ok(g) => *g,
         Err(poisoned) => *poisoned.into_inner(),
     };
-    if !hint.visible || !hint.focused {
+    if !hint.visible || !hint.focused || hint.focus_ambiguous {
         let _ = cmd.response.send(false);
         return true;
     }
@@ -2472,6 +2589,95 @@ mod tests {
     }
 
     #[test]
+    fn active_page_target_url_uses_first_visible_page_target() {
+        let targets = vec![
+            DevToolsTarget {
+                target_type: "page".to_string(),
+                url: Some("https://example.test/one".to_string()),
+                title: Some("One".to_string()),
+                web_socket_debugger_url: Some("ws://127.0.0.1:9222/devtools/page/one".to_string()),
+            },
+            DevToolsTarget {
+                target_type: "page".to_string(),
+                url: Some("https://example.test/two".to_string()),
+                title: Some("Two".to_string()),
+                web_socket_debugger_url: Some("ws://127.0.0.1:9222/devtools/page/two".to_string()),
+            },
+        ];
+
+        assert_eq!(
+            active_page_target_url(&targets),
+            Some("ws://127.0.0.1:9222/devtools/page/one")
+        );
+    }
+
+    #[test]
+    fn active_page_target_url_ignores_non_page_targets() {
+        let targets = vec![
+            DevToolsTarget {
+                target_type: "iframe".to_string(),
+                url: Some("https://example.test/frame".to_string()),
+                title: Some("Frame".to_string()),
+                web_socket_debugger_url: Some(
+                    "ws://127.0.0.1:9222/devtools/page/frame".to_string(),
+                ),
+            },
+            DevToolsTarget {
+                target_type: "service_worker".to_string(),
+                url: Some("chrome-extension://example/background.js".to_string()),
+                title: Some("Service Worker".to_string()),
+                web_socket_debugger_url: Some("ws://127.0.0.1:9222/devtools/page/sw".to_string()),
+            },
+        ];
+
+        assert_eq!(active_page_target_url(&targets), None);
+    }
+
+    #[test]
+    fn ordered_target_candidates_prefer_active_page_over_current_target() {
+        let targets = vec![
+            DevToolsTarget {
+                target_type: "page".to_string(),
+                url: Some("https://example.test/active".to_string()),
+                title: Some("Active".to_string()),
+                web_socket_debugger_url: Some(
+                    "ws://127.0.0.1:9222/devtools/page/active".to_string(),
+                ),
+            },
+            DevToolsTarget {
+                target_type: "page".to_string(),
+                url: Some("https://www.youtube.com/watch?v=abc123".to_string()),
+                title: Some("Example Video - YouTube".to_string()),
+                web_socket_debugger_url: Some(
+                    "ws://127.0.0.1:9222/devtools/page/current".to_string(),
+                ),
+            },
+        ];
+
+        let ordered =
+            ordered_target_candidates(&targets, Some("ws://127.0.0.1:9222/devtools/page/current"));
+
+        assert_eq!(
+            ordered[0].web_socket_debugger_url.as_deref(),
+            Some("ws://127.0.0.1:9222/devtools/page/active")
+        );
+    }
+
+    #[test]
+    fn selected_focus_is_not_ambiguous_when_active_target_matches() {
+        assert!(!selected_focus_is_ambiguous(
+            3,
+            Some("ws://127.0.0.1:9222/devtools/page/active"),
+            "ws://127.0.0.1:9222/devtools/page/active",
+        ));
+        assert!(selected_focus_is_ambiguous(
+            3,
+            Some("ws://127.0.0.1:9222/devtools/page/active"),
+            "ws://127.0.0.1:9222/devtools/page/other",
+        ));
+    }
+
+    #[test]
     fn direct_wheel_dispatch_requires_focused_visible_target() {
         let mut hint = PageHintState {
             visible: true,
@@ -2485,6 +2691,10 @@ mod tests {
 
         hint.visible = false;
         hint.focused = true;
+        assert!(!can_dispatch_direct_wheel(&hint));
+
+        hint.visible = true;
+        hint.focus_ambiguous = true;
         assert!(!can_dispatch_direct_wheel(&hint));
     }
 

--- a/code/apps/bpane-host/src/message_dispatch/mod.rs
+++ b/code/apps/bpane-host/src/message_dispatch/mod.rs
@@ -128,7 +128,11 @@ pub async fn run(
                                 }
                                 if injected_via_cdp {
                                     trace!("input injected via cdp: {:?}", input_msg);
-                                } else if let Err(e) = input_backend.inject(&input_msg) {
+                                } else if let Err(e) = inject_via_backend(
+                                    input_backend.as_mut(),
+                                    &input_msg,
+                                    last_mouse_pos,
+                                ) {
                                     warn!("input inject failed: {e}");
                                 } else {
                                     trace!("input injected: {:?}", input_msg);
@@ -191,6 +195,19 @@ pub async fn run(
 
     download_watch_task.abort();
     result
+}
+
+fn inject_via_backend(
+    input_backend: &mut dyn InputBackend,
+    input_msg: &bpane_protocol::InputMessage,
+    last_mouse_pos: Option<(u16, u16)>,
+) -> anyhow::Result<()> {
+    if matches!(input_msg, bpane_protocol::InputMessage::MouseScroll { .. }) {
+        if let Some((x, y)) = last_mouse_pos {
+            input_backend.inject(&bpane_protocol::InputMessage::MouseMove { x, y })?;
+        }
+    }
+    input_backend.inject(input_msg)
 }
 
 /// Handle control messages in FFmpeg session mode.

--- a/code/apps/bpane-host/src/message_dispatch/tests.rs
+++ b/code/apps/bpane-host/src/message_dispatch/tests.rs
@@ -1,9 +1,9 @@
 use tokio::sync::mpsc;
 
 use bpane_protocol::frame::Message;
-use bpane_protocol::{ClipboardMessage, ControlMessage, SessionFlags};
+use bpane_protocol::{ClipboardMessage, ControlMessage, InputMessage, SessionFlags};
 
-use crate::capture;
+use crate::{capture, input::TestInputBackend};
 
 #[tokio::test]
 async fn handle_control_ffmpeg_bitrate_hint() {
@@ -107,4 +107,23 @@ fn clipboard_frame_empty_text() {
         decoded,
         Message::Clipboard(ClipboardMessage::Text { content }) if content.is_empty()
     ));
+}
+
+#[test]
+fn xtest_scroll_replays_last_pointer_position_before_wheel() {
+    let mut backend = TestInputBackend::default();
+    super::inject_via_backend(
+        &mut backend,
+        &InputMessage::MouseScroll { dx: 0, dy: -1 },
+        Some((320, 240)),
+    )
+    .unwrap();
+
+    assert_eq!(
+        backend.events,
+        vec![
+            InputMessage::MouseMove { x: 320, y: 240 },
+            InputMessage::MouseScroll { dx: 0, dy: -1 },
+        ]
+    );
 }

--- a/code/integrations/mcp-bridge/src/index.ts
+++ b/code/integrations/mcp-bridge/src/index.ts
@@ -2,13 +2,18 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import {
   CallToolRequestSchema,
+  isInitializeRequest,
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
   ListPromptsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+import { lookup } from "node:dns/promises";
 import http from "node:http";
+import { isIP } from "node:net";
 import {
   GatewaySessionAutomationAccessResponse,
   GatewaySessionResource,
@@ -55,6 +60,32 @@ async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
     throw new Error("request body is required");
   }
   return JSON.parse(raw) as T;
+}
+
+function singleHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function writeJsonRpcError(
+  res: http.ServerResponse,
+  statusCode: number,
+  message: string,
+  code = -32000,
+): void {
+  if (res.headersSent) {
+    return;
+  }
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code,
+        message,
+      },
+      id: null,
+    }),
+  );
 }
 
 class GatewayTokenManager {
@@ -237,6 +268,26 @@ function describeManagedCdpEndpoint(
   }
 }
 
+function isChromiumDevToolsSafeHostname(hostname: string): boolean {
+  return (
+    hostname === "localhost"
+    || hostname === "127.0.0.1"
+    || hostname === "::1"
+    || isIP(hostname) !== 0
+  );
+}
+
+async function resolveChromiumDevToolsEndpoint(cdpEndpoint: string): Promise<string> {
+  const url = new URL(cdpEndpoint);
+  if (isChromiumDevToolsSafeHostname(url.hostname)) {
+    return cdpEndpoint;
+  }
+
+  const resolved = await lookup(url.hostname, { family: 4 });
+  url.hostname = resolved.address;
+  return url.toString();
+}
+
 async function gatewaySessionHeaders(
   session: GatewaySessionResource | null,
   automationAccessManager: SessionAutomationAccessManager,
@@ -277,6 +328,12 @@ async function registerMcpOwner(
         const sessionSuffix = session ? ` for session ${session.id}` : "";
         console.log(
           `[mcp-bridge] registered as MCP owner${sessionSuffix} at ${width}x${height}`,
+        );
+        return;
+      }
+      if (!session && resp.status === 404) {
+        console.warn(
+          "[mcp-bridge] legacy MCP owner route is unavailable; continuing with fallback CDP endpoint",
         );
         return;
       }
@@ -321,7 +378,8 @@ function spawnPlaywrightMcp(cdpEndpoint: string): StdioClientTransport {
 
 class PlaywrightRuntimeController {
   private client: Client | null = null;
-  private cdpEndpoint: string | null = null;
+  private requestedCdpEndpoint: string | null = null;
+  private effectiveCdpEndpoint: string | null = null;
 
   async ensureConnected(
     session: GatewaySessionResource | null,
@@ -329,24 +387,29 @@ class PlaywrightRuntimeController {
   ): Promise<Client> {
     const access = await automationAccessManager.get(session);
     const nextEndpoint = resolveManagedCdpEndpoint(session, access);
-    if (this.client && this.cdpEndpoint === nextEndpoint) {
+    if (this.client && this.requestedCdpEndpoint === nextEndpoint) {
       return this.client;
     }
 
     await this.close();
 
-    const transport = spawnPlaywrightMcp(nextEndpoint);
+    const effectiveEndpoint = await resolveChromiumDevToolsEndpoint(nextEndpoint);
+    const transport = spawnPlaywrightMcp(effectiveEndpoint);
     const client = new Client(
       { name: "bpane-mcp-bridge", version: "0.1.0" },
       { capabilities: {} },
     );
     await client.connect(transport);
     this.client = client;
-    this.cdpEndpoint = nextEndpoint;
+    this.requestedCdpEndpoint = nextEndpoint;
+    this.effectiveCdpEndpoint = effectiveEndpoint;
 
     const sessionSuffix = session ? ` for session ${session.id}` : "";
+    const endpointSuffix = effectiveEndpoint === nextEndpoint
+      ? nextEndpoint
+      : `${nextEndpoint} (resolved to ${effectiveEndpoint})`;
     console.log(
-      `[mcp-bridge] connected to @playwright/mcp subprocess${sessionSuffix} via ${nextEndpoint}`,
+      `[mcp-bridge] connected to @playwright/mcp subprocess${sessionSuffix} via ${endpointSuffix}`,
     );
 
     return client;
@@ -354,14 +417,16 @@ class PlaywrightRuntimeController {
 
   async close(): Promise<void> {
     if (!this.client) {
-      this.cdpEndpoint = null;
+      this.requestedCdpEndpoint = null;
+      this.effectiveCdpEndpoint = null;
       return;
     }
 
     const client = this.client;
-    const previousEndpoint = this.cdpEndpoint;
+    const previousEndpoint = this.requestedCdpEndpoint;
     this.client = null;
-    this.cdpEndpoint = null;
+    this.requestedCdpEndpoint = null;
+    this.effectiveCdpEndpoint = null;
 
     try {
       await client.close();
@@ -376,7 +441,11 @@ class PlaywrightRuntimeController {
   }
 
   getCurrentEndpoint(): string | null {
-    return this.cdpEndpoint;
+    return this.requestedCdpEndpoint;
+  }
+
+  getEffectiveEndpoint(): string | null {
+    return this.effectiveCdpEndpoint;
   }
 }
 
@@ -510,13 +579,116 @@ async function main() {
   //    Each SSE connection gets its own Server instance to avoid the
   //    "Already connected to a transport" error.
   const transports = new Map<string, SSEServerTransport>();
+  const streamableTransports = new Map<string, StreamableHTTPServerTransport>();
   const servers = new Map<string, Server>();
+
+  async function releaseOwnershipIfIdle(): Promise<void> {
+    if (servers.size > 0) {
+      return;
+    }
+    console.log("[mcp-bridge] no MCP clients remaining — clearing ownership");
+    await unregisterMcpOwner(managedSession, automationAccessManager);
+    await playwrightRuntime.close();
+  }
+
+  async function handleStreamableHttpRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    let parsedBody: unknown | undefined;
+    if (req.method === "POST") {
+      try {
+        parsedBody = await readJsonBody<unknown>(req);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        writeJsonRpcError(res, 400, `Parse error: ${message}`, -32700);
+        return;
+      }
+    }
+
+    const requestedSessionId = singleHeader(req.headers["mcp-session-id"]);
+    if (requestedSessionId) {
+      const transport = streamableTransports.get(requestedSessionId);
+      if (!transport) {
+        writeJsonRpcError(res, 404, "Session not found", -32001);
+        return;
+      }
+      await transport.handleRequest(req, res, parsedBody);
+      return;
+    }
+
+    if (req.method !== "POST" || !isInitializeRequest(parsedBody)) {
+      writeJsonRpcError(res, 400, "Bad Request: No valid session ID provided");
+      return;
+    }
+
+    const needsBridgeBootstrap = servers.size === 0;
+    let sessionId: string | null = null;
+    let server: Server | null = null;
+    let transport: StreamableHTTPServerTransport | null = null;
+    try {
+      if (needsBridgeBootstrap) {
+        await registerMcpOwner(managedSession, automationAccessManager, width, height);
+      }
+      const playwrightClient = await playwrightRuntime.ensureConnected(
+        managedSession,
+        automationAccessManager,
+      );
+
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (initializedSessionId) => {
+          sessionId = initializedSessionId;
+          if (transport && server) {
+            streamableTransports.set(initializedSessionId, transport);
+            servers.set(initializedSessionId, server);
+          }
+          console.log(
+            `[mcp-bridge] MCP client connected (session=${initializedSessionId}, transport=streamable_http, total=${servers.size}, cdp=${playwrightRuntime.getCurrentEndpoint() ?? "unknown"})`,
+          );
+        },
+      });
+      server = createServerForConnection(playwrightClient, monitor);
+      server.onclose = () => {
+        const closedSessionId = sessionId ?? transport?.sessionId;
+        if (closedSessionId) {
+          streamableTransports.delete(closedSessionId);
+          servers.delete(closedSessionId);
+          console.log(
+            `[mcp-bridge] MCP client disconnected (session=${closedSessionId}, transport=streamable_http, remaining=${servers.size})`,
+          );
+          void releaseOwnershipIfIdle();
+        }
+      };
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, parsedBody);
+    } catch (error) {
+      if (sessionId) {
+        streamableTransports.delete(sessionId);
+        servers.delete(sessionId);
+      }
+      try {
+        await server?.close();
+      } catch {
+        // ignore cleanup failures after a failed streamable HTTP request
+      }
+      if (needsBridgeBootstrap) {
+        await releaseOwnershipIfIdle();
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      writeJsonRpcError(res, 503, message, -32603);
+    }
+  }
 
   const httpServer = http.createServer(async (req, res) => {
     // CORS headers
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.setHeader(
+      "Access-Control-Allow-Headers",
+      "Accept, Content-Type, Authorization, Mcp-Protocol-Version, Mcp-Session-Id",
+    );
 
     if (req.method === "OPTIONS") {
       res.writeHead(204);
@@ -543,6 +715,7 @@ async function main() {
             automationAccessManager.getCached(managedSession),
           ),
           playwright_cdp_endpoint: playwrightRuntime.getCurrentEndpoint(),
+          playwright_effective_cdp_endpoint: playwrightRuntime.getEffectiveEndpoint(),
         }),
       );
       return;
@@ -559,6 +732,7 @@ async function main() {
             automationAccessManager.getCached(managedSession),
           ),
           playwright_cdp_endpoint: playwrightRuntime.getCurrentEndpoint(),
+          playwright_effective_cdp_endpoint: playwrightRuntime.getEffectiveEndpoint(),
         }),
       );
       return;
@@ -634,6 +808,11 @@ async function main() {
       return;
     }
 
+    if (url.pathname === "/mcp") {
+      await handleStreamableHttpRequest(req, res);
+      return;
+    }
+
     if (url.pathname === "/sse") {
       const needsBridgeBootstrap = servers.size === 0;
       try {
@@ -702,6 +881,7 @@ async function main() {
           JSON.stringify({
             ok: true,
             cdp_endpoint: playwrightRuntime.getCurrentEndpoint(),
+            effective_cdp_endpoint: playwrightRuntime.getEffectiveEndpoint(),
           }),
         );
       } catch (error) {
@@ -718,6 +898,7 @@ async function main() {
 
   httpServer.listen(MCP_PORT, "0.0.0.0", () => {
     console.log(`[mcp-bridge] MCP server listening on port ${MCP_PORT}`);
+    console.log(`[mcp-bridge] Streamable HTTP endpoint: http://0.0.0.0:${MCP_PORT}/mcp`);
     console.log(`[mcp-bridge] SSE endpoint: http://0.0.0.0:${MCP_PORT}/sse`);
     console.log(`[mcp-bridge] Health: http://0.0.0.0:${MCP_PORT}/health`);
     console.log(`[mcp-bridge] Supervised delay: ${SUPERVISED_DELAY_MS}ms when viewers present`);

--- a/code/web/bpane-client/js/__tests__/input-controller.test.ts
+++ b/code/web/bpane-client/js/__tests__/input-controller.test.ts
@@ -139,6 +139,8 @@ function dispatchPointer(
 function dispatchWheel(
   target: HTMLElement,
   init: {
+    clientX?: number;
+    clientY?: number;
     deltaX?: number;
     deltaY: number;
     deltaMode?: number;
@@ -149,6 +151,8 @@ function dispatchWheel(
     cancelable: true,
   });
   Object.defineProperties(event, {
+    clientX: { configurable: true, value: init.clientX ?? 0 },
+    clientY: { configurable: true, value: init.clientY ?? 0 },
     deltaX: { configurable: true, value: init.deltaX ?? 0 },
     deltaY: { configurable: true, value: init.deltaY },
     deltaMode: { configurable: true, value: init.deltaMode ?? 0 },
@@ -343,8 +347,8 @@ describe('InputController pointer and scroll handling', () => {
       clientY: 175,
       button: 2,
     });
-    const firstWheel = dispatchWheel(canvas, { deltaY: 30 });
-    const secondWheel = dispatchWheel(canvas, { deltaY: 30 });
+    const firstWheel = dispatchWheel(canvas, { clientX: 150, clientY: 175, deltaY: 30 });
+    const secondWheel = dispatchWheel(canvas, { clientX: 150, clientY: 175, deltaY: 30 });
     const contextMenu = new Event('contextmenu', {
       bubbles: true,
       cancelable: true,
@@ -386,6 +390,11 @@ describe('InputController pointer and scroll handling', () => {
       dx: 0,
       dy: -1,
     });
+
+    const moveFrames = sentFrames.filter(({ payload }) => payload[0] === 0x01);
+    expect(moveFrames.map(decodeMouseMoveFrame)).toEqual([
+      { x: 400, y: 300 },
+    ]);
   });
 });
 

--- a/code/web/bpane-client/js/__tests__/pointer-input-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/pointer-input-runtime.test.ts
@@ -26,6 +26,8 @@ function dispatchPointer(
 function dispatchWheel(
   target: HTMLElement,
   init: {
+    clientX?: number;
+    clientY?: number;
     deltaX?: number;
     deltaY: number;
     deltaMode?: number;
@@ -36,6 +38,8 @@ function dispatchWheel(
     cancelable: true,
   });
   Object.defineProperties(event, {
+    clientX: { configurable: true, value: init.clientX ?? 0 },
+    clientY: { configurable: true, value: init.clientY ?? 0 },
     deltaX: { configurable: true, value: init.deltaX ?? 0 },
     deltaY: { configurable: true, value: init.deltaY },
     deltaMode: { configurable: true, value: init.deltaMode ?? 0 },
@@ -113,6 +117,7 @@ describe('PointerInputRuntime', () => {
   it('sends pointer buttons, accumulates wheel deltas, and focuses the keyboard target on click', () => {
     const canvas = document.createElement('canvas');
     const sendMouseButton = vi.fn();
+    const sendMouseMove = vi.fn();
     const sendScroll = vi.fn();
     const focusKeyboardTarget = vi.fn();
     setCanvasRect(canvas, {
@@ -126,7 +131,7 @@ describe('PointerInputRuntime', () => {
       canvas,
       drawCursor: vi.fn(),
       getRemoteDims: () => ({ width: 800, height: 600 }),
-      sendMouseMove: vi.fn(),
+      sendMouseMove,
       sendMouseButton,
       sendScroll,
       now: () => 100,
@@ -146,8 +151,8 @@ describe('PointerInputRuntime', () => {
       clientY: 175,
       button: 2,
     });
-    const firstWheel = dispatchWheel(canvas, { deltaY: 30 });
-    const secondWheel = dispatchWheel(canvas, { deltaY: 30 });
+    const firstWheel = dispatchWheel(canvas, { clientX: 150, clientY: 175, deltaY: 30 });
+    const secondWheel = dispatchWheel(canvas, { clientX: 150, clientY: 175, deltaY: 30 });
     const contextMenu = new Event('contextmenu', {
       bubbles: true,
       cancelable: true,
@@ -166,6 +171,9 @@ describe('PointerInputRuntime', () => {
     expect(sendMouseButton.mock.calls).toEqual([
       [2, true, 400, 300],
       [2, false, 400, 300],
+    ]);
+    expect(sendMouseMove.mock.calls).toEqual([
+      [400, 300],
     ]);
     expect(sendScroll.mock.calls).toEqual([
       [0, -1],
@@ -199,17 +207,18 @@ describe('PointerInputRuntime', () => {
       focusKeyboardTarget: vi.fn(),
     });
 
-    dispatchWheel(canvas, { deltaY: 30 });
+    dispatchWheel(canvas, { clientX: 5, clientY: 5, deltaY: 30 });
     dispatchPointer(canvas, 'pointermove', { clientX: 10, clientY: 10 });
     runtime.reset();
     now = 110;
     dispatchPointer(canvas, 'pointermove', { clientX: 20, clientY: 20 });
-    dispatchWheel(canvas, { deltaY: 30 });
-    dispatchWheel(canvas, { deltaY: 30 });
+    dispatchWheel(canvas, { clientX: 30, clientY: 40, deltaY: 30 });
+    dispatchWheel(canvas, { clientX: 30, clientY: 40, deltaY: 30 });
 
     expect(sendMouseMove.mock.calls).toEqual([
       [10, 10],
       [20, 20],
+      [30, 40],
     ]);
     expect(sendScroll.mock.calls).toEqual([
       [0, -1],

--- a/code/web/bpane-client/js/input/pointer-input-runtime.ts
+++ b/code/web/bpane-client/js/input/pointer-input-runtime.ts
@@ -73,6 +73,9 @@ export class PointerInputRuntime {
         this.scrollState,
       );
       if (dx || dy) {
+        const { x, y } = this.resolveCanvasPoint(event.clientX, event.clientY);
+        this.drawCursor(null, x, y);
+        this.sendMouseMoveFn(x, y);
         this.sendScrollFn(dx, dy);
       }
     }, { passive: false, signal: input.signal });

--- a/code/web/bpane-client/package.json
+++ b/code/web/bpane-client/package.json
@@ -12,6 +12,7 @@
     "smoke:automation-tasks": "node scripts/run-automation-task-smoke.mjs",
     "smoke:file-workspaces": "node scripts/run-file-workspace-smoke.mjs",
     "smoke:recording": "node scripts/run-recording-smoke.mjs",
+    "smoke:test-embed-lifecycle": "node scripts/run-test-embed-lifecycle-smoke.mjs",
     "smoke:test-embed-overlay": "node scripts/run-test-embed-overlay-smoke.mjs",
     "smoke:workflows": "node scripts/run-workflow-smoke.mjs",
     "smoke:workflow-cancel": "node scripts/run-workflow-cancel-smoke.mjs",

--- a/code/web/bpane-client/scripts/run-test-embed-lifecycle-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-test-embed-lifecycle-smoke.mjs
@@ -1,0 +1,175 @@
+import fs from 'node:fs/promises';
+import process from 'node:process';
+import { chromium } from 'playwright-core';
+import {
+  cleanupWorkflowSmokeSessions,
+  createLogger,
+  fetchAuthConfig,
+  getAccessToken,
+  launchChrome,
+  parseSmokeArgs,
+  poll,
+} from './workflow-smoke-lib.mjs';
+
+async function configureEmbedPage(page, options) {
+  await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => Boolean(window.__bpaneAuth && window.__bpaneControl),
+    { timeout: options.connectTimeoutMs },
+  );
+}
+
+async function ensureEmbedLoggedIn(page, options) {
+  const authConfig = await fetchAuthConfig(options);
+  if (!authConfig || authConfig.mode !== 'oidc') {
+    return authConfig;
+  }
+
+  const state = await page.evaluate(() => ({
+    configured: window.__bpaneAuth?.isConfigured?.() ?? false,
+    authenticated: window.__bpaneAuth?.isAuthenticated?.() ?? false,
+    exampleUser: window.__bpaneAuth?.getExampleUser?.() ?? null,
+  }));
+  if (!state.configured || state.authenticated) {
+    return authConfig;
+  }
+
+  const exampleUser = state.exampleUser;
+  if (!exampleUser?.username || !exampleUser?.password) {
+    throw new Error('OIDC auth is enabled, but no example user is configured for smoke login.');
+  }
+
+  await page.locator('#btn-login').click();
+  const username = page.locator('input[name="username"], #username').first();
+  const password = page.locator('input[name="password"], #password').first();
+  const loginState = await poll(
+    'OIDC login readiness',
+    async () => ({
+      authenticated: await page
+        .evaluate(() => window.__bpaneAuth?.isAuthenticated?.() === true)
+        .catch(() => false),
+      usernameVisible: await username.isVisible().catch(() => false),
+    }),
+    (value) => value.authenticated || value.usernameVisible,
+    options.connectTimeoutMs,
+  );
+  if (!loginState.authenticated) {
+    await username.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await password.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await username.fill(exampleUser.username);
+    await password.fill(exampleUser.password);
+    await page.locator('input[type="submit"], #kc-login').click();
+  }
+
+  const pageUrl = new URL(options.pageUrl);
+  const targetPrefix = `${pageUrl.origin}${pageUrl.pathname}`;
+  await page.waitForURL(new RegExp(`^${targetPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), {
+    timeout: options.connectTimeoutMs,
+  });
+  await page.waitForFunction(() => window.__bpaneAuth?.isAuthenticated?.() === true, {
+    timeout: options.connectTimeoutMs,
+  });
+  return authConfig;
+}
+
+async function run() {
+  const options = parseSmokeArgs(process.argv.slice(2), 'run-test-embed-lifecycle-smoke.mjs');
+  const log = createLogger('test-embed-lifecycle-smoke');
+
+  const browser = await launchChrome(chromium, options);
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 980 },
+  });
+  const page = await context.newPage();
+
+  try {
+    log(`Opening ${options.pageUrl}`);
+    await configureEmbedPage(page, options);
+    await ensureEmbedLoggedIn(page, options);
+
+    const accessToken = await getAccessToken(page);
+    if (accessToken) {
+      await cleanupWorkflowSmokeSessions(accessToken, options, log);
+      await page.evaluate(async () => {
+        await window.__bpaneControl.refreshSessions({ preserveSelection: true, silent: true });
+      });
+    }
+
+    log('Starting a new session from the standard layout.');
+    await page.click('#btn-new-session');
+
+    const connected = await poll(
+      'connected session lifecycle state',
+      async () => await page.evaluate(async () => {
+        const status = await window.__bpaneControl.refreshSessionStatus({ force: true, silent: true });
+        const stopButton = document.getElementById('btn-session-stop');
+        const disconnectAllButton = document.getElementById('btn-session-disconnect-all');
+        return {
+          control: window.__bpaneControl.getState(),
+          status,
+          stopDisabled: stopButton?.disabled ?? true,
+          disconnectAllDisabled: disconnectAllButton?.disabled ?? true,
+          stopEligibilityText: document.getElementById('session-stop-eligibility')?.textContent?.trim() ?? '',
+        };
+      }),
+      (value) => value.control?.connected === true && value.status?.connection_counts?.total_clients >= 1,
+      options.connectTimeoutMs,
+    );
+
+    if (!connected.control?.sessionId) {
+      throw new Error('Expected a connected session id after starting a new session.');
+    }
+    if (connected.status?.stop_eligibility?.allowed !== false) {
+      throw new Error('Expected safe stop to be blocked while the owner is still connected.');
+    }
+    if (!connected.stopDisabled) {
+      throw new Error('Expected Stop Selected to stay disabled while the current connection is still attached.');
+    }
+    if (connected.disconnectAllDisabled) {
+      throw new Error('Expected Disconnect All to remain enabled while live attachments exist.');
+    }
+
+    const summary = {
+      pageUrl: options.pageUrl,
+      sessionId: connected.control.sessionId,
+      connected: connected.control.connected,
+      stopDisabled: connected.stopDisabled,
+      disconnectAllDisabled: connected.disconnectAllDisabled,
+      stopEligibility: connected.status?.stop_eligibility ?? null,
+      connectionCounts: connected.status?.connection_counts ?? null,
+      stopEligibilityText: connected.stopEligibilityText,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (options.outputPath) {
+      await fs.writeFile(options.outputPath, JSON.stringify(summary, null, 2));
+      log(`Wrote summary to ${options.outputPath}`);
+    }
+  } finally {
+    try {
+      await page.evaluate(async () => {
+        const state = window.__bpaneControl?.getState?.();
+        if (state?.connected) {
+          await window.__bpaneControl.disconnect();
+        }
+      });
+    } catch {
+      // Ignore cleanup failures.
+    }
+    try {
+      const accessToken = await getAccessToken(page);
+      if (accessToken) {
+        await cleanupWorkflowSmokeSessions(accessToken, options, log);
+      }
+    } catch {
+      // Ignore cleanup failures.
+    }
+    await context.close();
+    await browser.close();
+  }
+}
+
+run().catch((error) => {
+  console.error(`[test-embed-lifecycle-smoke] ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/code/web/bpane-client/scripts/workflow-smoke-lib.mjs
+++ b/code/web/bpane-client/scripts/workflow-smoke-lib.mjs
@@ -222,7 +222,21 @@ export async function deleteSession(accessToken, options, sessionId) {
     method: 'DELETE',
     headers: { Authorization: `Bearer ${accessToken}` },
   });
-  if (!response.ok && response.status !== 404) {
+  if (response.ok || response.status === 404) {
+    return;
+  }
+  if (response.status === 409) {
+    const killResponse = await fetch(`${options.pageUrl}/api/v1/sessions/${sessionId}/kill`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (killResponse.ok || killResponse.status === 404) {
+      return;
+    }
+    const detail = await killResponse.text().catch(() => '');
+    throw new Error(`HTTP ${killResponse.status}${detail ? ` ${detail}` : ''}`);
+  }
+  if (!response.ok) {
     const detail = await response.text().catch(() => '');
     throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
   }

--- a/deploy/Dockerfile.mcp-bridge
+++ b/deploy/Dockerfile.mcp-bridge
@@ -1,4 +1,4 @@
-# BrowserPane MCP Bridge — SSE proxy for @playwright/mcp over CDP
+# BrowserPane MCP Bridge — Streamable HTTP/SSE proxy for @playwright/mcp over CDP
 FROM node:22-slim
 
 # Playwright system dependencies (Chromium not needed — we connect via CDP)

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -6,8 +6,7 @@
 #
 # Then open http://localhost:8080 in Chrome and log in.
 #
-# To exercise real multi-session runtime workers locally, start the stack with:
-#   BPANE_GATEWAY_RUNTIME_BACKEND=docker_pool \
+# The local stack defaults to docker_pool runtime workers:
 #   BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES=2 \
 #   docker compose -f deploy/compose.yml up --build
 #
@@ -22,7 +21,7 @@
 #   web       - nginx frontend (port 8080)
 #   keycloak  - local OIDC provider for dev/testing (port 8091)
 #   postgres  - session control-plane database
-#   mcp-bridge - MCP SSE server for Claude Code (port 8931)
+#   mcp-bridge - MCP bridge for Claude Code (port 8931)
 
 services:
   postgres:
@@ -103,7 +102,7 @@ services:
     command: >
       /usr/local/bin/bpane-gateway
       --agent-socket ${BPANE_GATEWAY_AGENT_SOCKET:-/run/bpane/agent.sock}
-      --runtime-backend ${BPANE_GATEWAY_RUNTIME_BACKEND:-static_single}
+      --runtime-backend ${BPANE_GATEWAY_RUNTIME_BACKEND:-docker_pool}
       --port 4433
       --max-viewers 10
       --max-active-runtimes ${BPANE_GATEWAY_MAX_ACTIVE_RUNTIMES:-2}

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -2072,13 +2072,27 @@
       }
       const shortId = getShortSessionId(resource.id);
       const state = resource.state ?? 'unknown';
-      const suffix = resource.id === mcpBridgeState.controlSessionId ? ' · MCP delegated' : '';
+      const suffix = resource.id === mcpBridgeState.controlSessionId
+        ? ' · MCP attached'
+        : (isResourceDelegatedToConfiguredMcpBridge(resource) ? ' · MCP delegated' : '');
       const clientRole = currentClientRole === 'recorder' ? ' · recorder' : '';
       return `Session: ${shortId} (${state})${suffix}${clientRole}`;
     }
 
     function supportsLocalMcpDelegation(resource) {
       return Boolean(resource?.id);
+    }
+
+    function isResourceDelegatedToConfiguredMcpBridge(resource) {
+      const delegate = resource?.automation_delegate;
+      const bridge = authState.config?.mcpBridge;
+      if (!delegate?.client_id || !bridge?.clientId) {
+        return false;
+      }
+      if (delegate.client_id !== bridge.clientId) {
+        return false;
+      }
+      return !bridge.issuer || delegate.issuer === bridge.issuer;
     }
 
     function setOverlayAction(button, { visible, enabled, label }) {
@@ -2173,7 +2187,9 @@
       const viewport = resource?.viewport?.width && resource?.viewport?.height
         ? `${resource.viewport.width}x${resource.viewport.height}`
         : '--';
-      const delegated = resource.id === mcpBridgeState.controlSessionId ? ' · MCP' : '';
+      const delegated = resource.id === mcpBridgeState.controlSessionId
+        ? ' · MCP attached'
+        : (isResourceDelegatedToConfiguredMcpBridge(resource) ? ' · MCP delegated' : '');
       return `${shortId} · ${state} · ${viewport}${delegated}`;
     }
 
@@ -2278,6 +2294,8 @@
 
     function renderMcpDelegationState() {
       const selectedSessionId = controlSessionState.resource?.id ?? '';
+      const selectedBackendDelegated =
+        isResourceDelegatedToConfiguredMcpBridge(controlSessionState.resource);
       const controlSessionId = mcpBridgeState.controlSessionId;
       const bridgeName = getMcpBridgeDisplayName();
 
@@ -2297,14 +2315,26 @@
       }
 
       if (!mcpBridgeState.available && mcpBridgeState.lastError) {
-        setMcpDisplayState('MCP: bridge unavailable', 'mcp-warning');
+        setMcpDisplayState(
+          selectedBackendDelegated ? 'MCP: delegated, bridge unchecked' : 'MCP: bridge unavailable',
+          'mcp-warning',
+        );
         mcpDelegationNote.className = 'helper-note warn';
-        mcpDelegationNote.textContent =
-          `${bridgeName} status could not be loaded right now. Delegation state may be stale until the bridge becomes reachable again.`;
+        mcpDelegationNote.textContent = selectedBackendDelegated
+          ? `The selected session ${getShortSessionId(selectedSessionId)} is delegated to ${bridgeName} in the control plane, but the bridge status could not be loaded right now.`
+          : `${bridgeName} status could not be loaded right now. Delegation state may be stale until the bridge becomes reachable again.`;
         return;
       }
 
       if (!controlSessionId) {
+        if (selectedSessionId && selectedBackendDelegated) {
+          setMcpDisplayState('MCP: backend delegated', 'mcp-warning');
+          mcpDelegationNote.className = 'helper-note warn';
+          mcpDelegationNote.textContent =
+            `The selected session ${getShortSessionId(selectedSessionId)} is delegated to ${bridgeName} in the control plane, but the bridge has not reported an attached control session yet.`;
+          return;
+        }
+
         setMcpDisplayState('MCP: no delegated session', 'mcp-inactive');
         mcpDelegationNote.className = 'helper-note info';
         mcpDelegationNote.textContent = selectedSessionId
@@ -2328,6 +2358,19 @@
         : `${bridgeName} is currently attached to session ${getShortSessionId(controlSessionId)}. Select that session if you want to inspect or share the exact delegated browser.`;
     }
 
+    function applyMcpBridgeStatusPayload(payload) {
+      const controlSessionId = typeof payload?.control_session_id === 'string'
+        ? payload.control_session_id
+        : (typeof payload?.session?.id === 'string' ? payload.session.id : '');
+      const controlSessionStateValue = typeof payload?.control_session_state === 'string'
+        ? payload.control_session_state
+        : (typeof payload?.session?.state === 'string' ? payload.session.state : '');
+      mcpBridgeState.controlSessionId = controlSessionId;
+      mcpBridgeState.controlSessionState = controlSessionStateValue;
+      mcpBridgeState.available = true;
+      mcpBridgeState.lastError = '';
+    }
+
     async function refreshMcpBridgeState({ silent = true } = {}) {
       const healthUrl = getMcpBridgeHealthUrl();
       if (!healthUrl || !authState.tokens?.access_token) {
@@ -2343,14 +2386,7 @@
           throw new Error(`HTTP ${response.status}`);
         }
         const payload = await response.json();
-        mcpBridgeState.controlSessionId = typeof payload?.control_session_id === 'string'
-          ? payload.control_session_id
-          : '';
-        mcpBridgeState.controlSessionState = typeof payload?.control_session_state === 'string'
-          ? payload.control_session_state
-          : '';
-        mcpBridgeState.available = true;
-        mcpBridgeState.lastError = '';
+        applyMcpBridgeStatusPayload(payload);
         renderSessionPicker();
         renderSessionState();
         if (!silent && mcpBridgeState.controlSessionId) {
@@ -2795,11 +2831,12 @@
       }
     }
 
-    async function resolveSelectedSessionResource(accessToken) {
+    async function resolveSelectedSessionResource(accessToken, { refresh = false } = {}) {
       try {
-        if (!controlSessionState.resources.length) {
+        if (refresh || !controlSessionState.resources.length) {
           await refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
         }
+        await refreshMcpBridgeState({ silent: true });
         const selected = controlSessionState.resources.find(
           (resource) => resource.id === controlSessionState.selectedSessionId,
         );
@@ -2911,7 +2948,12 @@
         }
         throw new Error(`bridge control session update failed: HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
       }
+      const payload = await response.json();
+      applyMcpBridgeStatusPayload(payload);
+      renderSessionPicker();
+      renderSessionState();
       log(`MCP bridge control session set to ${sessionId}`, 'ok');
+      return payload;
     }
 
     async function delegateCurrentSessionToMcp() {
@@ -2962,6 +3004,7 @@
       renderSessionState();
       log(`Delegated session ${controlSession.id} to ${authState.config.mcpBridge.clientId}`, 'ok');
       await assignMcpBridgeControlSession(controlSession.id);
+      await refreshMcpBridgeState({ silent: true });
     }
 
     async function logout() {
@@ -4692,7 +4735,7 @@
       try {
         const controlSession = mode === 'new'
           ? await createAndSelectSessionResource(accessToken)
-          : await resolveSelectedSessionResource(accessToken);
+          : await resolveSelectedSessionResource(accessToken, { refresh: true });
         if (!controlSession) {
           setStatus(mode === 'new' ? 'Session creation failed' : 'Session selection required', 'error');
           if (overlay) overlay.style.display = '';
@@ -4736,6 +4779,7 @@
               renderSessionPicker();
             }
             renderAuthState();
+            void refreshMcpBridgeState({ silent: true });
             cameraBtn.disabled = true;
             micBtn.disabled = false;
             uploadBtn.disabled = false;
@@ -4901,7 +4945,8 @@
             renderRecordingState();
             void getValidAccessToken().then((accessToken) => {
               if (accessToken) {
-                return refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
+                return refreshSessionResources(accessToken, { preserveSelection: true, silent: true })
+                  .then(() => refreshMcpBridgeState({ silent: true }));
               }
               return null;
             });
@@ -4995,7 +5040,8 @@
       renderRecordingState();
       void getValidAccessToken().then((accessToken) => {
         if (accessToken) {
-          return refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
+          return refreshSessionResources(accessToken, { preserveSelection: true, silent: true })
+            .then(() => refreshMcpBridgeState({ silent: true }));
         }
         return null;
       });
@@ -5056,7 +5102,8 @@
         setStatus('Login required', 'error');
         return null;
       }
-      return refreshSessionResources(accessToken, { preserveSelection: true, silent: false });
+      return refreshSessionResources(accessToken, { preserveSelection: true, silent: false })
+        .then(() => refreshMcpBridgeState({ silent: true }));
     }).catch((error) => {
       log(`Session refresh failed: ${error.message}`, 'error');
     }));
@@ -5231,6 +5278,7 @@
           throw new Error('no access token available');
         }
         const sessions = await refreshSessionResources(accessToken, { preserveSelection, silent });
+        await refreshMcpBridgeState({ silent: true });
         return cloneValue(sessions) ?? [];
       },
       selectSession: async (sessionId) => {

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -859,6 +859,70 @@
       line-height: 1.5;
     }
 
+    .session-connection-list {
+      display: grid;
+      gap: 10px;
+    }
+
+    .session-connection-card,
+    .session-connection-empty {
+      padding: 12px 14px;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: rgba(16, 27, 46, 0.74);
+    }
+
+    .session-connection-card {
+      display: grid;
+      gap: 10px;
+    }
+
+    .session-connection-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
+    }
+
+    .session-connection-title {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 0;
+      font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 12px;
+      color: var(--muted);
+    }
+
+    .session-connection-title strong {
+      color: #eef4ff;
+      font-size: 13px;
+      line-height: 1.35;
+      word-break: break-all;
+    }
+
+    .session-connection-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 11px;
+      color: #c5d3eb;
+    }
+
+    .session-connection-meta span {
+      padding: 6px 8px;
+      border-radius: 999px;
+      border: 1px solid rgba(137, 161, 201, 0.12);
+      background: rgba(18, 31, 54, 0.76);
+    }
+
+    .session-connection-empty {
+      color: var(--muted);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
     .panel-logs {
       min-height: 300px;
       flex: 1;
@@ -1034,6 +1098,40 @@
           <button id="btn-connect">Join / Reconnect</button>
           <button id="btn-delegate-mcp" disabled>Delegate MCP</button>
           <button id="btn-disconnect" disabled>Disconnect</button>
+        </div>
+
+        <div id="session-lifecycle-note" class="helper-note info">
+          Select a session to inspect its live lifecycle status, blockers, and attachments.
+        </div>
+
+        <div class="metrics-grid">
+          <span id="session-runtime-state">Runtime: --</span>
+          <span id="session-presence-state">Presence: --</span>
+          <span id="session-connection-counts">Connections: --</span>
+          <span id="session-stop-eligibility">Stop Eligibility: --</span>
+          <span id="session-idle-state">Idle: --</span>
+        </div>
+
+        <div class="form-row">
+          <button id="btn-session-status-refresh" disabled>Refresh Status</button>
+          <button id="btn-session-stop" disabled>Stop Selected</button>
+          <button id="btn-session-kill" disabled>Kill Selected</button>
+          <button id="btn-session-disconnect-all" disabled>Disconnect All</button>
+        </div>
+
+        <div class="workflow-stack">
+          <div class="panel-heading">
+            <span class="panel-title">Live Connections</span>
+            <p class="panel-copy">
+              Inspect the selected session’s current attachments and disconnect specific clients
+              without force-killing the runtime.
+            </p>
+          </div>
+          <div id="session-connection-list" class="session-connection-list">
+            <div class="session-connection-empty">
+              No selected session status loaded yet.
+            </div>
+          </div>
         </div>
       </section>
 
@@ -1384,6 +1482,10 @@
     const connectBtn = document.getElementById('btn-connect');
     const delegateMcpBtn = document.getElementById('btn-delegate-mcp');
     const disconnectBtn = document.getElementById('btn-disconnect');
+    const sessionStatusRefreshBtn = document.getElementById('btn-session-status-refresh');
+    const sessionStopBtn = document.getElementById('btn-session-stop');
+    const sessionKillBtn = document.getElementById('btn-session-kill');
+    const sessionDisconnectAllBtn = document.getElementById('btn-session-disconnect-all');
     const metricsStartBtn = document.getElementById('btn-metrics-start');
     const metricsStopBtn = document.getElementById('btn-metrics-stop');
     const metricsCopyBtn = document.getElementById('btn-metrics-copy');
@@ -1448,6 +1550,13 @@
     const logPanel = document.getElementById('log-panel');
     const authDisplay = document.getElementById('auth-display');
     const sessionDisplay = document.getElementById('session-display');
+    const sessionLifecycleNoteEl = document.getElementById('session-lifecycle-note');
+    const sessionRuntimeStateEl = document.getElementById('session-runtime-state');
+    const sessionPresenceStateEl = document.getElementById('session-presence-state');
+    const sessionConnectionCountsEl = document.getElementById('session-connection-counts');
+    const sessionStopEligibilityEl = document.getElementById('session-stop-eligibility');
+    const sessionIdleStateEl = document.getElementById('session-idle-state');
+    const sessionConnectionListEl = document.getElementById('session-connection-list');
     const mcpDisplay = document.getElementById('mcp-display');
     const mcpDelegationNote = document.getElementById('mcp-delegation-note');
     const authHint = document.getElementById('auth-hint');
@@ -2027,6 +2136,15 @@
       resources: [],
       selectedSessionId: '',
     };
+    const sessionLifecycleState = {
+      sessionId: '',
+      status: null,
+      loading: false,
+      acting: false,
+      disconnectingConnectionId: '',
+      error: '',
+      requestId: 0,
+    };
     const mcpBridgeState = {
       controlSessionId: '',
       controlSessionState: '',
@@ -2172,9 +2290,178 @@
     function renderSessionState() {
       sessionDisplay.textContent = getSessionLabel(controlSessionState.resource);
       renderMcpDelegationState();
+      renderSessionLifecycleState();
       renderRecordingState();
       renderRecordingCatalogState();
       renderOverlayState();
+    }
+
+    function summarizeSessionStopBlockers(blockers) {
+      if (!Array.isArray(blockers) || blockers.length === 0) {
+        return 'none';
+      }
+      return blockers
+        .map((blocker) => {
+          const count = Number.isFinite(blocker?.count) ? blocker.count : 0;
+          const kind = String(blocker?.kind || 'unknown').replace(/_/g, ' ');
+          return `${count} ${kind}`;
+        })
+        .join(', ');
+    }
+
+    function clearSessionLifecycleState(sessionId = '') {
+      sessionLifecycleState.sessionId = sessionId;
+      sessionLifecycleState.status = null;
+      sessionLifecycleState.loading = false;
+      sessionLifecycleState.acting = false;
+      sessionLifecycleState.disconnectingConnectionId = '';
+      sessionLifecycleState.error = '';
+    }
+
+    function buildSessionConnectionCard(connection) {
+      const card = document.createElement('article');
+      card.className = 'session-connection-card';
+
+      const header = document.createElement('div');
+      header.className = 'session-connection-header';
+
+      const title = document.createElement('div');
+      title.className = 'session-connection-title';
+      title.innerHTML = `<strong>Connection ${connection.connection_id}</strong><span>Role: ${connection.role ?? 'unknown'}</span>`;
+      header.appendChild(title);
+
+      const roleBadge = document.createElement('span');
+      roleBadge.className = `metric-badge ${normalizeMetricBadgeClass(connection.role)}`;
+      roleBadge.textContent = connection.role ?? 'unknown';
+      header.appendChild(roleBadge);
+      card.appendChild(header);
+
+      const meta = document.createElement('div');
+      meta.className = 'session-connection-meta';
+      const connectionIdChip = document.createElement('span');
+      connectionIdChip.textContent = `ID: ${connection.connection_id}`;
+      meta.appendChild(connectionIdChip);
+      card.appendChild(meta);
+
+      const actions = document.createElement('div');
+      actions.className = 'recording-library-actions';
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.action = 'disconnect-session-connection';
+      button.dataset.connectionId = String(connection.connection_id);
+      button.textContent = sessionLifecycleState.disconnectingConnectionId === String(connection.connection_id)
+        ? 'Disconnecting...'
+        : 'Disconnect';
+      button.disabled = sessionLifecycleState.loading
+        || sessionLifecycleState.acting
+        || Boolean(sessionLifecycleState.disconnectingConnectionId);
+      actions.appendChild(button);
+      card.appendChild(actions);
+
+      return card;
+    }
+
+    function renderSessionLifecycleState() {
+      const selected = controlSessionState.resource;
+      const selectedSessionId = selected?.id ?? '';
+      const canManageSessions = authState.config?.mode === 'oidc' && Boolean(authState.tokens?.access_token);
+      const status = sessionLifecycleState.sessionId === selectedSessionId
+        ? sessionLifecycleState.status
+        : null;
+      const totalConnections = Number(status?.connection_counts?.total_clients ?? 0);
+
+      sessionStatusRefreshBtn.disabled = !canManageSessions || !selectedSessionId || sessionLifecycleState.loading || sessionLifecycleState.acting;
+      sessionStopBtn.disabled = !canManageSessions
+        || !selectedSessionId
+        || sessionLifecycleState.loading
+        || sessionLifecycleState.acting
+        || selected?.state === 'stopped';
+      sessionKillBtn.disabled = !canManageSessions
+        || !selectedSessionId
+        || sessionLifecycleState.loading
+        || sessionLifecycleState.acting
+        || selected?.state === 'stopped';
+      sessionDisconnectAllBtn.disabled = !canManageSessions
+        || !selectedSessionId
+        || sessionLifecycleState.loading
+        || sessionLifecycleState.acting
+        || totalConnections === 0;
+
+      sessionRuntimeStateEl.textContent = `Runtime: ${status?.runtime_state ?? '--'}`;
+      sessionPresenceStateEl.textContent = `Presence: ${status?.presence_state ?? '--'}`;
+      if (status?.connection_counts) {
+        const counts = status.connection_counts;
+        sessionConnectionCountsEl.textContent =
+          `Connections: ${counts.total_clients} total · owner ${counts.owner_clients} · viewer ${counts.viewer_clients} · recorder ${counts.recorder_clients}`;
+      } else {
+        sessionConnectionCountsEl.textContent = 'Connections: --';
+      }
+      sessionStopEligibilityEl.textContent = status
+        ? `Stop Eligibility: ${status.stop_eligibility?.allowed ? 'allowed' : summarizeSessionStopBlockers(status.stop_eligibility?.blockers)}`
+        : 'Stop Eligibility: --';
+      if (status?.idle?.idle_since) {
+        sessionIdleStateEl.textContent =
+          `Idle: since ${formatTimestamp(status.idle.idle_since)} · deadline ${formatTimestamp(status.idle.idle_deadline)}`;
+      } else if (status?.idle?.idle_timeout_sec) {
+        sessionIdleStateEl.textContent = `Idle: timeout ${status.idle.idle_timeout_sec}s`;
+      } else {
+        sessionIdleStateEl.textContent = 'Idle: --';
+      }
+
+      if (!canManageSessions) {
+        sessionLifecycleNoteEl.className = 'helper-note info';
+        sessionLifecycleNoteEl.textContent = 'Login first to inspect or control session lifecycle state.';
+        sessionConnectionListEl.innerHTML =
+          '<div class="session-connection-empty">Login first to inspect live session attachments.</div>';
+        return;
+      }
+
+      if (!selectedSessionId) {
+        sessionLifecycleNoteEl.className = 'helper-note info';
+        sessionLifecycleNoteEl.textContent = 'Select a session to inspect its lifecycle status, blockers, and live attachments.';
+        sessionConnectionListEl.innerHTML =
+          '<div class="session-connection-empty">Select a session to load its live connection status.</div>';
+        return;
+      }
+
+      if (sessionLifecycleState.loading) {
+        sessionLifecycleNoteEl.className = 'helper-note info';
+        sessionLifecycleNoteEl.textContent = `Loading lifecycle status for session ${getShortSessionId(selectedSessionId)}...`;
+        sessionConnectionListEl.innerHTML =
+          '<div class="session-connection-empty">Loading live connection details...</div>';
+        return;
+      }
+
+      if (sessionLifecycleState.error) {
+        sessionLifecycleNoteEl.className = 'helper-note warn';
+        sessionLifecycleNoteEl.textContent = `Session lifecycle status could not be loaded: ${sessionLifecycleState.error}`;
+      } else if (!status) {
+        sessionLifecycleNoteEl.className = 'helper-note info';
+        sessionLifecycleNoteEl.textContent =
+          `Refresh the selected session to inspect stop blockers, live attachments, and side-effect-free status snapshots.`;
+      } else if (status.stop_eligibility?.allowed) {
+        sessionLifecycleNoteEl.className = 'helper-note ok';
+        sessionLifecycleNoteEl.textContent =
+          `Session ${getShortSessionId(selectedSessionId)} can be safely stopped right now. ${
+            totalConnections > 0
+              ? 'You can also disconnect individual attachments below without killing the runtime.'
+              : 'No live attachments are currently connected.'
+          }`;
+      } else {
+        sessionLifecycleNoteEl.className = 'helper-note warn';
+        sessionLifecycleNoteEl.textContent =
+          `Session ${getShortSessionId(selectedSessionId)} cannot be safely stopped yet: ${summarizeSessionStopBlockers(status.stop_eligibility?.blockers)}.`;
+      }
+
+      sessionConnectionListEl.innerHTML = '';
+      if (!status?.connections?.length) {
+        sessionConnectionListEl.innerHTML =
+          '<div class="session-connection-empty">No live session attachments are currently connected.</div>';
+        return;
+      }
+      for (const connection of status.connections) {
+        sessionConnectionListEl.appendChild(buildSessionConnectionCard(connection));
+      }
     }
 
     function isJoinableSession(resource) {
@@ -2198,7 +2485,13 @@
         (resource) => resource.id === controlSessionState.selectedSessionId,
       ) ?? null;
       controlSessionState.resource = selected;
+      if (!selected?.id) {
+        clearSessionLifecycleState('');
+      }
       renderSessionState();
+      void refreshSelectedSessionLifecycleStatus({ silent: true }).catch((error) => {
+        log(`Session lifecycle refresh failed: ${error.message}`, 'error');
+      });
       void refreshRecordingCatalogForSelectedSession({ force: false, silent: true }).catch((error) => {
         log(`Recording library refresh failed: ${error.message}`, 'error');
       });
@@ -2493,6 +2786,7 @@
       controlSessionState.resource = null;
       controlSessionState.resources = [];
       controlSessionState.selectedSessionId = '';
+      clearSessionLifecycleState('');
       clearRecordingCatalogState();
       clearWorkflowState();
       stopMcpBridgePolling({ clearState: true });
@@ -2762,6 +3056,95 @@
       return sessions;
     }
 
+    async function readApiFailure(response) {
+      let detail = '';
+      try {
+        const payload = await response.json();
+        detail = payload?.error ?? JSON.stringify(payload);
+      } catch {
+        detail = await response.text().catch(() => '');
+      }
+      return `HTTP ${response.status}${detail ? ` ${detail}` : ''}`;
+    }
+
+    async function fetchSessionLifecycleStatus(accessToken, sessionId) {
+      const response = await fetch(`${SESSION_API_URL}/${encodeURIComponent(sessionId)}/status`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
+      });
+      if (!response.ok) {
+        throw new Error(await readApiFailure(response));
+      }
+      return await response.json();
+    }
+
+    async function refreshSelectedSessionLifecycleStatus({ silent = true, force = false } = {}) {
+      const accessToken = await getValidAccessToken();
+      const sessionId = controlSessionState.resource?.id ?? '';
+      if (!accessToken || !sessionId) {
+        clearSessionLifecycleState(sessionId);
+        renderSessionLifecycleState();
+        return null;
+      }
+      if (
+        !force
+        && !sessionLifecycleState.loading
+        && sessionLifecycleState.sessionId === sessionId
+        && sessionLifecycleState.status
+        && !sessionLifecycleState.error
+      ) {
+        return sessionLifecycleState.status;
+      }
+
+      const requestId = sessionLifecycleState.requestId + 1;
+      sessionLifecycleState.requestId = requestId;
+      sessionLifecycleState.sessionId = sessionId;
+      sessionLifecycleState.loading = true;
+      sessionLifecycleState.error = '';
+      renderSessionLifecycleState();
+
+      try {
+        const status = await fetchSessionLifecycleStatus(accessToken, sessionId);
+        if (sessionLifecycleState.requestId !== requestId) {
+          return null;
+        }
+        sessionLifecycleState.status = status;
+        sessionLifecycleState.loading = false;
+        sessionLifecycleState.error = '';
+        renderSessionLifecycleState();
+        if (!silent) {
+          log(`Loaded lifecycle status for session ${sessionId}`, 'info');
+        }
+        return status;
+      } catch (error) {
+        if (sessionLifecycleState.requestId !== requestId) {
+          return null;
+        }
+        sessionLifecycleState.status = null;
+        sessionLifecycleState.loading = false;
+        sessionLifecycleState.error = error.message;
+        renderSessionLifecycleState();
+        if (!silent) {
+          log(`Session lifecycle status refresh failed: ${error.message}`, 'error');
+        }
+        throw error;
+      }
+    }
+
+    async function refreshSelectedSessionControlData({ silent = true, forceStatus = false } = {}) {
+      const accessToken = await getValidAccessToken();
+      if (!accessToken) {
+        clearSessionLifecycleState(controlSessionState.resource?.id ?? '');
+        renderSessionLifecycleState();
+        return null;
+      }
+      await refreshSessionResources(accessToken, { preserveSelection: true, silent: true });
+      return refreshSelectedSessionLifecycleStatus({ silent, force: forceStatus });
+    }
+
     async function createSessionResource(accessToken) {
       const response = await fetch(SESSION_API_URL, {
         method: 'POST',
@@ -3005,6 +3388,164 @@
       log(`Delegated session ${controlSession.id} to ${authState.config.mcpBridge.clientId}`, 'ok');
       await assignMcpBridgeControlSession(controlSession.id);
       await refreshMcpBridgeState({ silent: true });
+    }
+
+    async function stopSelectedSession() {
+      const accessToken = await getValidAccessToken();
+      const selected = controlSessionState.resource;
+      if (!accessToken || !selected?.id) {
+        throw new Error('login and session selection are required');
+      }
+
+      sessionLifecycleState.acting = true;
+      sessionLifecycleState.error = '';
+      renderSessionLifecycleState();
+      try {
+        const response = await fetch(`${SESSION_API_URL}/${encodeURIComponent(selected.id)}/stop`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+          cache: 'no-store',
+        });
+        const payload = await response.json().catch(() => null);
+        if (response.status === 409) {
+          if (payload?.session?.id) {
+            controlSessionState.resource = payload.session;
+          }
+          await refreshSelectedSessionControlData({ silent: true, forceStatus: true });
+          log(
+            `Safe stop blocked for session ${selected.id}: ${summarizeSessionStopBlockers(payload?.session?.status?.stop_eligibility?.blockers)}`,
+            'warn',
+          );
+          return payload;
+        }
+        if (!response.ok) {
+          throw new Error(
+            payload?.error ? `HTTP ${response.status} ${payload.error}` : `HTTP ${response.status}`,
+          );
+        }
+        log(`Stopped session ${selected.id}`, 'ok');
+        await refreshSelectedSessionControlData({ silent: true, forceStatus: true });
+        return payload;
+      } finally {
+        sessionLifecycleState.acting = false;
+        renderSessionLifecycleState();
+      }
+    }
+
+    async function killSelectedSession() {
+      const accessToken = await getValidAccessToken();
+      const selected = controlSessionState.resource;
+      if (!accessToken || !selected?.id) {
+        throw new Error('login and session selection are required');
+      }
+
+      sessionLifecycleState.acting = true;
+      sessionLifecycleState.error = '';
+      renderSessionLifecycleState();
+      try {
+        const response = await fetch(`${SESSION_API_URL}/${encodeURIComponent(selected.id)}/kill`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            Accept: 'application/json',
+          },
+          cache: 'no-store',
+        });
+        if (!response.ok) {
+          throw new Error(await readApiFailure(response));
+        }
+        const payload = await response.json();
+        log(`Force-killed session ${selected.id}`, 'warn');
+        await refreshSelectedSessionControlData({ silent: true, forceStatus: true });
+        return payload;
+      } finally {
+        sessionLifecycleState.acting = false;
+        renderSessionLifecycleState();
+      }
+    }
+
+    async function disconnectAllSelectedSessionConnections() {
+      const accessToken = await getValidAccessToken();
+      const selected = controlSessionState.resource;
+      if (!accessToken || !selected?.id) {
+        throw new Error('login and session selection are required');
+      }
+
+      sessionLifecycleState.acting = true;
+      sessionLifecycleState.error = '';
+      renderSessionLifecycleState();
+      try {
+        const response = await fetch(
+          `${SESSION_API_URL}/${encodeURIComponent(selected.id)}/connections/disconnect-all`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Accept: 'application/json',
+            },
+            cache: 'no-store',
+          },
+        );
+        if (!response.ok) {
+          throw new Error(await readApiFailure(response));
+        }
+        const payload = await response.json();
+        sessionLifecycleState.sessionId = selected.id;
+        sessionLifecycleState.status = payload;
+        sessionLifecycleState.error = '';
+        log(`Disconnected all live attachments from session ${selected.id}`, 'warn');
+        await refreshSelectedSessionControlData({ silent: true, forceStatus: true });
+        return payload;
+      } finally {
+        sessionLifecycleState.acting = false;
+        renderSessionLifecycleState();
+      }
+    }
+
+    async function disconnectSelectedSessionConnection(connectionId) {
+      const accessToken = await getValidAccessToken();
+      const selected = controlSessionState.resource;
+      if (!accessToken || !selected?.id) {
+        throw new Error('login and session selection are required');
+      }
+      if (connectionId === undefined || connectionId === null || connectionId === '') {
+        throw new Error('connection id is required');
+      }
+
+      sessionLifecycleState.acting = true;
+      sessionLifecycleState.disconnectingConnectionId = String(connectionId);
+      sessionLifecycleState.error = '';
+      renderSessionLifecycleState();
+      try {
+        const response = await fetch(
+          `${SESSION_API_URL}/${encodeURIComponent(selected.id)}/connections/${encodeURIComponent(String(connectionId))}/disconnect`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              Accept: 'application/json',
+            },
+            cache: 'no-store',
+          },
+        );
+        if (!response.ok) {
+          throw new Error(await readApiFailure(response));
+        }
+        const payload = await response.json();
+        sessionLifecycleState.sessionId = selected.id;
+        sessionLifecycleState.status = payload;
+        sessionLifecycleState.error = '';
+        log(`Disconnected connection ${connectionId} from session ${selected.id}`, 'warn');
+        await refreshSelectedSessionControlData({ silent: true, forceStatus: true });
+        return payload;
+      } finally {
+        sessionLifecycleState.acting = false;
+        sessionLifecycleState.disconnectingConnectionId = '';
+        renderSessionLifecycleState();
+      }
     }
 
     async function logout() {
@@ -4780,6 +5321,7 @@
             }
             renderAuthState();
             void refreshMcpBridgeState({ silent: true });
+            void refreshSelectedSessionLifecycleStatus({ silent: true, force: true });
             cameraBtn.disabled = true;
             micBtn.disabled = false;
             uploadBtn.disabled = false;
@@ -4946,7 +5488,10 @@
             void getValidAccessToken().then((accessToken) => {
               if (accessToken) {
                 return refreshSessionResources(accessToken, { preserveSelection: true, silent: true })
-                  .then(() => refreshMcpBridgeState({ silent: true }));
+                  .then(() => Promise.all([
+                    refreshMcpBridgeState({ silent: true }),
+                    refreshSelectedSessionLifecycleStatus({ silent: true, force: true }),
+                  ]));
               }
               return null;
             });
@@ -5041,7 +5586,10 @@
       void getValidAccessToken().then((accessToken) => {
         if (accessToken) {
           return refreshSessionResources(accessToken, { preserveSelection: true, silent: true })
-            .then(() => refreshMcpBridgeState({ silent: true }));
+            .then(() => Promise.all([
+              refreshMcpBridgeState({ silent: true }),
+              refreshSelectedSessionLifecycleStatus({ silent: true, force: true }),
+            ]));
         }
         return null;
       });
@@ -5103,7 +5651,10 @@
         return null;
       }
       return refreshSessionResources(accessToken, { preserveSelection: true, silent: false })
-        .then(() => refreshMcpBridgeState({ silent: true }));
+        .then(() => Promise.all([
+          refreshMcpBridgeState({ silent: true }),
+          refreshSelectedSessionLifecycleStatus({ silent: true, force: true }),
+        ]));
     }).catch((error) => {
       log(`Session refresh failed: ${error.message}`, 'error');
     }));
@@ -5112,6 +5663,39 @@
     connectBtn.addEventListener('click', () => void connect('selected'));
     overlayConnectBtn.addEventListener('click', () => void connect('selected'));
     disconnectBtn.addEventListener('click', () => void doDisconnect());
+    sessionStatusRefreshBtn.addEventListener('click', () => {
+      void refreshSelectedSessionLifecycleStatus({ silent: false, force: true }).catch((error) => {
+        log(`Session lifecycle status refresh failed: ${error.message}`, 'error');
+      });
+    });
+    sessionStopBtn.addEventListener('click', () => {
+      void stopSelectedSession().catch((error) => {
+        log(`Session stop failed: ${error.message}`, 'error');
+      });
+    });
+    sessionKillBtn.addEventListener('click', () => {
+      void killSelectedSession().catch((error) => {
+        log(`Session kill failed: ${error.message}`, 'error');
+      });
+    });
+    sessionDisconnectAllBtn.addEventListener('click', () => {
+      void disconnectAllSelectedSessionConnections().catch((error) => {
+        log(`Disconnect-all failed: ${error.message}`, 'error');
+      });
+    });
+    sessionConnectionListEl.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-action="disconnect-session-connection"]');
+      if (!button) {
+        return;
+      }
+      const connectionId = button.dataset.connectionId;
+      if (!connectionId) {
+        return;
+      }
+      void disconnectSelectedSessionConnection(connectionId).catch((error) => {
+        log(`Connection disconnect failed: ${error.message}`, 'error');
+      });
+    });
     recordingStartBtn.addEventListener('click', () => void startSessionRecording());
     recordingStopBtn.addEventListener('click', () => void stopSessionRecording());
     recordingDownloadBtn.addEventListener('click', downloadLastRecording);
@@ -5299,6 +5883,10 @@
         renderAuthState();
         return cloneValue(resource);
       },
+      refreshSessionStatus: async ({ force = true, silent = false } = {}) => {
+        const status = await refreshSelectedSessionLifecycleStatus({ force, silent });
+        return cloneValue(status);
+      },
       startNewSession: async (options = {}) => {
         await connect('new', options);
         return cloneValue(controlSessionState.resource);
@@ -5307,6 +5895,10 @@
         await connect('selected', options);
         return cloneValue(controlSessionState.resource);
       },
+      stopSelectedSession,
+      killSelectedSession,
+      disconnectAllSelectedSessionConnections,
+      disconnectSessionConnection: disconnectSelectedSessionConnection,
       disconnect: doDisconnect,
     };
     window.__bpaneRecording = {
@@ -5445,7 +6037,7 @@
     log(`Session control API: ${SESSION_API_URL}`, 'info');
     log(`Default client role: ${DEFAULT_CLIENT_ROLE}`, 'info');
     log('Benchmark metrics API: window.__bpaneBenchmarkMetrics.{startSample,stopSample,resetSample,getSummary}', 'info');
-    log('Control API: window.__bpaneControl.{listSessions,getState,refreshSessions,selectSession,startNewSession,connectSelected,disconnect}', 'info');
+    log('Control API: window.__bpaneControl.{listSessions,getState,refreshSessions,selectSession,refreshSessionStatus,startNewSession,connectSelected,stopSelectedSession,killSelectedSession,disconnectAllSelectedSessionConnections,disconnectSessionConnection,disconnect}', 'info');
     log(
       'Recording API: window.__bpaneRecording.{start,stop,downloadLast,refreshCatalog,downloadCatalogRecording,downloadPlaybackExport,setAutoDownload,getState,getCatalogState}',
       'info',

--- a/dev/test-embed.html
+++ b/dev/test-embed.html
@@ -2369,13 +2369,14 @@
         ? sessionLifecycleState.status
         : null;
       const totalConnections = Number(status?.connection_counts?.total_clients ?? 0);
+      const canSafelyStopSession = selected?.state !== 'stopped' && status?.stop_eligibility?.allowed === true;
 
       sessionStatusRefreshBtn.disabled = !canManageSessions || !selectedSessionId || sessionLifecycleState.loading || sessionLifecycleState.acting;
       sessionStopBtn.disabled = !canManageSessions
         || !selectedSessionId
         || sessionLifecycleState.loading
         || sessionLifecycleState.acting
-        || selected?.state === 'stopped';
+        || !canSafelyStopSession;
       sessionKillBtn.disabled = !canManageSessions
         || !selectedSessionId
         || sessionLifecycleState.loading

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -1664,6 +1664,26 @@ paths:
                 $ref: '#/components/schemas/SessionStopConflictResponse'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/kill:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    post:
+      tags: [Sessions]
+      summary: Force kill a session resource and terminate live attachments
+      operationId: killSession
+      responses:
+        '200':
+          description: Session force killed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/automation-owner:
     parameters:
       - $ref: '#/components/parameters/SessionId'
@@ -3962,6 +3982,7 @@ components:
       enum:
         - manual_stop
         - session_stop
+        - session_kill
         - idle_stop
         - gateway_restart
         - worker_exit

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -1300,7 +1300,7 @@ paths:
           $ref: '#/components/responses/BackendUnavailable'
     delete:
       tags: [Sessions]
-      summary: Stop a session resource
+      summary: Safely stop a session resource
       operationId: deleteSession
       responses:
         '200':
@@ -1314,7 +1314,11 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/Conflict'
+          description: Session cannot be stopped while blockers remain
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStopConflictResponse'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/recordings:
@@ -1616,14 +1620,14 @@ paths:
       - $ref: '#/components/parameters/SessionId'
     get:
       tags: [Session Runtime]
-      summary: Get live runtime telemetry for a runtime-compatible session
+      summary: Get a session lifecycle, runtime, and presence snapshot
       operationId: getSessionStatus
       security:
         - bearerAuth: []
         - sessionAutomationAccessToken: []
       responses:
         '200':
-          description: Live runtime telemetry snapshot
+          description: Session lifecycle and presence snapshot
           content:
             application/json:
               schema:
@@ -1632,8 +1636,32 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/stop:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    post:
+      tags: [Sessions]
+      summary: Safely stop a session resource
+      operationId: stopSession
+      responses:
+        '200':
+          description: Session stopped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/Conflict'
+          description: Session cannot be stopped while blockers remain
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStopConflictResponse'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/automation-owner:
@@ -3741,6 +3769,9 @@ components:
         - viewer_clients
         - recorder_clients
         - automation_owner
+        - recording_activity
+        - automation_tasks
+        - workflow_runs
     SessionStopBlocker:
       type: object
       required: [kind, count]
@@ -3760,6 +3791,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SessionStopBlocker'
+    SessionStopConflictResponse:
+      type: object
+      required: [error, session]
+      properties:
+        error:
+          type: string
+        session:
+          $ref: '#/components/schemas/SessionResource'
     SessionIdleStatus:
       type: object
       required: [idle_timeout_sec, idle_since, idle_deadline]

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -3690,6 +3690,111 @@ components:
           type: string
           nullable: true
           format: uri
+    SessionRuntimeState:
+      type: string
+      enum:
+        - not_started
+        - starting
+        - running
+        - stopping
+        - stopped
+    SessionPresenceState:
+      type: string
+      enum:
+        - empty
+        - connected
+        - automation_owned
+        - recording_only
+        - idle
+    SessionConnectionCounts:
+      type: object
+      required:
+        - interactive_clients
+        - owner_clients
+        - viewer_clients
+        - recorder_clients
+        - automation_clients
+        - total_clients
+      properties:
+        interactive_clients:
+          type: integer
+          minimum: 0
+        owner_clients:
+          type: integer
+          minimum: 0
+        viewer_clients:
+          type: integer
+          minimum: 0
+        recorder_clients:
+          type: integer
+          minimum: 0
+        automation_clients:
+          type: integer
+          minimum: 0
+        total_clients:
+          type: integer
+          minimum: 0
+    SessionStopBlockerKind:
+      type: string
+      enum:
+        - owner_clients
+        - viewer_clients
+        - recorder_clients
+        - automation_owner
+    SessionStopBlocker:
+      type: object
+      required: [kind, count]
+      properties:
+        kind:
+          $ref: '#/components/schemas/SessionStopBlockerKind'
+        count:
+          type: integer
+          minimum: 0
+    SessionStopEligibility:
+      type: object
+      required: [allowed, blockers]
+      properties:
+        allowed:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionStopBlocker'
+    SessionIdleStatus:
+      type: object
+      required: [idle_timeout_sec, idle_since, idle_deadline]
+      properties:
+        idle_timeout_sec:
+          type: integer
+          nullable: true
+          minimum: 1
+        idle_since:
+          type: string
+          format: date-time
+          nullable: true
+        idle_deadline:
+          type: string
+          format: date-time
+          nullable: true
+    SessionStatusSummary:
+      type: object
+      required:
+        - runtime_state
+        - presence_state
+        - connection_counts
+        - stop_eligibility
+        - idle
+      properties:
+        runtime_state:
+          $ref: '#/components/schemas/SessionRuntimeState'
+        presence_state:
+          $ref: '#/components/schemas/SessionPresenceState'
+        connection_counts:
+          $ref: '#/components/schemas/SessionConnectionCounts'
+        stop_eligibility:
+          $ref: '#/components/schemas/SessionStopEligibility'
+        idle:
+          $ref: '#/components/schemas/SessionIdleStatus'
     SessionResource:
       type: object
       required:
@@ -3708,6 +3813,7 @@ components:
         - recording
         - connect
         - runtime
+        - status
         - created_at
         - updated_at
         - stopped_at
@@ -3754,6 +3860,8 @@ components:
           $ref: '#/components/schemas/SessionConnectInfo'
         runtime:
           $ref: '#/components/schemas/SessionRuntimeInfo'
+        status:
+          $ref: '#/components/schemas/SessionStatusSummary'
         created_at:
           type: string
           format: date-time
@@ -4141,6 +4249,12 @@ components:
     SessionStatus:
       type: object
       required:
+        - state
+        - runtime_state
+        - presence_state
+        - connection_counts
+        - stop_eligibility
+        - idle
         - browser_clients
         - viewer_clients
         - recorder_clients
@@ -4153,6 +4267,18 @@ components:
         - playback
         - telemetry
       properties:
+        state:
+          $ref: '#/components/schemas/SessionLifecycleState'
+        runtime_state:
+          $ref: '#/components/schemas/SessionRuntimeState'
+        presence_state:
+          $ref: '#/components/schemas/SessionPresenceState'
+        connection_counts:
+          $ref: '#/components/schemas/SessionConnectionCounts'
+        stop_eligibility:
+          $ref: '#/components/schemas/SessionStopEligibility'
+        idle:
+          $ref: '#/components/schemas/SessionIdleStatus'
         browser_clients:
           type: integer
           minimum: 0

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -1638,6 +1638,52 @@ paths:
           $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/connections/{connection_id}/disconnect:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+      - name: connection_id
+        in: path
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+    post:
+      tags: [Sessions]
+      summary: Disconnect a single live session attachment
+      operationId: disconnectSessionConnection
+      responses:
+        '200':
+          description: Live session attachment disconnected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/connections/disconnect-all:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    post:
+      tags: [Sessions]
+      summary: Disconnect all live session attachments
+      operationId: disconnectAllSessionConnections
+      responses:
+        '200':
+          description: All live session attachments disconnected
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStatus'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/stop:
     parameters:
       - $ref: '#/components/parameters/SessionId'
@@ -3782,6 +3828,23 @@ components:
         total_clients:
           type: integer
           minimum: 0
+    SessionConnectionRole:
+      type: string
+      enum:
+        - owner
+        - viewer
+        - recorder
+    SessionConnectionInfo:
+      type: object
+      required:
+        - connection_id
+        - role
+      properties:
+        connection_id:
+          type: integer
+          minimum: 1
+        role:
+          $ref: '#/components/schemas/SessionConnectionRole'
     SessionStopBlockerKind:
       type: string
       enum:
@@ -4315,6 +4378,7 @@ components:
         - connection_counts
         - stop_eligibility
         - idle
+        - connections
         - browser_clients
         - viewer_clients
         - recorder_clients
@@ -4339,6 +4403,10 @@ components:
           $ref: '#/components/schemas/SessionStopEligibility'
         idle:
           $ref: '#/components/schemas/SessionIdleStatus'
+        connections:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionConnectionInfo'
         browser_clients:
           type: integer
           minimum: 0


### PR DESCRIPTION
## Summary
- add side-effect-free session lifecycle status with explicit runtime, presence, idle, and connection state
- add safe stop, force kill, and connection-level disconnect controls to the session API and test console
- switch local compose testing to `docker_pool`, harden MCP/browser cooperation, and update lifecycle/MCP documentation

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -p bpane-gateway --all-targets --all-features -- -D warnings`
- `cargo test -p bpane-gateway`
- `npm run smoke:test-embed-overlay -- --headless`
- `npm run smoke:test-embed-lifecycle -- --headless`

Refs #55
