### PR TITLE
BPANE-0087 Admin workflow run inspector

### DIFF
--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -57,10 +57,10 @@ use crate::workflow::{
     StoredWorkflowDefinition, StoredWorkflowDefinitionVersion, StoredWorkflowRun,
     WorkflowDefinitionListResponse, WorkflowDefinitionResource, WorkflowDefinitionVersionResource,
     WorkflowRunEventListResponse, WorkflowRunEventResource, WorkflowRunInterventionResource,
-    WorkflowRunLogListResponse, WorkflowRunLogResource, WorkflowRunProducedFileResource,
-    WorkflowRunRecordingResource, WorkflowRunResource, WorkflowRunRetentionResource,
-    WorkflowRunSourceSnapshot, WorkflowRunState, WorkflowRunTransitionRequest,
-    WorkflowRunWorkspaceInput,
+    WorkflowRunListResponse, WorkflowRunLogListResponse, WorkflowRunLogResource,
+    WorkflowRunProducedFileResource, WorkflowRunRecordingResource, WorkflowRunResource,
+    WorkflowRunRetentionResource, WorkflowRunSourceSnapshot, WorkflowRunState,
+    WorkflowRunTransitionRequest, WorkflowRunWorkspaceInput,
 };
 use crate::workflow::{
     validate_workflow_source_entrypoint, WorkflowObservabilitySnapshot, WorkflowSourceArchive,

--- a/code/apps/bpane-gateway/src/api/tests/workflow_definitions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/workflow_definitions/contract.rs
@@ -1,8 +1,13 @@
 use super::*;
 
 #[tokio::test]
-async fn creates_workflow_definitions_versions_and_runs_with_default_sessions() {
-    let (app, token) = test_router();
+async fn creates_workflow_definitions_versions_and_workflow_runs_with_default_sessions() {
+    let (app, token, state) = test_router_with_state();
+    sleep(Duration::from_secs(1)).await;
+    let foreign_token = state
+        .auth_validator
+        .generate_token()
+        .expect("hmac auth validator should generate a second dev token");
 
     let create_workflow = app
         .clone()
@@ -130,6 +135,95 @@ async fn creates_workflow_definitions_versions_and_runs_with_default_sessions() 
     assert_eq!(run["workflow_definition_id"], workflow_id);
     assert_eq!(run["workflow_version"], "v1");
     assert_eq!(run["state"], "pending");
+
+    let list_runs = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/workflow-runs")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_runs.status(), StatusCode::OK);
+    let runs_body = response_json(list_runs).await;
+    let runs = runs_body["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0]["id"], run_id);
+    assert_eq!(runs[0]["session_id"], session_id);
+    assert_eq!(
+        runs[0]["events_path"],
+        format!("/api/v1/workflow-runs/{run_id}/events")
+    );
+    assert_eq!(
+        runs[0]["logs_path"],
+        format!("/api/v1/workflow-runs/{run_id}/logs")
+    );
+
+    let foreign_list_runs = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/workflow-runs")
+                .header("authorization", bearer(&foreign_token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(foreign_list_runs.status(), StatusCode::OK);
+    let foreign_runs_body = response_json(foreign_list_runs).await;
+    assert_eq!(foreign_runs_body["runs"].as_array().unwrap().len(), 0);
+
+    let create_second_run = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/workflow-runs")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "workflow_id": workflow_id,
+                        "version": "v1",
+                        "session": {
+                            "existing_session_id": session_id
+                        },
+                        "input": {
+                            "month": "2026-04",
+                            "country_code": "DE"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_second_run.status(), StatusCode::CREATED);
+    let second_run = response_json(create_second_run).await;
+    let second_run_id = second_run["id"].as_str().unwrap().to_string();
+
+    let ordered_list_runs = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/workflow-runs")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ordered_list_runs.status(), StatusCode::OK);
+    let ordered_runs_body = response_json(ordered_list_runs).await;
+    let ordered_runs = ordered_runs_body["runs"].as_array().unwrap();
+    assert_eq!(ordered_runs.len(), 2);
+    assert_eq!(ordered_runs[0]["id"], second_run_id);
+    assert_eq!(ordered_runs[1]["id"], run_id);
 
     let get_run = app
         .clone()

--- a/code/apps/bpane-gateway/src/api/workflows.rs
+++ b/code/apps/bpane-gateway/src/api/workflows.rs
@@ -1,13 +1,16 @@
 mod create;
 mod read;
 
-use axum::routing::{get, post};
+use axum::routing::get;
 
 use super::*;
 
 pub(super) fn workflow_routes() -> Router<Arc<ApiState>> {
     Router::new()
-        .route("/api/v1/workflow-runs", post(create::create_workflow_run))
+        .route(
+            "/api/v1/workflow-runs",
+            get(read::list_workflow_runs).post(create::create_workflow_run),
+        )
         .route(
             "/api/v1/workflow-runs/{run_id}",
             get(read::get_workflow_run),

--- a/code/apps/bpane-gateway/src/api/workflows/read.rs
+++ b/code/apps/bpane-gateway/src/api/workflows/read.rs
@@ -1,5 +1,31 @@
 use super::super::*;
 
+pub(super) async fn list_workflow_runs(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<WorkflowRunListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let _ = state.workflow_lifecycle.reconcile_waiting_runs().await;
+    let mut runs = state
+        .session_store
+        .list_workflow_runs_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    runs.sort_by(|left, right| {
+        right
+            .created_at
+            .cmp(&left.created_at)
+            .then_with(|| right.id.cmp(&left.id))
+    });
+    let mut resources = Vec::with_capacity(runs.len());
+    for run in runs {
+        resources.push(build_workflow_run_resource(&state, &run).await?);
+    }
+    Ok(Json(WorkflowRunListResponse { runs: resources }))
+}
+
 pub(super) async fn get_workflow_run(
     headers: HeaderMap,
     Path(run_id): Path<Uuid>,

--- a/code/apps/bpane-gateway/src/workflow/mod.rs
+++ b/code/apps/bpane-gateway/src/workflow/mod.rs
@@ -8,9 +8,9 @@ pub mod state;
 pub use observability::{WorkflowObservability, WorkflowObservabilitySnapshot};
 pub use resources::{
     WorkflowDefinitionListResponse, WorkflowDefinitionResource, WorkflowDefinitionVersionResource,
-    WorkflowRunEventListResponse, WorkflowRunEventResource, WorkflowRunLogListResponse,
-    WorkflowRunLogResource, WorkflowRunProducedFileResource, WorkflowRunRecordingResource,
-    WorkflowRunResource, WorkflowRunRetentionResource,
+    WorkflowRunEventListResponse, WorkflowRunEventResource, WorkflowRunListResponse,
+    WorkflowRunLogListResponse, WorkflowRunLogResource, WorkflowRunProducedFileResource,
+    WorkflowRunRecordingResource, WorkflowRunResource, WorkflowRunRetentionResource,
 };
 pub use retention::WorkflowRetentionManager;
 pub use runtime::{

--- a/code/apps/bpane-gateway/src/workflow/resources.rs
+++ b/code/apps/bpane-gateway/src/workflow/resources.rs
@@ -150,6 +150,11 @@ pub struct WorkflowRunResource {
     pub updated_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct WorkflowRunListResponse {
+    pub runs: Vec<WorkflowRunResource>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct WorkflowRunEventResource {
     pub id: Uuid,

--- a/code/web/bpane-admin/src/lib/api/workflow-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-client.test.ts
@@ -112,6 +112,19 @@ describe('WorkflowClient', () => {
     );
   });
 
+  it('lists workflow runs for the current owner', async () => {
+    const fetchImpl = jsonFetch({ runs: [RUN] });
+    const client = newClient(fetchImpl);
+
+    const response = await client.listRuns();
+
+    expect(response.runs[0]?.id).toBe(RUN.id);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('http://localhost:8932/api/v1/workflow-runs'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('controls workflow run cancellation and resume', async () => {
     const fetchImpl = jsonFetchSequence([{ ...RUN, state: 'cancelled' }, { ...RUN, state: 'running' }]);
     const client = newClient(fetchImpl);

--- a/code/web/bpane-admin/src/lib/api/workflow-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-client.test.ts
@@ -71,6 +71,43 @@ describe('WorkflowClient', () => {
     );
   });
 
+  it('creates workflow definitions and versions', async () => {
+    const fetchImpl = jsonFetchSequence([WORKFLOW, VERSION]);
+    const client = newClient(fetchImpl);
+
+    const workflow = await client.createDefinition({
+      name: WORKFLOW.name,
+      description: WORKFLOW.description ?? undefined,
+      labels: WORKFLOW.labels,
+    });
+    const version = await client.createDefinitionVersion(WORKFLOW.id, {
+      version: 'v1',
+      executor: 'playwright',
+      entrypoint: 'dev/workflows/browserpane-tour/run.mjs',
+      source: { kind: 'git', repository_url: '/workspace', ref: 'HEAD', root_path: 'dev' },
+    });
+
+    expect(workflow.id).toBe(WORKFLOW.id);
+    expect(version.entrypoint).toBe(VERSION.entrypoint);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL('http://localhost:8932/api/v1/workflows'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: WORKFLOW.name,
+          description: WORKFLOW.description,
+          labels: WORKFLOW.labels,
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL(`http://localhost:8932/api/v1/workflows/${WORKFLOW.id}/versions`),
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
   it('encodes workflow and version identifiers', async () => {
     const fetchImpl = jsonFetch(VERSION);
     const client = newClient(fetchImpl);

--- a/code/web/bpane-admin/src/lib/api/workflow-client.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-client.ts
@@ -7,6 +7,8 @@ import {
 import { WorkflowMapper } from './workflow-mapper';
 import { WorkflowRunMapper } from './workflow-run-mapper';
 import type {
+  CreateWorkflowDefinitionCommand,
+  CreateWorkflowDefinitionVersionCommand,
   CreateWorkflowRunCommand,
   RejectWorkflowRunCommand,
   ResumeWorkflowRunCommand,
@@ -47,9 +49,26 @@ export class WorkflowClient {
     return WorkflowMapper.toDefinitionList(payload);
   }
 
+  async createDefinition(command: CreateWorkflowDefinitionCommand): Promise<WorkflowDefinitionResource> {
+    const payload = await this.#request('POST', '/api/v1/workflows', command);
+    return WorkflowMapper.toDefinition(payload);
+  }
+
   async getDefinition(workflowId: string): Promise<WorkflowDefinitionResource> {
     const payload = await this.#request('GET', `/api/v1/workflows/${encodeURIComponent(workflowId)}`);
     return WorkflowMapper.toDefinition(payload);
+  }
+
+  async createDefinitionVersion(
+    workflowId: string,
+    command: CreateWorkflowDefinitionVersionCommand,
+  ): Promise<WorkflowDefinitionVersionResource> {
+    const payload = await this.#request(
+      'POST',
+      `/api/v1/workflows/${encodeURIComponent(workflowId)}/versions`,
+      command,
+    );
+    return WorkflowMapper.toDefinitionVersion(payload);
   }
 
   async getDefinitionVersion(

--- a/code/web/bpane-admin/src/lib/api/workflow-client.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-client.ts
@@ -15,6 +15,7 @@ import type {
   WorkflowDefinitionResource,
   WorkflowDefinitionVersionResource,
   WorkflowRunEventListResponse,
+  WorkflowRunListResponse,
   WorkflowRunLogListResponse,
   WorkflowRunProducedFileListResponse,
   WorkflowRunProducedFileResource,
@@ -65,6 +66,11 @@ export class WorkflowClient {
   async createRun(command: CreateWorkflowRunCommand): Promise<WorkflowRunResource> {
     const payload = await this.#request('POST', '/api/v1/workflow-runs', command);
     return WorkflowRunMapper.toRun(payload);
+  }
+
+  async listRuns(): Promise<WorkflowRunListResponse> {
+    const payload = await this.#request('GET', '/api/v1/workflow-runs');
+    return WorkflowRunMapper.toRunList(payload);
   }
 
   async getRun(runId: string): Promise<WorkflowRunResource> {

--- a/code/web/bpane-admin/src/lib/api/workflow-run-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-run-mapper.ts
@@ -3,6 +3,7 @@ import type {
   WorkflowRunEventResource,
   WorkflowRunInterventionRequestResource,
   WorkflowRunInterventionResource,
+  WorkflowRunListResponse,
   WorkflowRunLogListResponse,
   WorkflowRunLogResource,
   WorkflowRunProducedFileListResponse,
@@ -20,6 +21,13 @@ import {
 } from './control-wire';
 
 export class WorkflowRunMapper {
+  static toRunList(payload: unknown): WorkflowRunListResponse {
+    const object = expectRecord(payload, 'workflow run list response');
+    return {
+      runs: expectArray(object.runs, 'workflow run list runs').map((entry) => this.toRun(entry)),
+    };
+  }
+
   static toRun(payload: unknown): WorkflowRunResource {
     const object = expectRecord(payload, 'workflow run resource');
     const sourceSystem = optionalString(object.source_system, 'workflow run source_system');

--- a/code/web/bpane-admin/src/lib/api/workflow-types.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-types.ts
@@ -87,6 +87,10 @@ export type WorkflowRunResource = {
   readonly updated_at: string;
 };
 
+export type WorkflowRunListResponse = {
+  readonly runs: readonly WorkflowRunResource[];
+};
+
 export type WorkflowRunInterventionResource = {
   readonly pending_request?: WorkflowRunInterventionRequestResource | null;
 };

--- a/code/web/bpane-admin/src/lib/api/workflow-types.ts
+++ b/code/web/bpane-admin/src/lib/api/workflow-types.ts
@@ -12,6 +12,12 @@ export type WorkflowDefinitionListResponse = {
   readonly workflows: readonly WorkflowDefinitionResource[];
 };
 
+export type CreateWorkflowDefinitionCommand = {
+  readonly name: string;
+  readonly description?: string;
+  readonly labels?: Readonly<Record<string, string>>;
+};
+
 export type WorkflowDefinitionVersionResource = {
   readonly id: string;
   readonly workflow_definition_id: string;
@@ -26,6 +32,19 @@ export type WorkflowDefinitionVersionResource = {
   readonly allowed_extension_ids: readonly string[];
   readonly allowed_file_workspace_ids: readonly string[];
   readonly created_at: string;
+};
+
+export type CreateWorkflowDefinitionVersionCommand = {
+  readonly version: string;
+  readonly executor: string;
+  readonly entrypoint: string;
+  readonly source?: unknown;
+  readonly input_schema?: unknown;
+  readonly output_schema?: unknown;
+  readonly default_session?: unknown;
+  readonly allowed_credential_binding_ids?: readonly string[];
+  readonly allowed_extension_ids?: readonly string[];
+  readonly allowed_file_workspace_ids?: readonly string[];
 };
 
 export type WorkflowRunSessionCommand = {

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { onMount } from 'svelte';
+  import type { WorkflowClient } from '../api/workflow-client';
+  import type {
+    WorkflowRunEventResource,
+    WorkflowRunLogResource,
+    WorkflowRunProducedFileResource,
+    WorkflowRunResource,
+  } from '../api/workflow-types';
+
+  type AdminWorkflowRunDetailRouteProps = {
+    readonly workflowClient: WorkflowClient;
+    readonly runId: string;
+  };
+
+  let { workflowClient, runId }: AdminWorkflowRunDetailRouteProps = $props();
+  let run = $state<WorkflowRunResource | null>(null);
+  let events = $state<readonly WorkflowRunEventResource[]>([]);
+  let logs = $state<readonly WorkflowRunLogResource[]>([]);
+  let files = $state<readonly WorkflowRunProducedFileResource[]>([]);
+  let loading = $state(false);
+  let actionInFlight = $state(false);
+  let error = $state<string | null>(null);
+  let evidenceError = $state<string | null>(null);
+  let lastRefreshedAt = $state<string | null>(null);
+  let operatorInputText = $state('{}');
+  let rejectReason = $state('Rejected from admin');
+
+  const terminal = $derived(isTerminal(run?.state ?? null));
+  const pendingRequest = $derived(run?.intervention.pending_request ?? null);
+  const operatorInputValid = $derived(isJson(operatorInputText));
+
+  onMount(() => {
+    void refreshInspector();
+  });
+
+  async function refreshInspector(): Promise<void> {
+    loading = true;
+    error = null;
+    evidenceError = null;
+    try {
+      run = await workflowClient.getRun(runId);
+      await loadEvidence();
+      lastRefreshedAt = new Date().toISOString();
+    } catch (refreshError) {
+      error = errorMessage(refreshError, 'Unexpected workflow run detail error');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadEvidence(): Promise<void> {
+    const [eventResult, logResult, fileResult] = await Promise.allSettled([
+      workflowClient.listRunEvents(runId),
+      workflowClient.listRunLogs(runId),
+      workflowClient.listProducedFiles(runId),
+    ]);
+    const errors: string[] = [];
+    if (eventResult.status === 'fulfilled') {
+      events = eventResult.value.events;
+    } else {
+      events = [];
+      errors.push(errorMessage(eventResult.reason, 'Workflow run events failed'));
+    }
+    if (logResult.status === 'fulfilled') {
+      logs = logResult.value.logs;
+    } else {
+      logs = [];
+      errors.push(errorMessage(logResult.reason, 'Workflow run logs failed'));
+    }
+    if (fileResult.status === 'fulfilled') {
+      files = fileResult.value.files;
+    } else {
+      files = [];
+      errors.push(errorMessage(fileResult.reason, 'Workflow run produced files failed'));
+    }
+    evidenceError = errors.length > 0 ? errors.join(' | ') : null;
+  }
+
+  async function mutateRun(action: () => Promise<WorkflowRunResource>): Promise<void> {
+    actionInFlight = true;
+    error = null;
+    try {
+      run = await action();
+      await loadEvidence();
+      lastRefreshedAt = new Date().toISOString();
+    } catch (mutationError) {
+      error = errorMessage(mutationError, 'Unexpected workflow run action error');
+    } finally {
+      actionInFlight = false;
+    }
+  }
+
+  async function downloadProducedFile(fileId: string): Promise<void> {
+    const file = files.find((entry) => entry.file_id === fileId);
+    if (!file) {
+      return;
+    }
+    try {
+      const url = URL.createObjectURL(await workflowClient.downloadProducedFileContent(file));
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = file.file_name;
+      document.body.append(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (downloadError) {
+      error = errorMessage(downloadError, 'Produced file download failed');
+    }
+  }
+
+  function submitInput(): void {
+    if (!operatorInputValid) {
+      error = 'Operator input must be valid JSON.';
+      return;
+    }
+    void mutateRun(() => workflowClient.submitRunInput(runId, {
+      input: parseJson(operatorInputText),
+      comment: 'operator input from workflow run detail',
+    }));
+  }
+
+  function formatDate(value: string | null | undefined): string {
+    return value ? new Date(value).toLocaleString() : '--';
+  }
+
+  function formatJson(value: unknown): string {
+    if (value === undefined || value === null) {
+      return '--';
+    }
+    const serialized = JSON.stringify(value, null, 2);
+    return serialized.length > 900 ? `${serialized.slice(0, 900)}...` : serialized;
+  }
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KiB`;
+    }
+    return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+  }
+
+  function parseJson(text: string): unknown {
+    return JSON.parse(text.trim() || '{}');
+  }
+
+  function isJson(text: string): boolean {
+    try {
+      parseJson(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  function isTerminal(state: string | null): boolean {
+    return state === 'succeeded' || state === 'failed' || state === 'cancelled' || state === 'timed_out';
+  }
+
+  function errorMessage(value: unknown, fallback: string): string {
+    return value instanceof Error ? value.message : fallback;
+  }
+</script>
+
+<section class="grid gap-5" data-testid="workflow-run-inspector-detail">
+  <div class="admin-panel mt-0">
+    <div class="admin-header">
+      <div class="min-w-0">
+        <p class="admin-eyebrow">Workflow run detail</p>
+        <h1 class="m-0 truncate font-mono text-xl font-bold text-admin-ink" data-testid="workflow-run-inspector-title">
+          {run?.id ?? runId}
+        </h1>
+      </div>
+      <div class="admin-actions">
+        <a class="admin-button-ghost" href={`${base}/workflow-runs`}>Workflow runs</a>
+        {#if run}
+          <a class="admin-button-ghost" data-testid="workflow-run-session-link" href={`${base}/sessions/${encodeURIComponent(run.session_id)}`}>Session</a>
+        {/if}
+        <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="workflow-run-inspector-detail-refresh"
+          disabled={loading || actionInFlight}
+          onclick={() => void refreshInspector()}
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+    <p class="m-0 mt-3 text-sm text-admin-ink/62" data-testid="workflow-run-inspector-last-refresh">
+      Last refreshed {formatDate(lastRefreshedAt)}
+    </p>
+  </div>
+
+  {#if loading && !run}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0">Loading workflow run...</p>
+    </section>
+  {:else if error && !run}
+    <section class="admin-panel mt-0">
+      <p class="admin-error mt-0" data-testid="workflow-run-inspector-detail-error">{error}</p>
+    </section>
+  {:else if run}
+    {#if error}
+      <p class="admin-error" data-testid="workflow-run-inspector-action-error">{error}</p>
+    {/if}
+
+    <section class="grid gap-3 md:grid-cols-4" aria-label="Workflow run facts">
+      {@render Fact('State', run.state, 'workflow-run-detail-state')}
+      {@render Fact('Version', run.workflow_version, 'workflow-run-detail-version')}
+      {@render Fact('Logs', String(logs.length), 'workflow-run-detail-log-count')}
+      {@render Fact('Files', String(files.length), 'workflow-run-detail-file-count')}
+    </section>
+
+    <section class="admin-panel mt-0 grid gap-4">
+      <div class="grid gap-3 lg:grid-cols-2">
+        <div class="grid min-w-0 gap-2 text-sm text-admin-ink/72">
+          <span><strong>Workflow:</strong> <code class="admin-code-pill">{run.workflow_definition_id}</code></span>
+          <span><strong>Version id:</strong> <code class="admin-code-pill">{run.workflow_definition_version_id}</code></span>
+          <span><strong>Session:</strong> <code class="admin-code-pill" data-testid="workflow-run-detail-session-id">{run.session_id}</code></span>
+          <span><strong>Automation task:</strong> <code class="admin-code-pill">{run.automation_task_id}</code></span>
+          <span><strong>Source:</strong> {run.source_system ?? '--'} {run.source_reference ?? ''}</span>
+          <span><strong>Client request:</strong> {run.client_request_id ?? '--'}</span>
+        </div>
+        <div class="grid min-w-0 gap-2 text-sm text-admin-ink/72">
+          <span><strong>Created:</strong> {formatDate(run.created_at)}</span>
+          <span><strong>Updated:</strong> {formatDate(run.updated_at)}</span>
+          <span><strong>Started:</strong> {formatDate(run.started_at)}</span>
+          <span><strong>Completed:</strong> {formatDate(run.completed_at)}</span>
+          <span><strong>Runtime:</strong> {run.runtime?.resume_mode ?? '--'} | exact {run.runtime?.exact_runtime_available ? 'yes' : 'no'}</span>
+          <span><strong>Hold until:</strong> {formatDate(run.runtime?.hold_until)}</span>
+        </div>
+      </div>
+      {#if run.error}
+        <p class="admin-error m-0" data-testid="workflow-run-detail-terminal-error">{run.error}</p>
+      {/if}
+    </section>
+
+    <section class="admin-panel mt-0 grid gap-4">
+      <div class="admin-header">
+        <div>
+          <p class="admin-eyebrow">Controls</p>
+          <h2 class="admin-section-title">Run actions</h2>
+        </div>
+        <div class="admin-actions">
+          <button
+            class="admin-button-primary"
+            type="button"
+            data-testid="workflow-run-detail-cancel"
+            disabled={terminal || actionInFlight}
+            onclick={() => void mutateRun(() => workflowClient.cancelRun(runId))}
+          >
+            Cancel
+          </button>
+          <button
+            class="admin-button-primary"
+            type="button"
+            data-testid="workflow-run-detail-resume"
+            disabled={!pendingRequest || actionInFlight}
+            onclick={() => void mutateRun(() => workflowClient.resumeRun(runId, { comment: 'released from workflow run detail' }))}
+          >
+            Resume
+          </button>
+        </div>
+      </div>
+
+      <p class="m-0 text-sm text-admin-ink/70" data-testid="workflow-run-detail-pending-prompt">
+        {pendingRequest?.prompt ?? pendingRequest?.kind ?? 'No pending operator input.'}
+      </p>
+      <label class="grid gap-1.5 text-sm font-bold text-admin-ink">
+        Operator input JSON
+        <textarea
+          class="min-h-24 rounded-xl border border-admin-ink/14 bg-admin-field p-3 font-mono text-xs text-admin-ink"
+          data-testid="workflow-run-detail-operator-input"
+          bind:value={operatorInputText}
+          disabled={!pendingRequest || actionInFlight}
+        ></textarea>
+      </label>
+      <label class="grid gap-1.5 text-sm font-bold text-admin-ink">
+        Reject reason
+        <input
+          class="min-h-10 rounded-xl border border-admin-ink/14 bg-admin-field px-3 text-admin-ink"
+          data-testid="workflow-run-detail-reject-reason"
+          bind:value={rejectReason}
+          disabled={!pendingRequest || actionInFlight}
+        />
+      </label>
+      <div class="flex flex-wrap gap-2">
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="workflow-run-detail-submit-input"
+          disabled={!pendingRequest || !operatorInputValid || actionInFlight}
+          onclick={submitInput}
+        >
+          Submit input
+        </button>
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="workflow-run-detail-reject"
+          disabled={!pendingRequest || rejectReason.trim().length === 0 || actionInFlight}
+          onclick={() => void mutateRun(() => workflowClient.rejectRun(runId, { reason: rejectReason.trim() }))}
+        >
+          Reject
+        </button>
+      </div>
+    </section>
+
+    <section class="grid gap-3 lg:grid-cols-2">
+      {@render JsonPanel('Input', run.input, 'workflow-run-detail-input')}
+      {@render JsonPanel('Output', run.output, 'workflow-run-detail-output')}
+    </section>
+
+    <section class="grid gap-3 lg:grid-cols-2">
+      {@render Timeline('Recent events', events, 'No workflow events loaded.', 'workflow-run-detail-event-count')}
+      {@render LogTimeline('Recent logs', logs, 'No workflow logs loaded.', 'workflow-run-detail-log-list-count')}
+    </section>
+
+    <section class="admin-panel mt-0 grid gap-3">
+      <div class="admin-header">
+        <div>
+          <p class="admin-eyebrow">Produced files</p>
+          <h2 class="admin-section-title">Artifacts</h2>
+        </div>
+        <span class="text-sm font-bold text-admin-ink/70" data-testid="workflow-run-detail-produced-file-count">
+          {files.length} files
+        </span>
+      </div>
+      {#if files.length === 0}
+        <p class="admin-empty mt-0">No produced files loaded.</p>
+      {:else}
+        <div class="grid gap-2">
+          {#each files as file}
+            <button
+              class="flex min-w-0 items-center justify-between gap-3 rounded-xl border border-admin-ink/10 bg-admin-field p-3 text-left text-sm text-admin-ink"
+              type="button"
+              data-testid="workflow-run-detail-produced-file"
+              onclick={() => void downloadProducedFile(file.file_id)}
+            >
+              <span class="min-w-0 truncate font-bold">{file.file_name}</span>
+              <span class="shrink-0 text-xs text-admin-ink/58">{formatBytes(file.byte_count)}</span>
+            </button>
+          {/each}
+        </div>
+      {/if}
+      {#if evidenceError}
+        <p class="admin-error" data-testid="workflow-run-inspector-evidence-error">{evidenceError}</p>
+      {/if}
+    </section>
+  {/if}
+</section>
+
+{#snippet Fact(label: string, value: string, testId: string)}
+  <span class="min-w-0 rounded-xl bg-admin-leaf/10 p-3 text-xs font-bold text-admin-ink/68 uppercase">
+    {label}
+    <strong class="mt-1 block truncate font-mono text-admin-ink normal-case" data-testid={testId}>{value}</strong>
+  </span>
+{/snippet}
+
+{#snippet JsonPanel(title: string, value: unknown, testId: string)}
+  <section class="admin-panel mt-0">
+    <p class="admin-eyebrow">{title}</p>
+    <pre class="m-0 max-h-[320px] overflow-auto rounded-xl bg-admin-night/80 p-3 text-xs text-admin-ink/78" data-testid={testId}>{formatJson(value)}</pre>
+  </section>
+{/snippet}
+
+{#snippet Timeline(title: string, rows: readonly WorkflowRunEventResource[], empty: string, testId: string)}
+  <section class="admin-panel mt-0">
+    <div class="admin-header">
+      <div>
+        <p class="admin-eyebrow">{title}</p>
+        <h2 class="admin-section-title" data-testid={testId}>{rows.length}</h2>
+      </div>
+    </div>
+    {#if rows.length === 0}
+      <p class="admin-empty mt-0">{empty}</p>
+    {:else}
+      <div class="mt-3 grid gap-2">
+        {#each rows.slice(-8).reverse() as row}
+          <p class="m-0 rounded-xl bg-admin-field p-3 text-xs text-admin-ink/70">
+            <strong class="block truncate text-admin-ink">{row.event_type}</strong>
+            <span class="[overflow-wrap:anywhere]">{row.message}</span>
+          </p>
+        {/each}
+      </div>
+    {/if}
+  </section>
+{/snippet}
+
+{#snippet LogTimeline(title: string, rows: readonly WorkflowRunLogResource[], empty: string, testId: string)}
+  <section class="admin-panel mt-0">
+    <div class="admin-header">
+      <div>
+        <p class="admin-eyebrow">{title}</p>
+        <h2 class="admin-section-title" data-testid={testId}>{rows.length}</h2>
+      </div>
+    </div>
+    {#if rows.length === 0}
+      <p class="admin-empty mt-0">{empty}</p>
+    {:else}
+      <div class="mt-3 grid gap-2">
+        {#each rows.slice(-8).reverse() as row}
+          <p class="m-0 rounded-xl bg-admin-field p-3 text-xs text-admin-ink/70">
+            <strong class="block truncate text-admin-ink">{row.source} {row.stream}</strong>
+            <span class="[overflow-wrap:anywhere]">{row.message}</span>
+          </p>
+        {/each}
+      </div>
+    {/if}
+  </section>
+{/snippet}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowRunListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowRunListRoute.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { onMount } from 'svelte';
+  import type { WorkflowClient } from '../api/workflow-client';
+  import type { WorkflowRunResource } from '../api/workflow-types';
+
+  type AdminWorkflowRunListRouteProps = {
+    readonly workflowClient: WorkflowClient;
+  };
+
+  let { workflowClient }: AdminWorkflowRunListRouteProps = $props();
+  let runs = $state<readonly WorkflowRunResource[]>([]);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let search = $state('');
+  let lastRefreshedAt = $state<string | null>(null);
+
+  const filteredRuns = $derived(filterRuns(runs, search));
+
+  onMount(() => {
+    void loadRuns();
+  });
+
+  async function loadRuns(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      runs = (await workflowClient.listRuns()).runs;
+      lastRefreshedAt = new Date().toISOString();
+    } catch (loadError) {
+      error = errorMessage(loadError);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function detailHref(runId: string): string {
+    return `${base}/workflow-runs/${encodeURIComponent(runId)}`;
+  }
+
+  function sessionHref(sessionId: string): string {
+    return `${base}/sessions/${encodeURIComponent(sessionId)}`;
+  }
+
+  function filterRuns(items: readonly WorkflowRunResource[], query: string): readonly WorkflowRunResource[] {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) {
+      return items;
+    }
+    return items.filter((run) => [
+      run.id,
+      run.state,
+      run.session_id,
+      run.automation_task_id,
+      run.workflow_definition_id,
+      run.workflow_version,
+      run.source_system ?? '',
+      run.source_reference ?? '',
+      run.client_request_id ?? '',
+    ].some((value) => value.toLowerCase().includes(normalized)));
+  }
+
+  function formatDate(value: string | null): string {
+    return value ? new Date(value).toLocaleString() : 'not refreshed';
+  }
+
+  function terminalLabel(run: WorkflowRunResource): string {
+    if (run.completed_at) {
+      return `completed ${formatDate(run.completed_at)}`;
+    }
+    if (run.started_at) {
+      return `started ${formatDate(run.started_at)}`;
+    }
+    return `created ${formatDate(run.created_at)}`;
+  }
+
+  function errorMessage(value: unknown): string {
+    return value instanceof Error ? value.message : 'Unexpected workflow run list error';
+  }
+</script>
+
+<section class="grid gap-5" data-testid="workflow-run-inspector-list">
+  <div class="admin-panel mt-0">
+    <div class="admin-header">
+      <div>
+        <p class="admin-eyebrow">Workflow runs</p>
+        <h1 class="admin-section-title">Workflow run inspector</h1>
+      </div>
+      <div class="admin-actions">
+        <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <a class="admin-button-ghost" href={`${base}/sessions`}>Sessions</a>
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="workflow-run-inspector-refresh"
+          disabled={loading}
+          onclick={() => void loadRuns()}
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+    <div class="mt-4 grid gap-3 md:grid-cols-[minmax(220px,360px)_1fr] md:items-end">
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Search
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="workflow-run-inspector-search"
+          placeholder="Run id, state, session, source"
+          bind:value={search}
+        />
+      </label>
+      <p class="m-0 text-sm text-admin-ink/62" data-testid="workflow-run-inspector-count">
+        {filteredRuns.length} of {runs.length} visible runs | Last refreshed {formatDate(lastRefreshedAt)}
+      </p>
+    </div>
+  </div>
+
+  {#if loading && runs.length === 0}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0">Loading workflow runs...</p>
+    </section>
+  {:else if error}
+    <section class="admin-panel mt-0">
+      <p class="admin-error mt-0" data-testid="workflow-run-inspector-error">{error}</p>
+    </section>
+  {:else if filteredRuns.length === 0}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0" data-testid="workflow-run-inspector-empty">
+        No workflow runs match the current filter.
+      </p>
+    </section>
+  {:else}
+    <section class="grid gap-2" aria-label="Workflow run table">
+      {#each filteredRuns as run}
+        <a
+          class="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 rounded-xl border border-admin-ink/10 bg-admin-panel/82 p-4 text-admin-ink no-underline transition hover:border-admin-leaf/42 hover:bg-admin-field/78"
+          href={detailHref(run.id)}
+          data-testid="workflow-run-inspector-row"
+          data-run-id={run.id}
+        >
+          <span class="grid min-w-0 gap-1">
+            <strong class="truncate font-mono text-sm" title={run.id}>{run.id}</strong>
+            <span class="truncate text-xs text-admin-ink/58">
+              v{run.workflow_version} | {terminalLabel(run)}
+            </span>
+            <span class="truncate text-xs text-admin-ink/58">
+              session <span class="font-mono">{run.session_id}</span>
+            </span>
+          </span>
+          <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">
+            <span class="rounded-lg bg-admin-field/72 px-2 py-1" data-testid="workflow-run-inspector-row-state">
+              {run.state}
+            </span>
+            <span class="rounded-lg bg-admin-field/72 px-2 py-1">
+              {run.produced_files.length} files
+            </span>
+          </span>
+        </a>
+        <a class="sr-only" href={sessionHref(run.session_id)}>Linked session</a>
+      {/each}
+    </section>
+  {/if}
+</section>

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -180,7 +180,13 @@
       {:else if activePanel.id === 'logs'}
         <LogsSurface entries={props.logEntries} onClear={props.onClearLogs} />
       {:else if activePanel.id === 'workflows'}
-        <WorkflowOperationsSurface workflowClient={props.workflowClient} selectedSession={props.selectedSession} />
+        <WorkflowOperationsSurface
+          workflowClient={props.workflowClient}
+          selectedSession={props.selectedSession}
+          connected={props.browserConnected}
+          onCreateSession={props.onCreateSession}
+          onConnectSession={props.onJoinSelectedSession}
+        />
       {:else}
         <FeaturePlaceholderPanel panel={activePanel} />
       {/if}

--- a/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
@@ -10,9 +10,18 @@
   type WorkflowOperationsSurfaceProps = {
     readonly workflowClient: WorkflowClient;
     readonly selectedSession: SessionResource | null;
+    readonly connected: boolean;
+    readonly onCreateSession: () => void;
+    readonly onConnectSession: () => void;
   };
 
-  let { workflowClient, selectedSession }: WorkflowOperationsSurfaceProps = $props();
+  let {
+    workflowClient,
+    selectedSession,
+    connected,
+    onCreateSession,
+    onConnectSession,
+  }: WorkflowOperationsSurfaceProps = $props();
   const workflowService = $derived(new WorkflowOperationsService(workflowClient));
   let definitions = $state<readonly WorkflowDefinitionResource[]>([]);
   let selectedWorkflowId = $state('');
@@ -33,7 +42,7 @@
   const interventionInputValid = $derived(isJson(interventionInputText));
   const viewModel = $derived(WorkflowOperationsViewModelBuilder.build({
     selectedSession, definitions, selectedWorkflowId, selectedVersion, selectedVersionResource,
-    currentRun, logs, events, files, loading, actionInFlight, error, inputValid,
+    currentRun, logs, events, files, loading, actionInFlight, error, inputValid, connected,
     interventionInputValid,
   }));
 
@@ -90,7 +99,12 @@
   }
 
   async function invokeRun(): Promise<void> {
-    if (!selectedSession || !selectedWorkflowId || !selectedVersion) {
+    if (viewModel.invokeBlockedReason) {
+      error = viewModel.invokeBlockedReason;
+      return;
+    }
+    if (!selectedSession) {
+      error = 'Select or create a session before invoking a workflow. The selected session is the workflow baseline.';
       return;
     }
     await runAction(async () => {
@@ -191,6 +205,8 @@
   onVersionChange={(version) => { selectedVersion = version.trim(); selectedVersionResource = null; }}
   onInputTextChange={(next) => { inputText = next; }}
   onInterventionInputChange={(next) => { interventionInputText = next; }}
+  onCreateSession={onCreateSession}
+  onConnectSession={onConnectSession}
   onInvokeRun={() => void invokeRun()}
   onRefreshRun={() => void refreshRunResources()}
   onCancelRun={() => currentRun && void mutateRun(() => workflowService.cancelRun(currentRun!.id))}

--- a/code/web/bpane-admin/src/lib/application/workflow-operations-service.test.ts
+++ b/code/web/bpane-admin/src/lib/application/workflow-operations-service.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowClient } from '../api/workflow-client';
+import type {
+  WorkflowDefinitionResource,
+  WorkflowDefinitionVersionResource,
+} from '../api/workflow-types';
+import { WorkflowOperationsService } from './workflow-operations-service';
+
+describe('WorkflowOperationsService', () => {
+  it('registers the BrowserPane Tour template and hides smoke definitions', async () => {
+    const client = {
+      listDefinitions: vi.fn().mockResolvedValue({ workflows: [SMOKE_WORKFLOW] }),
+      createDefinition: vi.fn().mockResolvedValue(TOUR_WORKFLOW_DRAFT),
+      createDefinitionVersion: vi.fn().mockResolvedValue(TOUR_VERSION),
+      getDefinition: vi.fn().mockResolvedValue(TOUR_WORKFLOW),
+      getDefinitionVersion: vi.fn().mockResolvedValue(TOUR_VERSION),
+    } as unknown as WorkflowClient;
+    const service = new WorkflowOperationsService(client);
+
+    const selection = await service.loadDefinitions('', '');
+
+    expect(selection.definitions).toEqual([TOUR_WORKFLOW]);
+    expect(selection.selectedWorkflowId).toBe(TOUR_WORKFLOW.id);
+    expect(selection.selectedVersion).toBe('v1');
+    expect(selection.selectedVersionResource?.executor).toBe('playwright');
+    expect(client.createDefinition).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'BrowserPane Tour',
+      labels: expect.objectContaining({ bpane_admin_template: 'browserpane-tour' }),
+    }));
+    expect(client.createDefinitionVersion).toHaveBeenCalledWith(
+      TOUR_WORKFLOW_DRAFT.id,
+      expect.objectContaining({
+        executor: 'playwright',
+        entrypoint: 'dev/workflows/browserpane-tour/run.mjs',
+        source: expect.objectContaining({ repository_url: '/workspace', root_path: 'dev' }),
+      }),
+    );
+  });
+
+  it('keeps an existing template visible while preserving an explicit user selection', async () => {
+    const client = {
+      listDefinitions: vi.fn().mockResolvedValue({
+        workflows: [SMOKE_WORKFLOW, USER_WORKFLOW, TOUR_WORKFLOW],
+      }),
+      createDefinition: vi.fn(),
+      createDefinitionVersion: vi.fn(),
+      getDefinition: vi.fn(),
+      getDefinitionVersion: vi.fn().mockResolvedValue(USER_VERSION),
+    } as unknown as WorkflowClient;
+    const service = new WorkflowOperationsService(client);
+
+    const selection = await service.loadDefinitions(USER_WORKFLOW.id, 'v1');
+
+    expect(selection.definitions.map((definition) => definition.id)).toEqual([
+      TOUR_WORKFLOW.id,
+      USER_WORKFLOW.id,
+    ]);
+    expect(selection.selectedWorkflowId).toBe(USER_WORKFLOW.id);
+    expect(selection.selectedVersionResource).toEqual(USER_VERSION);
+    expect(client.createDefinition).not.toHaveBeenCalled();
+    expect(client.createDefinitionVersion).not.toHaveBeenCalled();
+  });
+});
+
+const SMOKE_WORKFLOW: WorkflowDefinitionResource = {
+  id: 'workflow-smoke',
+  name: 'admin-workflow-smoke-1778576705740',
+  description: 'Admin smoke workflow',
+  labels: { suite: 'admin-workflow-smoke' },
+  latest_version: 'v1',
+  created_at: '2026-05-04T19:00:00Z',
+  updated_at: '2026-05-04T19:00:00Z',
+};
+
+const TOUR_WORKFLOW_DRAFT: WorkflowDefinitionResource = {
+  id: 'workflow-tour',
+  name: 'BrowserPane Tour',
+  description: 'Example workflow that tours browserpane.io and the BrowserPane GitHub repository',
+  labels: { bpane_admin_template: 'browserpane-tour', source: 'bpane-admin-template' },
+  latest_version: null,
+  created_at: '2026-05-04T19:00:00Z',
+  updated_at: '2026-05-04T19:00:00Z',
+};
+
+const TOUR_WORKFLOW: WorkflowDefinitionResource = {
+  ...TOUR_WORKFLOW_DRAFT,
+  latest_version: 'v1',
+};
+
+const USER_WORKFLOW: WorkflowDefinitionResource = {
+  id: 'workflow-user',
+  name: 'Customer Onboarding',
+  description: null,
+  labels: { source: 'operator' },
+  latest_version: 'v1',
+  created_at: '2026-05-04T19:01:00Z',
+  updated_at: '2026-05-04T19:01:00Z',
+};
+
+const TOUR_VERSION: WorkflowDefinitionVersionResource = {
+  id: 'version-tour',
+  workflow_definition_id: TOUR_WORKFLOW.id,
+  version: 'v1',
+  executor: 'playwright',
+  entrypoint: 'dev/workflows/browserpane-tour/run.mjs',
+  source: { kind: 'git', repository_url: '/workspace', ref: 'HEAD', root_path: 'dev' },
+  input_schema: { type: 'object' },
+  output_schema: null,
+  default_session: null,
+  allowed_credential_binding_ids: [],
+  allowed_extension_ids: [],
+  allowed_file_workspace_ids: [],
+  created_at: '2026-05-04T19:00:00Z',
+};
+
+const USER_VERSION: WorkflowDefinitionVersionResource = {
+  id: 'version-user',
+  workflow_definition_id: USER_WORKFLOW.id,
+  version: 'v1',
+  executor: 'playwright',
+  entrypoint: 'workflows/customer/run.mjs',
+  input_schema: null,
+  output_schema: null,
+  default_session: null,
+  allowed_credential_binding_ids: [],
+  allowed_extension_ids: [],
+  allowed_file_workspace_ids: [],
+  created_at: '2026-05-04T19:01:00Z',
+};

--- a/code/web/bpane-admin/src/lib/application/workflow-operations-service.ts
+++ b/code/web/bpane-admin/src/lib/application/workflow-operations-service.ts
@@ -1,5 +1,7 @@
 import type { WorkflowClient } from '../api/workflow-client';
 import type {
+  CreateWorkflowDefinitionCommand,
+  CreateWorkflowDefinitionVersionCommand,
   WorkflowDefinitionResource,
   WorkflowDefinitionVersionResource,
   WorkflowRunEventResource,
@@ -22,6 +24,40 @@ export type WorkflowRunSnapshot = {
   readonly files: readonly WorkflowRunProducedFileResource[];
 };
 
+const ADMIN_TEMPLATE_LABEL = 'bpane_admin_template';
+const ADMIN_HIDDEN_LABEL = 'bpane_admin_hidden';
+const BROWSERPANE_TOUR_TEMPLATE = 'browserpane-tour';
+const INCLUDE_HIDDEN_STORAGE_KEY = 'bpane.admin.showHiddenWorkflowDefinitions';
+
+const BROWSERPANE_TOUR_DEFINITION = {
+  name: 'BrowserPane Tour',
+  description: 'Example workflow that tours browserpane.io and the BrowserPane GitHub repository',
+  labels: {
+    [ADMIN_TEMPLATE_LABEL]: BROWSERPANE_TOUR_TEMPLATE,
+    source: 'bpane-admin-template',
+  },
+} satisfies CreateWorkflowDefinitionCommand;
+
+const BROWSERPANE_TOUR_VERSION = {
+  version: 'v1',
+  executor: 'playwright',
+  entrypoint: 'dev/workflows/browserpane-tour/run.mjs',
+  source: {
+    kind: 'git',
+    repository_url: '/workspace',
+    ref: 'HEAD',
+    root_path: 'dev',
+  },
+  input_schema: {
+    type: 'object',
+    properties: {
+      scroll_delay_ms: { type: 'number' },
+      scroll_step_px: { type: 'number' },
+      max_scroll_steps: { type: 'number' },
+    },
+  },
+} satisfies CreateWorkflowDefinitionVersionCommand;
+
 export class WorkflowOperationsService {
   constructor(private readonly workflowClient: WorkflowClient) {}
 
@@ -29,12 +65,12 @@ export class WorkflowOperationsService {
     selectedWorkflowId: string,
     selectedVersion: string,
   ): Promise<WorkflowDefinitionSelection> {
-    const definitions = (await this.workflowClient.listDefinitions()).workflows;
+    const definitions = await this.loadVisibleDefinitions();
     const selected = definitions.find((entry) => entry.id === selectedWorkflowId)
       ?? definitions[0]
       ?? null;
     const workflowId = selected?.id ?? '';
-    const version = selected?.latest_version ?? selectedVersion;
+    const version = selected ? (selected.latest_version ?? selectedVersion) : '';
     return {
       definitions,
       selectedWorkflowId: workflowId,
@@ -101,5 +137,81 @@ export class WorkflowOperationsService {
 
   async downloadFile(file: WorkflowRunProducedFileResource): Promise<Blob> {
     return await this.workflowClient.downloadProducedFileContent(file);
+  }
+
+  async loadVisibleDefinitions(): Promise<readonly WorkflowDefinitionResource[]> {
+    const definitions = (await this.workflowClient.listDefinitions()).workflows;
+    const withTemplate = await this.ensureBrowserPaneTourTemplate(definitions);
+    if (includeHiddenWorkflowDefinitions()) {
+      return withTemplate;
+    }
+    return visibleWorkflowDefinitions(withTemplate);
+  }
+
+  async ensureBrowserPaneTourTemplate(
+    definitions: readonly WorkflowDefinitionResource[],
+  ): Promise<readonly WorkflowDefinitionResource[]> {
+    const existingTemplate = definitions.find(isBrowserPaneTourDefinition);
+    if (!existingTemplate) {
+      return [await this.createBrowserPaneTourTemplate(), ...definitions];
+    }
+    if (existingTemplate.latest_version) {
+      return definitions;
+    }
+    await this.workflowClient.createDefinitionVersion(
+      existingTemplate.id,
+      BROWSERPANE_TOUR_VERSION,
+    );
+    const refreshedTemplate = await this.workflowClient.getDefinition(existingTemplate.id);
+    return [
+      refreshedTemplate,
+      ...definitions.filter((definition) => definition.id !== existingTemplate.id),
+    ];
+  }
+
+  async createBrowserPaneTourTemplate(): Promise<WorkflowDefinitionResource> {
+    const definition = await this.workflowClient.createDefinition(BROWSERPANE_TOUR_DEFINITION);
+    await this.workflowClient.createDefinitionVersion(definition.id, BROWSERPANE_TOUR_VERSION);
+    return await this.workflowClient.getDefinition(definition.id);
+  }
+}
+
+function visibleWorkflowDefinitions(
+  definitions: readonly WorkflowDefinitionResource[],
+): readonly WorkflowDefinitionResource[] {
+  const visible = definitions.filter(isVisibleWorkflowDefinition);
+  const templates = visible.filter(isAdminTemplateDefinition);
+  const others = visible.filter((definition) => !isAdminTemplateDefinition(definition));
+  return [...templates.sort(compareByName), ...others];
+}
+
+function isVisibleWorkflowDefinition(definition: WorkflowDefinitionResource): boolean {
+  if (definition.labels[ADMIN_HIDDEN_LABEL] === 'true') {
+    return false;
+  }
+  if (isAdminTemplateDefinition(definition)) {
+    return Boolean(definition.latest_version);
+  }
+  const suite = definition.labels.suite ?? '';
+  return !suite.toLowerCase().includes('smoke') && !definition.name.toLowerCase().includes('smoke');
+}
+
+function isBrowserPaneTourDefinition(definition: WorkflowDefinitionResource): boolean {
+  return definition.labels[ADMIN_TEMPLATE_LABEL] === BROWSERPANE_TOUR_TEMPLATE;
+}
+
+function isAdminTemplateDefinition(definition: WorkflowDefinitionResource): boolean {
+  return Boolean(definition.labels[ADMIN_TEMPLATE_LABEL]);
+}
+
+function compareByName(left: WorkflowDefinitionResource, right: WorkflowDefinitionResource): number {
+  return left.name.localeCompare(right.name);
+}
+
+function includeHiddenWorkflowDefinitions(): boolean {
+  try {
+    return globalThis.sessionStorage?.getItem(INCLUDE_HIDDEN_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
   }
 }

--- a/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { base } from '$app/paths';
-  import { Download, Play, RefreshCw, Send, Unlock, XCircle } from 'lucide-svelte';
+  import { Download, Play, Plug, RefreshCw, Send, Unlock, XCircle } from 'lucide-svelte';
   import type { WorkflowOperationsViewModel } from './workflow-operations-view-model';
 
   type WorkflowOperationsPanelProps = {
@@ -12,6 +12,8 @@
     readonly onVersionChange: (version: string) => void;
     readonly onInputTextChange: (value: string) => void;
     readonly onInterventionInputChange: (value: string) => void;
+    readonly onCreateSession: () => void;
+    readonly onConnectSession: () => void;
     readonly onInvokeRun: () => void;
     readonly onRefreshRun: () => void;
     readonly onCancelRun: () => void;
@@ -46,7 +48,7 @@
   <div class="grid min-w-0 gap-3 rounded-[16px] bg-admin-cream/70 p-3">
     <div class="grid min-w-0 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(8rem,12rem)]">
       <label class="grid min-w-0 gap-1.5 text-sm font-bold text-admin-ink">
-        Definition
+        Template
         <select
           class="min-h-10 min-w-0 rounded-xl border border-admin-ink/14 bg-admin-cream px-3 text-admin-ink"
           data-testid="workflow-definition-select"
@@ -55,7 +57,7 @@
           onchange={(event) => props.onWorkflowChange(event.currentTarget.value)}
         >
           {#if props.viewModel.definitionOptions.length === 0}
-            <option value="">No workflow definitions</option>
+            <option value="">No workflow templates</option>
           {:else}
             {#each props.viewModel.definitionOptions as definition}
               <option value={definition.id}>{definition.label}</option>
@@ -90,7 +92,25 @@
       <button class="admin-button-primary" type="button" data-testid="workflow-refresh" disabled={!props.viewModel.canRefresh} onclick={props.onRefreshDefinitions}>
         <RefreshCw size={14} aria-hidden="true" /> Refresh
       </button>
-      <button class="admin-button-primary" type="button" data-testid="workflow-invoke" disabled={!props.viewModel.canRun} onclick={props.onInvokeRun}>
+      {#if props.viewModel.canCreateBaseline}
+        <button class="admin-button-primary" type="button" data-testid="workflow-create-session" onclick={props.onCreateSession}>
+          <Plug size={14} aria-hidden="true" /> Create session
+        </button>
+      {/if}
+      {#if props.viewModel.canConnectBaseline}
+        <button class="admin-button-primary" type="button" data-testid="workflow-connect-session" onclick={props.onConnectSession}>
+          <Plug size={14} aria-hidden="true" /> Connect session
+        </button>
+      {/if}
+      <button
+        class="admin-button-primary"
+        type="button"
+        data-testid="workflow-invoke"
+        disabled={!props.viewModel.canRun}
+        title={props.viewModel.invokeBlockedReason ?? 'Invoke workflow run'}
+        aria-describedby={props.viewModel.invokeBlockedReason ? 'workflow-invoke-disabled-reason' : undefined}
+        onclick={props.onInvokeRun}
+      >
         <Play size={14} aria-hidden="true" /> Invoke run
       </button>
       <button class="admin-button-primary" type="button" data-testid="workflow-run-refresh" disabled={!props.viewModel.canRefreshRun} onclick={props.onRefreshRun}>
@@ -105,6 +125,15 @@
         </a>
       {/if}
     </div>
+    {#if props.viewModel.invokeBlockedReason}
+      <p
+        class="m-0 rounded-xl border border-admin-warm/20 bg-admin-warm/10 px-3 py-2 text-sm font-bold text-admin-ink"
+        id="workflow-invoke-disabled-reason"
+        data-testid="workflow-invoke-disabled-reason"
+      >
+        {props.viewModel.invokeBlockedReason}
+      </p>
+    {/if}
   </div>
 
   <div class="grid min-w-0 grid-cols-2 gap-2 xl:grid-cols-4 max-[640px]:grid-cols-1">

--- a/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import { Download, Play, RefreshCw, Send, Unlock, XCircle } from 'lucide-svelte';
   import type { WorkflowOperationsViewModel } from './workflow-operations-view-model';
 
@@ -20,6 +21,10 @@
   };
 
   let props: WorkflowOperationsPanelProps = $props();
+
+  function runDetailHref(runId: string): string {
+    return `${base}/workflow-runs/${encodeURIComponent(runId)}`;
+  }
 </script>
 
 <section class="grid min-w-0 gap-4" aria-label="Workflow operations">
@@ -94,6 +99,11 @@
       <button class="admin-button-primary" type="button" data-testid="workflow-cancel" disabled={!props.viewModel.canCancel} onclick={props.onCancelRun}>
         <XCircle size={14} aria-hidden="true" /> Cancel
       </button>
+      {#if props.viewModel.currentRunId !== '--'}
+        <a class="admin-button-ghost" data-testid="workflow-run-detail-link" href={runDetailHref(props.viewModel.currentRunId)}>
+          Inspect details
+        </a>
+      {/if}
     </div>
   </div>
 

--- a/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.test.ts
@@ -23,12 +23,16 @@ describe('WorkflowOperationsViewModelBuilder', () => {
       actionInFlight: false,
       error: null,
       inputValid: true,
+      connected: false,
       interventionInputValid: true,
     });
 
     expect(viewModel.status).toBe('ready');
     expect(viewModel.canRun).toBe(false);
+    expect(viewModel.canCreateBaseline).toBe(true);
+    expect(viewModel.canConnectBaseline).toBe(false);
     expect(viewModel.note).toContain('Select or create');
+    expect(viewModel.invokeBlockedReason).toContain('selected session is the workflow baseline');
   });
 
   it('enables invocation for a selected session and workflow version', () => {
@@ -46,6 +50,7 @@ describe('WorkflowOperationsViewModelBuilder', () => {
       actionInFlight: false,
       error: null,
       inputValid: true,
+      connected: true,
       interventionInputValid: true,
     });
 
@@ -54,6 +59,77 @@ describe('WorkflowOperationsViewModelBuilder', () => {
     expect(viewModel.selectedSessionLabel).toBe(SESSION.id);
     expect(viewModel.runSessionLabel).toBe('--');
     expect(viewModel.canRun).toBe(true);
+    expect(viewModel.canCreateBaseline).toBe(false);
+    expect(viewModel.canConnectBaseline).toBe(false);
+    expect(viewModel.invokeBlockedReason).toBeNull();
+  });
+
+  it('requires the selected baseline session to be connected in the admin view', () => {
+    const viewModel = WorkflowOperationsViewModelBuilder.build({
+      selectedSession: SESSION,
+      definitions: [WORKFLOW],
+      selectedWorkflowId: WORKFLOW.id,
+      selectedVersion: 'v1',
+      selectedVersionResource: VERSION,
+      currentRun: null,
+      logs: [],
+      events: [],
+      files: [],
+      loading: false,
+      actionInFlight: false,
+      error: null,
+      inputValid: true,
+      connected: false,
+      interventionInputValid: true,
+    });
+
+    expect(viewModel.canRun).toBe(false);
+    expect(viewModel.canConnectBaseline).toBe(true);
+    expect(viewModel.invokeBlockedReason).toBe(
+      'Connect the selected session before invoking a workflow from the admin view.',
+    );
+  });
+
+  it('explains missing definitions and invalid run input before invocation', () => {
+    const missingDefinition = WorkflowOperationsViewModelBuilder.build({
+      selectedSession: SESSION,
+      definitions: [],
+      selectedWorkflowId: '',
+      selectedVersion: '',
+      selectedVersionResource: null,
+      currentRun: null,
+      logs: [],
+      events: [],
+      files: [],
+      loading: false,
+      actionInFlight: false,
+      error: null,
+      inputValid: true,
+      connected: true,
+      interventionInputValid: true,
+    });
+    expect(missingDefinition.canRun).toBe(false);
+    expect(missingDefinition.invokeBlockedReason).toContain('workflow definition and version');
+
+    const invalidInput = WorkflowOperationsViewModelBuilder.build({
+      selectedSession: SESSION,
+      definitions: [WORKFLOW],
+      selectedWorkflowId: WORKFLOW.id,
+      selectedVersion: 'v1',
+      selectedVersionResource: VERSION,
+      currentRun: null,
+      logs: [],
+      events: [],
+      files: [],
+      loading: false,
+      actionInFlight: false,
+      error: null,
+      inputValid: false,
+      connected: true,
+      interventionInputValid: true,
+    });
+    expect(invalidInput.canRun).toBe(false);
+    expect(invalidInput.invokeBlockedReason).toBe('Run input must be valid JSON.');
   });
 
   it('enables intervention actions only for awaiting-input runs', () => {
@@ -83,6 +159,7 @@ describe('WorkflowOperationsViewModelBuilder', () => {
       actionInFlight: false,
       error: null,
       inputValid: true,
+      connected: true,
       interventionInputValid: true,
     });
 

--- a/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.ts
@@ -38,6 +38,9 @@ export type WorkflowOperationsViewModel = {
   readonly loading: boolean;
   readonly canRefresh: boolean;
   readonly canRun: boolean;
+  readonly canCreateBaseline: boolean;
+  readonly canConnectBaseline: boolean;
+  readonly invokeBlockedReason: string | null;
   readonly canRefreshRun: boolean;
   readonly canCancel: boolean;
   readonly canReleaseHold: boolean;
@@ -71,12 +74,14 @@ export class WorkflowOperationsViewModelBuilder {
     readonly actionInFlight: boolean;
     readonly error: string | null;
     readonly inputValid: boolean;
+    readonly connected: boolean;
     readonly interventionInputValid: boolean;
   }): WorkflowOperationsViewModel {
     const hasSession = Boolean(input.selectedSession);
     const hasDefinition = Boolean(input.selectedWorkflowId && input.selectedVersion);
     const terminal = isTerminal(input.currentRun?.state ?? null);
     const pendingRequest = input.currentRun?.intervention.pending_request ?? null;
+    const invokeBlockedReason = blockedInvokeReason(input);
     return {
       title: hasSession ? 'Workflow run controls' : 'Select a session for workflow runs',
       status: statusLabel(input.loading, input.error, input.currentRun),
@@ -100,7 +105,10 @@ export class WorkflowOperationsViewModelBuilder {
       error: input.error,
       loading: input.loading || input.actionInFlight,
       canRefresh: !input.loading && !input.actionInFlight,
-      canRun: hasSession && hasDefinition && input.inputValid && !input.actionInFlight,
+      canRun: invokeBlockedReason === null,
+      canCreateBaseline: !hasSession && !input.loading && !input.actionInFlight,
+      canConnectBaseline: hasSession && !input.connected && !input.loading && !input.actionInFlight,
+      invokeBlockedReason,
       canRefreshRun: Boolean(input.currentRun) && !input.actionInFlight,
       canCancel: Boolean(input.currentRun) && !terminal && !input.actionInFlight,
       canReleaseHold: Boolean(pendingRequest) && !input.actionInFlight,
@@ -131,6 +139,33 @@ function statusLabel(
   return currentRun?.state ?? 'ready';
 }
 
+function blockedInvokeReason(input: {
+  readonly selectedSession: SessionResource | null;
+  readonly selectedWorkflowId: string;
+  readonly selectedVersion: string;
+  readonly loading: boolean;
+  readonly actionInFlight: boolean;
+  readonly inputValid: boolean;
+  readonly connected: boolean;
+}): string | null {
+  if (input.loading || input.actionInFlight) {
+    return 'Workflow data is still loading.';
+  }
+  if (!input.selectedSession) {
+    return 'Select or create a session before invoking a workflow. The selected session is the workflow baseline.';
+  }
+  if (!input.connected) {
+    return 'Connect the selected session before invoking a workflow from the admin view.';
+  }
+  if (!input.selectedWorkflowId || !input.selectedVersion) {
+    return 'Select a workflow definition and version before invoking a workflow.';
+  }
+  if (!input.inputValid) {
+    return 'Run input must be valid JSON.';
+  }
+  return null;
+}
+
 function note(definitionCount: number, hasSession: boolean, error: string | null): string {
   if (error) {
     return error;
@@ -139,7 +174,7 @@ function note(definitionCount: number, hasSession: boolean, error: string | null
     return 'Select or create a session before invoking a workflow.';
   }
   if (definitionCount === 0) {
-    return 'No workflow definitions are available for this owner yet.';
+    return 'No workflow templates are available for this owner yet.';
   }
   return 'Invoke a workflow against the selected session and inspect run output.';
 }

--- a/code/web/bpane-admin/src/routes/workflow-runs/+page.svelte
+++ b/code/web/bpane-admin/src/routes/workflow-runs/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import AdminRouteShell from '$lib/application/AdminRouteShell.svelte';
+  import AdminWorkflowRunListRoute from '$lib/application/AdminWorkflowRunListRoute.svelte';
+</script>
+
+<AdminRouteShell title="BrowserPane Workflow Runs">
+  {#snippet children(route)}
+    <AdminWorkflowRunListRoute workflowClient={route.workflowClient} />
+  {/snippet}
+</AdminRouteShell>

--- a/code/web/bpane-admin/src/routes/workflow-runs/[run_id]/+page.svelte
+++ b/code/web/bpane-admin/src/routes/workflow-runs/[run_id]/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import AdminRouteShell from '$lib/application/AdminRouteShell.svelte';
+  import AdminWorkflowRunDetailRoute from '$lib/application/AdminWorkflowRunDetailRoute.svelte';
+
+  let { data }: { data: { runId: string } } = $props();
+</script>
+
+<AdminRouteShell title="BrowserPane Workflow Run Detail">
+  {#snippet children(route)}
+    <AdminWorkflowRunDetailRoute workflowClient={route.workflowClient} runId={data.runId} />
+  {/snippet}
+</AdminRouteShell>

--- a/code/web/bpane-admin/src/routes/workflow-runs/[run_id]/+page.ts
+++ b/code/web/bpane-admin/src/routes/workflow-runs/[run_id]/+page.ts
@@ -1,0 +1,5 @@
+export function load({ params }: { params: { run_id: string } }): { runId: string } {
+  return {
+    runId: params.run_id,
+  };
+}

--- a/code/web/bpane-client/package.json
+++ b/code/web/bpane-client/package.json
@@ -22,6 +22,7 @@
     "smoke:mcp-session-endpoints": "node scripts/run-mcp-session-endpoints-smoke.mjs",
     "smoke:admin-recording": "node scripts/run-admin-recording-smoke.mjs",
     "smoke:admin-workflow": "node scripts/run-admin-workflow-smoke.mjs",
+    "smoke:admin-workflow-run-detail": "node scripts/run-admin-workflow-run-detail-smoke.mjs",
     "smoke:admin-browserpane-tour": "node scripts/run-admin-browserpane-tour-workflow.mjs",
     "smoke:admin-session-detail": "node scripts/run-admin-session-detail-smoke.mjs",
     "smoke:recording": "node scripts/run-recording-smoke.mjs",

--- a/code/web/bpane-client/scripts/admin-workflow-smoke-lib.mjs
+++ b/code/web/bpane-client/scripts/admin-workflow-smoke-lib.mjs
@@ -7,7 +7,10 @@ export async function createWorkflow(accessToken, rootUrl) {
     body: JSON.stringify({
       name: `admin-workflow-smoke-${Date.now()}`,
       description: 'Validate admin workflow operations controls',
-      labels: { suite: 'admin-workflow-smoke' },
+      labels: {
+        suite: 'admin-workflow-smoke',
+        bpane_admin_hidden: 'true',
+      },
     }),
   });
 }

--- a/code/web/bpane-client/scripts/run-admin-browserpane-tour-workflow.mjs
+++ b/code/web/bpane-client/scripts/run-admin-browserpane-tour-workflow.mjs
@@ -44,8 +44,7 @@ async function run() {
     const accessToken = await getAdminAccessToken(page);
     const source = createWorkspaceSource();
     buildWorkflowWorkerImage();
-    const workflow = await createWorkflow(accessToken, rootUrl);
-    await createWorkflowVersion(accessToken, rootUrl, workflow.id, source);
+    const workflow = await ensureBrowserPaneTourWorkflow(accessToken, rootUrl, source);
     await createAndJoinSession(page, options);
     const runId = await invokeWorkflow(page, options, workflow.id);
     const state = await waitForTerminalState(page, options);
@@ -95,15 +94,44 @@ function createWorkspaceSource() {
   return { repositoryUrl: '/workspace', ref: `refs/heads/${ref}` };
 }
 
+async function ensureBrowserPaneTourWorkflow(accessToken, rootUrl, source) {
+  const workflows = await listWorkflows(accessToken, rootUrl);
+  const existing = workflows.find((workflow) => {
+    return workflow?.labels?.bpane_admin_template === 'browserpane-tour';
+  });
+  if (existing?.latest_version) {
+    return existing;
+  }
+  const workflow = existing ?? await createWorkflow(accessToken, rootUrl);
+  await createWorkflowVersion(accessToken, rootUrl, workflow.id, source);
+  return await fetchWorkflow(accessToken, rootUrl, workflow.id);
+}
+
+async function listWorkflows(accessToken, rootUrl) {
+  const response = await fetchJson(`${rootUrl}/api/v1/workflows`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return Array.isArray(response.workflows) ? response.workflows : [];
+}
+
 async function createWorkflow(accessToken, rootUrl) {
   return await fetchJson(`${rootUrl}/api/v1/workflows`, {
     method: 'POST',
     headers: jsonHeaders(accessToken),
     body: JSON.stringify({
-      name: `browserpane-tour-${Date.now()}`,
+      name: 'BrowserPane Tour',
       description: 'Example workflow that tours browserpane.io and the GitHub repository',
-      labels: { suite: 'admin-browserpane-tour' },
+      labels: {
+        bpane_admin_template: 'browserpane-tour',
+        source: 'bpane-admin-template',
+      },
     }),
+  });
+}
+
+async function fetchWorkflow(accessToken, rootUrl, workflowId) {
+  return await fetchJson(`${rootUrl}/api/v1/workflows/${encodeURIComponent(workflowId)}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
   });
 }
 

--- a/code/web/bpane-client/scripts/run-admin-workflow-run-detail-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-workflow-run-detail-smoke.mjs
@@ -1,0 +1,201 @@
+import fs from 'node:fs/promises';
+import process from 'node:process';
+import { chromium } from 'playwright-core';
+import {
+  cleanupAdminBeforeRun,
+  ensureAdminLoggedIn,
+  getAdminAccessToken,
+} from './admin-smoke-lib.mjs';
+import {
+  appendRunLog,
+  createWorkflow,
+  createWorkflowVersion,
+  issueAutomationAccess,
+  transitionRun,
+} from './admin-workflow-smoke-lib.mjs';
+import { DEFAULTS, createLogger, deleteSession, fetchJson, launchChrome, parseSmokeArgs, poll } from './workflow-smoke-lib.mjs';
+
+async function run() {
+  const options = parseSmokeArgs(process.argv.slice(2), 'run-admin-workflow-run-detail-smoke.mjs');
+  if (options.pageUrl === DEFAULTS.pageUrl) {
+    options.pageUrl = `${DEFAULTS.pageUrl}/admin/`;
+  }
+  const rootUrl = new URL('/', options.pageUrl).origin;
+  const log = createLogger('admin-workflow-run-detail-smoke');
+  const browser = await launchChrome(chromium, options);
+  const context = await browser.newContext({ viewport: { width: 1440, height: 980 } });
+  const page = await context.newPage();
+  let summary = null;
+  let createdSessionId = '';
+
+  try {
+    log(`Opening ${options.pageUrl}`);
+    await ensureAdminLoggedIn(page, options);
+    await cleanupAdminBeforeRun(page, options, log);
+    const accessToken = await getAdminAccessToken(page);
+    const workflow = await createWorkflow(accessToken, rootUrl);
+    await createWorkflowVersion(accessToken, rootUrl, workflow.id);
+    const session = await createSession(accessToken, rootUrl);
+    createdSessionId = session.id;
+    const runResource = await createRun(accessToken, rootUrl, workflow.id, session.id);
+    const automation = await issueAutomationAccess(accessToken, rootUrl, session.id);
+    await transitionRun(automation.token, rootUrl, runResource.id, {
+      state: 'running',
+      message: 'route-level manual executor attached',
+    });
+    await appendRunLog(automation.token, rootUrl, runResource.id, 'route-level workflow run detail smoke log');
+    await transitionRun(automation.token, rootUrl, runResource.id, {
+      state: 'awaiting_input',
+      message: 'route-level approval required',
+      data: {
+        intervention_request: {
+          request_id: crypto.randomUUID(),
+          kind: 'approval',
+          prompt: 'Approve the route-level workflow run detail smoke',
+        },
+        runtime_hold: { mode: 'live', timeout_sec: 30 },
+      },
+    });
+
+    log('Verifying workflow run list and detail routes.');
+    await verifyRunList(page, options, runResource.id);
+    await verifyRunDetail(page, options, runResource.id, session.id);
+    await page.getByTestId('workflow-run-detail-operator-input').fill('{\n  "approved": true\n}');
+    await page.getByTestId('workflow-run-detail-submit-input').click();
+    await waitForDetailState(page, options, 'running');
+    await transitionRun(automation.token, rootUrl, runResource.id, {
+      state: 'succeeded',
+      message: 'route-level workflow run detail smoke succeeded',
+    });
+    await page.getByTestId('workflow-run-inspector-detail-refresh').click();
+    await waitForDetailState(page, options, 'succeeded');
+    if (await page.getByTestId('workflow-run-detail-cancel').isEnabled()) {
+      throw new Error('Cancel should be disabled for a succeeded workflow run.');
+    }
+
+    summary = {
+      pageUrl: options.pageUrl,
+      workflowId: workflow.id,
+      runId: runResource.id,
+      sessionId: session.id,
+      finalState: await page.getByTestId('workflow-run-detail-state').textContent(),
+    };
+    await emitSummary(options, summary, log);
+  } finally {
+    const cleanupToken = await getAdminAccessToken(page).catch(() => '');
+    if (cleanupToken && createdSessionId) {
+      await deleteSession(cleanupToken, { ...options, pageUrl: rootUrl }, createdSessionId).catch((error) => {
+        log(`cleanup warning: failed to delete session ${createdSessionId}: ${error instanceof Error ? error.message : String(error)}`);
+      });
+    }
+    await context.close();
+    await browser.close();
+  }
+}
+
+async function createSession(accessToken, rootUrl) {
+  return await fetchJson(`${rootUrl}/api/v1/sessions`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ labels: { suite: 'admin-workflow-run-detail-smoke' } }),
+  });
+}
+
+async function createRun(accessToken, rootUrl, workflowId, sessionId) {
+  return await fetchJson(`${rootUrl}/api/v1/workflow-runs`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      workflow_id: workflowId,
+      version: 'v1',
+      session: { existing_session_id: sessionId },
+      input: { task: 'route workflow run detail smoke' },
+      client_request_id: `admin-workflow-run-detail-${Date.now()}`,
+      labels: { source: 'admin-workflow-run-detail-smoke' },
+    }),
+  });
+}
+
+async function verifyRunList(page, options, runId) {
+  await page.goto(adminRouteUrl(options, 'workflow-runs'), { waitUntil: 'domcontentloaded' });
+  await page.getByTestId('workflow-run-inspector-list').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  const row = page.locator(`[data-testid="workflow-run-inspector-row"][data-run-id="${runId}"]`);
+  await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await row.click();
+  await page.waitForURL(/\/workflow-runs\/[^/]+$/, { timeout: options.connectTimeoutMs });
+}
+
+async function verifyRunDetail(page, options, runId, sessionId) {
+  await waitForDetailUrl(page, options, runId);
+  await page.getByTestId('workflow-run-inspector-detail').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  await waitForDetailState(page, options, 'awaiting_input');
+  await waitForText(page, options, 'workflow-run-detail-session-id', sessionId);
+  await waitForMinimumCount(page, options, 'workflow-run-detail-event-count', 1);
+  await waitForMinimumCount(page, options, 'workflow-run-detail-log-list-count', 1);
+  await page.getByText('Approve the route-level workflow run detail smoke').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  const sessionHref = await page.getByTestId('workflow-run-session-link').getAttribute('href');
+  if (!sessionHref?.includes(`/sessions/${sessionId}`)) {
+    throw new Error(`Expected workflow run session link for ${sessionId}, got ${sessionHref}`);
+  }
+}
+
+async function waitForDetailUrl(page, options, runId) {
+  await page.waitForURL(new RegExp(`/workflow-runs/${runId}$`), { timeout: options.connectTimeoutMs });
+}
+
+async function waitForDetailState(page, options, expected) {
+  await poll(
+    `workflow run detail state ${expected}`,
+    async () => await page.getByTestId('workflow-run-detail-state').textContent(),
+    (value) => value === expected,
+    options.connectTimeoutMs,
+  );
+}
+
+async function waitForText(page, options, testId, expected) {
+  await poll(
+    testId,
+    async () => await page.getByTestId(testId).textContent(),
+    (value) => value === expected,
+    options.connectTimeoutMs,
+  );
+}
+
+async function waitForMinimumCount(page, options, testId, minimum) {
+  await poll(
+    testId,
+    async () => Number(await page.getByTestId(testId).textContent()),
+    (value) => Number.isFinite(value) && value >= minimum,
+    options.connectTimeoutMs,
+  );
+}
+
+function adminRouteUrl(options, routePath) {
+  const baseUrl = new URL(options.pageUrl);
+  if (!baseUrl.pathname.endsWith('/')) {
+    baseUrl.pathname = `${baseUrl.pathname}/`;
+  }
+  return new URL(routePath, baseUrl).toString();
+}
+
+async function emitSummary(options, summary, log) {
+  console.log(JSON.stringify(summary, null, 2));
+  if (options.outputPath) {
+    await fs.writeFile(options.outputPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+    log(`Wrote summary to ${options.outputPath}`);
+  }
+}
+
+run().catch((error) => {
+  console.error(`[admin-workflow-run-detail-smoke] ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/code/web/bpane-client/scripts/run-admin-workflow-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-workflow-smoke.mjs
@@ -20,18 +20,22 @@ async function run() {
   try {
     log(`Opening ${options.pageUrl}`);
     await ensureAdminLoggedIn(page, options);
+    await page.evaluate(() => {
+      sessionStorage.setItem('bpane.admin.showHiddenWorkflowDefinitions', 'true');
+    });
     await cleanupAdminBeforeRun(page, options, log);
     const accessToken = await getAdminAccessToken(page);
     const workflow = await createWorkflow(accessToken, rootUrl);
     const version = await createWorkflowVersion(accessToken, rootUrl, workflow.id);
 
     await openAdminTab(page, 'sessions');
-    await page.getByTestId('session-new').click();
-    sessionId = await resolveSelectedSessionId(page, options);
-    await waitForBrowserConnected(page, options);
-
+    await page.getByTestId('session-refresh').click();
     await openAdminTab(page, 'workflows');
     await page.getByTestId('workflow-definition-select').selectOption(workflow.id);
+    await prepareWorkflowBaseline(page, options);
+    sessionId = await resolveWorkflowBaselineSessionId(page, options);
+    await waitForBrowserConnected(page, options);
+
     await waitForEnabled(page.getByTestId('workflow-invoke'), options, 'admin workflow invoke');
     await page.getByTestId('workflow-input').fill('{\n  "task": "admin workflow smoke"\n}');
     await page.getByTestId('workflow-invoke').click();
@@ -99,14 +103,13 @@ async function run() {
   }
 }
 
-async function resolveSelectedSessionId(page, options) {
-  const row = page.getByTestId('session-row').first();
-  await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
-  const sessionId = await row.getAttribute('data-session-id') ?? '';
-  if (!sessionId) {
-    throw new Error('Admin session row did not expose a session id.');
-  }
-  return sessionId;
+async function resolveWorkflowBaselineSessionId(page, options) {
+  return await poll(
+    'admin workflow baseline session id',
+    async () => await page.getByTestId('workflow-session-id').textContent(),
+    (value) => Boolean(value && value !== '--'),
+    options.connectTimeoutMs,
+  );
 }
 
 async function waitForRunId(page, options) {
@@ -133,6 +136,31 @@ async function waitForText(page, options, testId, expected) {
 
 async function waitForContains(page, options, testId, expected) {
   await poll(testId, async () => await page.getByTestId(testId).textContent(), (value) => value?.includes(expected), options.connectTimeoutMs);
+}
+
+async function prepareWorkflowBaseline(page, options) {
+  const state = await poll('workflow baseline prerequisite action', async () => {
+    const invokeEnabled = await page.getByTestId('workflow-invoke').isEnabled().catch(() => false);
+    const createVisible = await page.getByTestId('workflow-create-session').isVisible().catch(() => false);
+    const connectVisible = await page.getByTestId('workflow-connect-session').isVisible().catch(() => false);
+    const reason = await page.getByTestId('workflow-invoke-disabled-reason').textContent().catch(() => '');
+    return { invokeEnabled, createVisible, connectVisible, reason };
+  }, (value) => value.invokeEnabled || value.createVisible || value.connectVisible, options.connectTimeoutMs);
+  if (state.invokeEnabled) {
+    return;
+  }
+  if (!state.reason) {
+    throw new Error('Workflow invoke was blocked without a visible reason.');
+  }
+  if (state.createVisible) {
+    await page.getByTestId('workflow-create-session').click();
+    return;
+  }
+  if (state.connectVisible) {
+    await page.getByTestId('workflow-connect-session').click();
+    return;
+  }
+  throw new Error(`Workflow baseline is blocked without an action: ${state.reason}`);
 }
 
 async function waitForEnabled(locator, options, description) {


### PR DESCRIPTION
## Summary
- add owner-scoped workflow run list/detail inspection routes in the admin app
- expose workflow run events, logs, produced files, intervention actions, and linked sessions
- stabilize workflow invocation UX with a connected baseline session requirement and a reusable BrowserPane Tour template
- hide smoke-only workflow definitions from the normal admin selector while preserving smoke coverage

## Validation
- `cargo fmt --all --check`
- `cargo test -p bpane-gateway workflow_runs`
- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && npm run smoke:admin-workflow -- --headless`
- `cd code/web/bpane-client && npm run smoke:admin-browserpane-tour -- --headless --connect-timeout-ms 240000`
- `cd code/web/bpane-client && npm run smoke:admin-workflow-run-detail -- --headless`

Closes #87