### PR TITLE
Add admin file workspace and session binding manager

### DIFF
--- a/code/web/bpane-admin/src/lib/api/authenticated-api.ts
+++ b/code/web/bpane-admin/src/lib/api/authenticated-api.ts
@@ -11,6 +11,9 @@ type AuthenticatedRequestOptions = {
   readonly path: string;
   readonly body?: unknown;
   readonly accept?: string;
+  readonly bodyMode?: 'json' | 'raw' | undefined;
+  readonly contentType?: string | null | undefined;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
 };
 
 export class ControlApiError extends Error {
@@ -18,7 +21,7 @@ export class ControlApiError extends Error {
     readonly status: number,
     readonly body: string,
   ) {
-    super(`BrowserPane control API returned HTTP ${status}`);
+    super(`BrowserPane control API returned HTTP ${status}${body ? `: ${body}` : ''}`);
   }
 }
 
@@ -27,11 +30,19 @@ export async function sendAuthenticatedRequest(options: AuthenticatedRequestOpti
   const headers: Record<string, string> = {
     accept: options.accept ?? 'application/json',
     authorization: `Bearer ${accessToken}`,
+    ...(options.headers ?? {}),
   };
   const init: RequestInit = { method: options.method, headers };
   if (options.body !== undefined) {
-    headers['content-type'] = 'application/json';
-    init.body = JSON.stringify(options.body);
+    if (options.bodyMode === 'raw') {
+      if (options.contentType !== null) {
+        headers['content-type'] = options.contentType ?? 'application/octet-stream';
+      }
+      init.body = options.body as BodyInit;
+    } else {
+      headers['content-type'] = options.contentType ?? 'application/json';
+      init.body = JSON.stringify(options.body);
+    }
   }
 
   const response = await options.fetchImpl(new URL(options.path, options.baseUrl), init);

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -1,4 +1,5 @@
 import { ControlSessionMapper } from './control-session-mapper';
+import { ControlFileWorkspaceMapper } from './control-file-workspace-mapper';
 import { ControlSessionFileMapper } from './control-session-file-mapper';
 import { ControlSessionStatusMapper } from './control-session-status-mapper';
 import { RecordingMapper } from './recording-mapper';
@@ -10,12 +11,21 @@ import {
 } from './authenticated-api';
 import type {
   CreateSessionCommand,
+  CreateFileWorkspaceCommand,
+  CreateSessionFileBindingCommand,
+  FileWorkspaceFileListResponse,
+  FileWorkspaceFileResource,
+  FileWorkspaceListResponse,
+  FileWorkspaceResource,
   SessionAccessTokenResponse,
+  SessionFileBindingListResponse,
+  SessionFileBindingResource,
   SessionFileListResponse,
   SessionFileResource,
   SessionListResponse,
   SessionResource,
   SetAutomationDelegateCommand,
+  UploadFileWorkspaceFileCommand,
 } from './control-types';
 import type {
   SessionRecordingListResponse,
@@ -143,6 +153,136 @@ export class ControlClient {
     return await response.blob();
   }
 
+  async listFileWorkspaces(): Promise<FileWorkspaceListResponse> {
+    const payload = await this.#request('GET', '/api/v1/file-workspaces');
+    return ControlFileWorkspaceMapper.toWorkspaceList(payload);
+  }
+
+  async createFileWorkspace(command: CreateFileWorkspaceCommand): Promise<FileWorkspaceResource> {
+    const payload = await this.#request('POST', '/api/v1/file-workspaces', {
+      ...command,
+      labels: command.labels ?? {},
+    });
+    return ControlFileWorkspaceMapper.toWorkspace(payload);
+  }
+
+  async getFileWorkspace(workspaceId: string): Promise<FileWorkspaceResource> {
+    const payload = await this.#request(
+      'GET',
+      `/api/v1/file-workspaces/${encodeURIComponent(workspaceId)}`,
+    );
+    return ControlFileWorkspaceMapper.toWorkspace(payload);
+  }
+
+  async listFileWorkspaceFiles(workspaceId: string): Promise<FileWorkspaceFileListResponse> {
+    const payload = await this.#request(
+      'GET',
+      `/api/v1/file-workspaces/${encodeURIComponent(workspaceId)}/files`,
+    );
+    return ControlFileWorkspaceMapper.toWorkspaceFileList(payload);
+  }
+
+  async uploadFileWorkspaceFile(
+    workspaceId: string,
+    command: UploadFileWorkspaceFileCommand,
+  ): Promise<FileWorkspaceFileResource> {
+    const headers: Record<string, string> = {
+      'x-bpane-file-name': command.fileName,
+    };
+    if (command.provenance !== undefined && command.provenance !== null) {
+      headers['x-bpane-file-provenance'] = JSON.stringify(command.provenance);
+    }
+    const response = await this.#send(
+      'POST',
+      `/api/v1/file-workspaces/${encodeURIComponent(workspaceId)}/files`,
+      command.content,
+      'application/json',
+      {
+        bodyMode: 'raw',
+        contentType: command.mediaType ?? 'application/octet-stream',
+        headers,
+      },
+    );
+    return ControlFileWorkspaceMapper.toWorkspaceFile(await response.json());
+  }
+
+  async getFileWorkspaceFile(
+    workspaceId: string,
+    fileId: string,
+  ): Promise<FileWorkspaceFileResource> {
+    const payload = await this.#request(
+      'GET',
+      `/api/v1/file-workspaces/${encodeURIComponent(workspaceId)}/files/${encodeURIComponent(fileId)}`,
+    );
+    return ControlFileWorkspaceMapper.toWorkspaceFile(payload);
+  }
+
+  async deleteFileWorkspaceFile(
+    workspaceId: string,
+    fileId: string,
+  ): Promise<FileWorkspaceFileResource> {
+    const payload = await this.#request(
+      'DELETE',
+      `/api/v1/file-workspaces/${encodeURIComponent(workspaceId)}/files/${encodeURIComponent(fileId)}`,
+    );
+    return ControlFileWorkspaceMapper.toWorkspaceFile(payload);
+  }
+
+  async downloadFileWorkspaceFileContent(file: FileWorkspaceFileResource): Promise<Blob> {
+    const response = await this.#send('GET', file.content_path, undefined, '*/*');
+    return await response.blob();
+  }
+
+  async listSessionFileBindings(sessionId: string): Promise<SessionFileBindingListResponse> {
+    const payload = await this.#request(
+      'GET',
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/file-bindings`,
+    );
+    return ControlFileWorkspaceMapper.toSessionFileBindingList(payload);
+  }
+
+  async createSessionFileBinding(
+    sessionId: string,
+    command: CreateSessionFileBindingCommand,
+  ): Promise<SessionFileBindingResource> {
+    const payload = await this.#request(
+      'POST',
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/file-bindings`,
+      {
+        ...command,
+        labels: command.labels ?? {},
+      },
+    );
+    return ControlFileWorkspaceMapper.toSessionFileBinding(payload);
+  }
+
+  async getSessionFileBinding(
+    sessionId: string,
+    bindingId: string,
+  ): Promise<SessionFileBindingResource> {
+    const payload = await this.#request(
+      'GET',
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/file-bindings/${encodeURIComponent(bindingId)}`,
+    );
+    return ControlFileWorkspaceMapper.toSessionFileBinding(payload);
+  }
+
+  async removeSessionFileBinding(
+    sessionId: string,
+    bindingId: string,
+  ): Promise<SessionFileBindingResource> {
+    const payload = await this.#request(
+      'DELETE',
+      `/api/v1/sessions/${encodeURIComponent(sessionId)}/file-bindings/${encodeURIComponent(bindingId)}`,
+    );
+    return ControlFileWorkspaceMapper.toSessionFileBinding(payload);
+  }
+
+  async downloadSessionFileBindingContent(binding: SessionFileBindingResource): Promise<Blob> {
+    const response = await this.#send('GET', binding.content_path, undefined, '*/*');
+    return await response.blob();
+  }
+
   async listSessionRecordings(sessionId: string): Promise<SessionRecordingListResponse> {
     const payload = await this.#request(
       'GET',
@@ -176,7 +316,17 @@ export class ControlClient {
     return await response.json();
   }
 
-  async #send(method: string, path: string, body?: unknown, accept = 'application/json'): Promise<Response> {
+  async #send(
+    method: string,
+    path: string,
+    body?: unknown,
+    accept = 'application/json',
+    options: {
+      readonly bodyMode?: 'json' | 'raw';
+      readonly contentType?: string | null;
+      readonly headers?: Readonly<Record<string, string>>;
+    } = {},
+  ): Promise<Response> {
     return await sendAuthenticatedRequest({
       baseUrl: this.#baseUrl,
       accessTokenProvider: this.#accessTokenProvider,
@@ -186,6 +336,9 @@ export class ControlClient {
       path,
       body,
       accept,
+      bodyMode: options.bodyMode,
+      contentType: options.contentType,
+      headers: options.headers,
     });
   }
 }

--- a/code/web/bpane-admin/src/lib/api/control-file-workspace-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-file-workspace-client.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ControlClient, type FetchLike } from './control-client';
+
+const WORKSPACE = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
+  name: 'Admin inputs',
+  description: 'Reusable smoke inputs',
+  labels: { suite: 'admin' },
+  files_path: '/api/v1/file-workspaces/019df4d2-f4f7-7b00-9e0c-79683b1c82f6/files',
+  created_at: '2026-05-04T19:00:00Z',
+  updated_at: '2026-05-04T19:01:00Z',
+};
+
+const WORKSPACE_FILE = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f7',
+  workspace_id: WORKSPACE.id,
+  name: 'customer-sample.csv',
+  media_type: 'text/csv',
+  byte_count: 22,
+  sha256_hex: '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c',
+  provenance: { source: 'admin-upload' },
+  content_path: `/api/v1/file-workspaces/${WORKSPACE.id}/files/019df4d2-f4f7-7b00-9e0c-79683b1c82f7/content`,
+  created_at: '2026-05-04T19:02:00Z',
+  updated_at: '2026-05-04T19:03:00Z',
+};
+
+const BINDING = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f8',
+  session_id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f9',
+  workspace_id: WORKSPACE.id,
+  file_id: WORKSPACE_FILE.id,
+  file_name: WORKSPACE_FILE.name,
+  media_type: WORKSPACE_FILE.media_type,
+  byte_count: WORKSPACE_FILE.byte_count,
+  sha256_hex: WORKSPACE_FILE.sha256_hex,
+  provenance: WORKSPACE_FILE.provenance,
+  mount_path: 'uploads/customer-sample.csv',
+  mode: 'read_only',
+  state: 'pending',
+  error: null,
+  labels: {},
+  content_path: '/api/v1/sessions/019df4d2-f4f7-7b00-9e0c-79683b1c82f9/file-bindings/019df4d2-f4f7-7b00-9e0c-79683b1c82f8/content',
+  created_at: '2026-05-04T19:04:00Z',
+  updated_at: '2026-05-04T19:05:00Z',
+};
+
+describe('ControlClient file workspaces and session file bindings', () => {
+  it('creates and lists file workspaces with owner bearer auth', async () => {
+    const fetchImpl = jsonFetchSequence([WORKSPACE, { workspaces: [WORKSPACE] }]);
+    const client = newClient(fetchImpl);
+
+    const created = await client.createFileWorkspace({
+      name: 'Admin inputs',
+      description: 'Reusable smoke inputs',
+      labels: { suite: 'admin' },
+    });
+    const listed = await client.listFileWorkspaces();
+
+    expect(created.id).toBe(WORKSPACE.id);
+    expect(listed.workspaces[0]?.name).toBe('Admin inputs');
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL('http://localhost:8932/api/v1/file-workspaces'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Admin inputs',
+          description: 'Reusable smoke inputs',
+          labels: { suite: 'admin' },
+        }),
+        headers: expect.objectContaining({ authorization: 'Bearer owner-token' }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL('http://localhost:8932/api/v1/file-workspaces'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('uploads, downloads, and deletes workspace files with raw content headers', async () => {
+    const body = new Blob(['customer,total\n1,2\n'], { type: 'text/csv' });
+    const fetchImpl = vi.fn<FetchLike>(async (_input, init) => {
+      if (init?.method === 'GET' && String(_input).endsWith('/content')) {
+        return new Response('customer,total\n1,2\n', { status: 200 });
+      }
+      return jsonResponse(WORKSPACE_FILE);
+    });
+    const client = newClient(fetchImpl);
+
+    const uploaded = await client.uploadFileWorkspaceFile(WORKSPACE.id, {
+      fileName: 'customer-sample.csv',
+      mediaType: 'text/csv',
+      provenance: { source: 'admin-upload' },
+      content: body,
+    });
+    const downloaded = await client.downloadFileWorkspaceFileContent(uploaded);
+    await client.deleteFileWorkspaceFile(WORKSPACE.id, uploaded.id);
+
+    expect(await downloaded.text()).toBe('customer,total\n1,2\n');
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL(`http://localhost:8932/api/v1/file-workspaces/${WORKSPACE.id}/files`),
+      expect.objectContaining({
+        method: 'POST',
+        body,
+        headers: expect.objectContaining({
+          'content-type': 'text/csv',
+          'x-bpane-file-name': 'customer-sample.csv',
+          'x-bpane-file-provenance': JSON.stringify({ source: 'admin-upload' }),
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      new URL(`http://localhost:8932/api/v1/file-workspaces/${WORKSPACE.id}/files/${WORKSPACE_FILE.id}`),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  it('creates, lists, and removes session file bindings', async () => {
+    const fetchImpl = jsonFetchSequence([BINDING, { bindings: [BINDING] }, BINDING]);
+    const client = newClient(fetchImpl);
+
+    const created = await client.createSessionFileBinding(BINDING.session_id, {
+      workspace_id: WORKSPACE.id,
+      file_id: WORKSPACE_FILE.id,
+      mount_path: 'uploads/customer-sample.csv',
+    });
+    const listed = await client.listSessionFileBindings(BINDING.session_id);
+    await client.removeSessionFileBinding(BINDING.session_id, created.id);
+
+    expect(created.mount_path).toBe('uploads/customer-sample.csv');
+    expect(listed.bindings[0]?.file_name).toBe('customer-sample.csv');
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL(`http://localhost:8932/api/v1/sessions/${BINDING.session_id}/file-bindings`),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          workspace_id: WORKSPACE.id,
+          file_id: WORKSPACE_FILE.id,
+          mount_path: 'uploads/customer-sample.csv',
+          labels: {},
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      new URL(`http://localhost:8932/api/v1/sessions/${BINDING.session_id}/file-bindings/${BINDING.id}`),
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+
+function newClient(fetchImpl: ReturnType<typeof vi.fn<FetchLike>>): ControlClient {
+  return new ControlClient({
+    baseUrl: 'http://localhost:8932',
+    accessTokenProvider: () => 'owner-token',
+    fetchImpl,
+  });
+}
+
+function jsonFetchSequence(payloads: readonly unknown[]): ReturnType<typeof vi.fn<FetchLike>> {
+  const queue = [...payloads];
+  return vi.fn<FetchLike>(async () => jsonResponse(queue.shift()));
+}
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/code/web/bpane-admin/src/lib/api/control-file-workspace-mapper.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-file-workspace-mapper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { ControlFileWorkspaceMapper } from './control-file-workspace-mapper';
+
+const WORKSPACE = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
+  name: 'Admin inputs',
+  description: null,
+  labels: { suite: 'admin' },
+  files_path: '/api/v1/file-workspaces/019df4d2-f4f7-7b00-9e0c-79683b1c82f6/files',
+  created_at: '2026-05-04T19:00:00Z',
+  updated_at: '2026-05-04T19:01:00Z',
+};
+
+const WORKSPACE_FILE = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f7',
+  workspace_id: WORKSPACE.id,
+  name: 'customer-sample.csv',
+  media_type: 'text/csv',
+  byte_count: 22,
+  sha256_hex: '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c',
+  provenance: { source: 'admin-upload' },
+  content_path: `/api/v1/file-workspaces/${WORKSPACE.id}/files/019df4d2-f4f7-7b00-9e0c-79683b1c82f7/content`,
+  created_at: '2026-05-04T19:02:00Z',
+  updated_at: '2026-05-04T19:03:00Z',
+};
+
+const BINDING = {
+  id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f8',
+  session_id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f9',
+  workspace_id: WORKSPACE.id,
+  file_id: WORKSPACE_FILE.id,
+  file_name: WORKSPACE_FILE.name,
+  media_type: WORKSPACE_FILE.media_type,
+  byte_count: WORKSPACE_FILE.byte_count,
+  sha256_hex: WORKSPACE_FILE.sha256_hex,
+  provenance: WORKSPACE_FILE.provenance,
+  mount_path: 'uploads/customer-sample.csv',
+  mode: 'read_only',
+  state: 'pending',
+  error: null,
+  labels: {},
+  content_path: '/api/v1/sessions/session-1/file-bindings/binding-1/content',
+  created_at: '2026-05-04T19:04:00Z',
+  updated_at: '2026-05-04T19:05:00Z',
+};
+
+describe('ControlFileWorkspaceMapper', () => {
+  it('maps file workspace and file lists with explicit nullable metadata', () => {
+    const workspaces = ControlFileWorkspaceMapper.toWorkspaceList({ workspaces: [WORKSPACE] });
+    const files = ControlFileWorkspaceMapper.toWorkspaceFileList({
+      files: [{ ...WORKSPACE_FILE, media_type: null, provenance: null }],
+    });
+
+    expect(workspaces.workspaces[0]).toMatchObject({
+      id: WORKSPACE.id,
+      name: 'Admin inputs',
+      description: null,
+    });
+    expect(files.files[0]?.media_type).toBeNull();
+    expect(files.files[0]?.provenance).toBeNull();
+  });
+
+  it('maps session file bindings and preserves provenance', () => {
+    const response = ControlFileWorkspaceMapper.toSessionFileBindingList({ bindings: [BINDING] });
+
+    expect(response.bindings[0]).toMatchObject({
+      file_name: 'customer-sample.csv',
+      mount_path: 'uploads/customer-sample.csv',
+      mode: 'read_only',
+      state: 'pending',
+      provenance: { source: 'admin-upload' },
+    });
+  });
+
+  it('rejects malformed wire shapes with actionable resource labels', () => {
+    expect(() => ControlFileWorkspaceMapper.toWorkspaceList({ workspaces: null }))
+      .toThrow('file workspace list response must contain a workspaces array');
+    expect(() => ControlFileWorkspaceMapper.toWorkspaceFile({ ...WORKSPACE_FILE, provenance: 'bad' }))
+      .toThrow('file workspace file provenance must be an object');
+    expect(() => ControlFileWorkspaceMapper.toSessionFileBinding({ ...BINDING, mode: 'execute' }))
+      .toThrow('session file binding mode must be a known binding mode');
+  });
+});

--- a/code/web/bpane-admin/src/lib/api/control-file-workspace-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-file-workspace-mapper.ts
@@ -1,0 +1,137 @@
+import type {
+  FileWorkspaceFileListResponse,
+  FileWorkspaceFileResource,
+  FileWorkspaceListResponse,
+  FileWorkspaceResource,
+  SessionFileBindingListResponse,
+  SessionFileBindingMode,
+  SessionFileBindingResource,
+  SessionFileBindingState,
+} from './control-types';
+import {
+  expectNumber,
+  expectRecord,
+  expectString,
+  expectStringRecord,
+  optionalString,
+} from './control-wire';
+
+const SESSION_FILE_BINDING_MODES = new Set<string>(['read_only', 'read_write', 'scratch_output']);
+const SESSION_FILE_BINDING_STATES = new Set<string>(['pending', 'materialized', 'failed', 'removed']);
+
+export class ControlFileWorkspaceMapper {
+  static toWorkspaceList(payload: unknown): FileWorkspaceListResponse {
+    const object = expectRecord(payload, 'file workspace list response');
+    const workspaces = object.workspaces;
+    if (!Array.isArray(workspaces)) {
+      throw new Error('file workspace list response must contain a workspaces array');
+    }
+    return {
+      workspaces: workspaces.map((workspace) => this.toWorkspace(workspace)),
+    };
+  }
+
+  static toWorkspace(payload: unknown): FileWorkspaceResource {
+    const object = expectRecord(payload, 'file workspace resource');
+    const description = optionalString(object.description, 'file workspace description');
+    return {
+      id: expectString(object.id, 'file workspace id'),
+      name: expectString(object.name, 'file workspace name'),
+      ...(description !== undefined ? { description } : {}),
+      labels: expectStringRecord(object.labels, 'file workspace labels'),
+      files_path: expectString(object.files_path, 'file workspace files_path'),
+      created_at: expectString(object.created_at, 'file workspace created_at'),
+      updated_at: expectString(object.updated_at, 'file workspace updated_at'),
+    };
+  }
+
+  static toWorkspaceFileList(payload: unknown): FileWorkspaceFileListResponse {
+    const object = expectRecord(payload, 'file workspace file list response');
+    const files = object.files;
+    if (!Array.isArray(files)) {
+      throw new Error('file workspace file list response must contain a files array');
+    }
+    return {
+      files: files.map((file) => this.toWorkspaceFile(file)),
+    };
+  }
+
+  static toWorkspaceFile(payload: unknown): FileWorkspaceFileResource {
+    const object = expectRecord(payload, 'file workspace file resource');
+    const mediaType = optionalString(object.media_type, 'file workspace file media_type');
+    return {
+      id: expectString(object.id, 'file workspace file id'),
+      workspace_id: expectString(object.workspace_id, 'file workspace file workspace_id'),
+      name: expectString(object.name, 'file workspace file name'),
+      ...(mediaType !== undefined ? { media_type: mediaType } : {}),
+      byte_count: expectNumber(object.byte_count, 'file workspace file byte_count'),
+      sha256_hex: expectString(object.sha256_hex, 'file workspace file sha256_hex'),
+      provenance: expectNullableRecord(object.provenance, 'file workspace file provenance'),
+      content_path: expectString(object.content_path, 'file workspace file content_path'),
+      created_at: expectString(object.created_at, 'file workspace file created_at'),
+      updated_at: expectString(object.updated_at, 'file workspace file updated_at'),
+    };
+  }
+
+  static toSessionFileBindingList(payload: unknown): SessionFileBindingListResponse {
+    const object = expectRecord(payload, 'session file binding list response');
+    const bindings = object.bindings;
+    if (!Array.isArray(bindings)) {
+      throw new Error('session file binding list response must contain a bindings array');
+    }
+    return {
+      bindings: bindings.map((binding) => this.toSessionFileBinding(binding)),
+    };
+  }
+
+  static toSessionFileBinding(payload: unknown): SessionFileBindingResource {
+    const object = expectRecord(payload, 'session file binding resource');
+    const mediaType = optionalString(object.media_type, 'session file binding media_type');
+    const error = optionalString(object.error, 'session file binding error');
+    return {
+      id: expectString(object.id, 'session file binding id'),
+      session_id: expectString(object.session_id, 'session file binding session_id'),
+      workspace_id: expectString(object.workspace_id, 'session file binding workspace_id'),
+      file_id: expectString(object.file_id, 'session file binding file_id'),
+      file_name: expectString(object.file_name, 'session file binding file_name'),
+      ...(mediaType !== undefined ? { media_type: mediaType } : {}),
+      byte_count: expectNumber(object.byte_count, 'session file binding byte_count'),
+      sha256_hex: expectString(object.sha256_hex, 'session file binding sha256_hex'),
+      provenance: expectNullableRecord(object.provenance, 'session file binding provenance'),
+      mount_path: expectString(object.mount_path, 'session file binding mount_path'),
+      mode: expectSessionFileBindingMode(object.mode),
+      state: expectSessionFileBindingState(object.state),
+      ...(error !== undefined ? { error } : {}),
+      labels: expectStringRecord(object.labels, 'session file binding labels'),
+      content_path: expectString(object.content_path, 'session file binding content_path'),
+      created_at: expectString(object.created_at, 'session file binding created_at'),
+      updated_at: expectString(object.updated_at, 'session file binding updated_at'),
+    };
+  }
+}
+
+function expectNullableRecord(
+  value: unknown,
+  label: string,
+): Readonly<Record<string, unknown>> | null {
+  if (value === null) {
+    return null;
+  }
+  return expectRecord(value, label);
+}
+
+function expectSessionFileBindingMode(value: unknown): SessionFileBindingMode {
+  const mode = expectString(value, 'session file binding mode');
+  if (!SESSION_FILE_BINDING_MODES.has(mode)) {
+    throw new Error('session file binding mode must be a known binding mode');
+  }
+  return mode as SessionFileBindingMode;
+}
+
+function expectSessionFileBindingState(value: unknown): SessionFileBindingState {
+  const state = expectString(value, 'session file binding state');
+  if (!SESSION_FILE_BINDING_STATES.has(state)) {
+    throw new Error('session file binding state must be a known binding state');
+  }
+  return state as SessionFileBindingState;
+}

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -98,3 +98,83 @@ export type SessionFileResource = {
 export type SessionFileListResponse = {
   readonly files: readonly SessionFileResource[];
 };
+
+export type FileWorkspaceResource = {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly files_path: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type FileWorkspaceListResponse = {
+  readonly workspaces: readonly FileWorkspaceResource[];
+};
+
+export type CreateFileWorkspaceCommand = {
+  readonly name: string;
+  readonly description?: string | null;
+  readonly labels?: Readonly<Record<string, string>>;
+};
+
+export type FileWorkspaceFileResource = {
+  readonly id: string;
+  readonly workspace_id: string;
+  readonly name: string;
+  readonly media_type?: string | null;
+  readonly byte_count: number;
+  readonly sha256_hex: string;
+  readonly provenance: Readonly<Record<string, unknown>> | null;
+  readonly content_path: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type FileWorkspaceFileListResponse = {
+  readonly files: readonly FileWorkspaceFileResource[];
+};
+
+export type UploadFileWorkspaceFileCommand = {
+  readonly fileName: string;
+  readonly content: BodyInit;
+  readonly mediaType?: string | null;
+  readonly provenance?: Readonly<Record<string, unknown>> | null;
+};
+
+export type SessionFileBindingMode = 'read_only' | 'read_write' | 'scratch_output';
+
+export type SessionFileBindingState = 'pending' | 'materialized' | 'failed' | 'removed';
+
+export type SessionFileBindingResource = {
+  readonly id: string;
+  readonly session_id: string;
+  readonly workspace_id: string;
+  readonly file_id: string;
+  readonly file_name: string;
+  readonly media_type?: string | null;
+  readonly byte_count: number;
+  readonly sha256_hex: string;
+  readonly provenance: Readonly<Record<string, unknown>> | null;
+  readonly mount_path: string;
+  readonly mode: SessionFileBindingMode;
+  readonly state: SessionFileBindingState;
+  readonly error?: string | null;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly content_path: string;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type SessionFileBindingListResponse = {
+  readonly bindings: readonly SessionFileBindingResource[];
+};
+
+export type CreateSessionFileBindingCommand = {
+  readonly workspace_id: string;
+  readonly file_id: string;
+  readonly mount_path: string;
+  readonly mode?: SessionFileBindingMode;
+  readonly labels?: Readonly<Record<string, string>>;
+};

--- a/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
@@ -1,0 +1,289 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { onMount } from 'svelte';
+  import type { ControlClient } from '../api/control-client';
+  import type {
+    FileWorkspaceFileResource,
+    FileWorkspaceResource,
+  } from '../api/control-types';
+  import {
+    FileWorkspaceViewModelBuilder,
+    type FileWorkspaceFileViewModel,
+  } from '../presentation/file-workspace-view-model';
+
+  type AdminFileWorkspaceDetailRouteProps = {
+    readonly controlClient: ControlClient;
+    readonly workspaceId: string;
+  };
+
+  let { controlClient, workspaceId }: AdminFileWorkspaceDetailRouteProps = $props();
+  let workspace = $state<FileWorkspaceResource | null>(null);
+  let files = $state<readonly FileWorkspaceFileResource[]>([]);
+  let loading = $state(false);
+  let uploading = $state(false);
+  let deletingFileId = $state<string | null>(null);
+  let downloadingFileId = $state<string | null>(null);
+  let error = $state<string | null>(null);
+  let actionMessage = $state<string | null>(null);
+  let lastRefreshedAt = $state<string | null>(null);
+  let fileInput = $state<HTMLInputElement | null>(null);
+
+  const fileRows = $derived(files.map((file) => FileWorkspaceViewModelBuilder.workspaceFile(file)));
+
+  onMount(() => {
+    void loadDetail();
+  });
+
+  async function loadDetail(): Promise<void> {
+    loading = true;
+    error = null;
+    actionMessage = null;
+    try {
+      const [nextWorkspace, nextFiles] = await Promise.all([
+        controlClient.getFileWorkspace(workspaceId),
+        controlClient.listFileWorkspaceFiles(workspaceId),
+      ]);
+      workspace = nextWorkspace;
+      files = nextFiles.files;
+      lastRefreshedAt = new Date().toISOString();
+    } catch (loadError) {
+      error = errorMessage(loadError, 'Unexpected file workspace detail error');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function uploadFile(): Promise<void> {
+    const selectedFile = fileInput?.files?.[0];
+    if (!selectedFile) {
+      error = 'Choose a file before uploading.';
+      return;
+    }
+    uploading = true;
+    error = null;
+    actionMessage = null;
+    try {
+      const uploaded = await controlClient.uploadFileWorkspaceFile(workspaceId, {
+        fileName: selectedFile.name,
+        mediaType: selectedFile.type || 'application/octet-stream',
+        content: selectedFile,
+        provenance: {
+          source: 'admin-upload',
+          uploaded_at: new Date().toISOString(),
+        },
+      });
+      files = [uploaded, ...files.filter((file) => file.id !== uploaded.id)];
+      if (fileInput) {
+        fileInput.value = '';
+      }
+      actionMessage = `Uploaded ${uploaded.name}.`;
+    } catch (uploadError) {
+      error = errorMessage(uploadError, 'Unexpected workspace file upload error');
+    } finally {
+      uploading = false;
+    }
+  }
+
+  async function downloadFile(fileId: string): Promise<void> {
+    const file = files.find((entry) => entry.id === fileId);
+    if (!file) {
+      return;
+    }
+    downloadingFileId = fileId;
+    error = null;
+    try {
+      const blob = await controlClient.downloadFileWorkspaceFileContent(file);
+      triggerDownload(blob, file.name);
+    } catch (downloadError) {
+      error = errorMessage(downloadError, 'Unexpected workspace file download error');
+    } finally {
+      downloadingFileId = null;
+    }
+  }
+
+  async function deleteFile(fileId: string): Promise<void> {
+    deletingFileId = fileId;
+    error = null;
+    actionMessage = null;
+    try {
+      const deleted = await controlClient.deleteFileWorkspaceFile(workspaceId, fileId);
+      files = files.filter((file) => file.id !== fileId);
+      actionMessage = `Deleted ${deleted.name}.`;
+    } catch (deleteError) {
+      error = errorMessage(deleteError, 'Unexpected workspace file delete error');
+    } finally {
+      deletingFileId = null;
+    }
+  }
+
+  function triggerDownload(blob: Blob, fileName: string): void {
+    const url = URL.createObjectURL(blob);
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      document.body.append(link);
+      link.click();
+      link.remove();
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  function formatDate(value: string | null): string {
+    return value ? new Date(value).toLocaleString() : 'not refreshed';
+  }
+
+  function errorMessage(value: unknown, fallback: string): string {
+    return value instanceof Error ? value.message : fallback;
+  }
+</script>
+
+<section class="grid gap-5" data-testid="file-workspace-detail">
+  <div class="admin-panel mt-0">
+    <div class="admin-header">
+      <div class="min-w-0">
+        <p class="admin-eyebrow">File workspace detail</p>
+        <h1
+          class="m-0 max-w-full text-xl font-bold text-admin-ink [overflow-wrap:anywhere]"
+          data-testid="file-workspace-detail-title"
+        >
+          {workspace?.name ?? workspaceId}
+        </h1>
+      </div>
+      <div class="admin-actions">
+        <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
+        <a class="admin-button-ghost" href={`${base}/sessions`}>Sessions</a>
+        <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="file-workspace-detail-refresh"
+          disabled={loading || uploading || Boolean(deletingFileId)}
+          onclick={() => void loadDetail()}
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+    <p class="m-0 mt-3 text-sm text-admin-ink/62" data-testid="file-workspace-detail-last-refresh">
+      Last refreshed {formatDate(lastRefreshedAt)}
+    </p>
+  </div>
+
+  {#if loading && !workspace}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0">Loading file workspace...</p>
+    </section>
+  {:else if error && !workspace}
+    <section class="admin-panel mt-0">
+      <p class="admin-error mt-0" data-testid="file-workspace-detail-error">{error}</p>
+    </section>
+  {:else}
+    {#if workspace}
+      <section class="admin-panel mt-0 grid gap-3">
+        <p class="admin-eyebrow">Workspace</p>
+        <div class="grid gap-2 text-sm text-admin-ink/72 md:grid-cols-2">
+          <span class="[overflow-wrap:anywhere]"><strong>Workspace id:</strong> <code class="admin-code-pill">{workspace.id}</code></span>
+          <span><strong>Files:</strong> {files.length}</span>
+          <span><strong>Description:</strong> {workspace.description ?? 'No description available.'}</span>
+          <span><strong>Updated:</strong> {formatDate(workspace.updated_at)}</span>
+        </div>
+      </section>
+    {/if}
+
+    <section class="admin-panel mt-0">
+      <div class="admin-header">
+        <div>
+          <p class="admin-eyebrow">Upload</p>
+          <h2 class="admin-section-title">Add workspace file</h2>
+        </div>
+      </div>
+      <form
+        class="mt-4 grid gap-3 md:grid-cols-[minmax(220px,1fr)_auto]"
+        onsubmit={(event) => {
+          event.preventDefault();
+          void uploadFile();
+        }}
+      >
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 py-2 text-admin-ink outline-none file:mr-3 file:rounded-lg file:border-0 file:bg-admin-leaf/15 file:px-3 file:py-1.5 file:text-admin-leaf"
+          type="file"
+          data-testid="file-workspace-upload-input"
+          bind:this={fileInput}
+        />
+        <button
+          class="admin-button-primary"
+          type="submit"
+          data-testid="file-workspace-upload-submit"
+          disabled={uploading || loading}
+        >
+          {uploading ? 'Uploading...' : 'Upload file'}
+        </button>
+      </form>
+      <p class="m-0 mt-3 text-sm text-admin-ink/58">
+        Files are downloaded as attachments; active content is not previewed in the admin UI.
+      </p>
+    </section>
+
+    {#if error}
+      <p class="admin-error" data-testid="file-workspace-action-error">{error}</p>
+    {/if}
+    {#if actionMessage}
+      <p class="m-0 text-sm font-bold text-admin-leaf" data-testid="file-workspace-action-message">{actionMessage}</p>
+    {/if}
+
+    <section class="admin-panel mt-0 grid gap-3">
+      <div class="admin-header">
+        <div>
+          <p class="admin-eyebrow">Workspace files</p>
+          <h2 class="admin-section-title">Reusable inputs</h2>
+        </div>
+      </div>
+      {#if fileRows.length === 0}
+        <p class="admin-empty mt-0" data-testid="file-workspace-files-empty">No files have been uploaded to this workspace yet.</p>
+      {:else}
+        <div class="grid gap-3">
+          {#each fileRows as file}
+            {@render FileRow(file)}
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
+</section>
+
+{#snippet FileRow(file: FileWorkspaceFileViewModel)}
+  <article
+    class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-field p-4 lg:grid-cols-[minmax(0,1fr)_auto]"
+    data-testid="file-workspace-file-row"
+    data-file-id={file.id}
+  >
+    <div class="grid min-w-0 gap-1">
+      <strong class="[overflow-wrap:anywhere]" data-testid="file-workspace-file-name">{file.name}</strong>
+      <span class="text-xs text-admin-ink/62">{file.size} | {file.mediaType} | {file.createdAt}</span>
+      <span class="font-mono text-xs text-admin-ink/58">{file.digest}</span>
+      <span class="text-xs text-admin-ink/58">{file.provenance}</span>
+    </div>
+    <div class="flex flex-wrap items-start gap-2">
+      <button
+        class="admin-button-primary"
+        type="button"
+        data-testid="file-workspace-file-download"
+        disabled={Boolean(downloadingFileId) || Boolean(deletingFileId)}
+        onclick={() => void downloadFile(file.id)}
+      >
+        {downloadingFileId === file.id ? 'Downloading...' : 'Download'}
+      </button>
+      <button
+        class="admin-button-ghost"
+        type="button"
+        data-testid="file-workspace-file-delete"
+        disabled={Boolean(downloadingFileId) || Boolean(deletingFileId)}
+        onclick={() => void deleteFile(file.id)}
+      >
+        {deletingFileId === file.id ? 'Deleting...' : 'Delete'}
+      </button>
+    </div>
+  </article>
+{/snippet}

--- a/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceListRoute.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import { goto } from '$app/navigation';
+  import { onMount } from 'svelte';
+  import type { ControlClient } from '../api/control-client';
+  import type { FileWorkspaceResource } from '../api/control-types';
+  import { FileWorkspaceViewModelBuilder } from '../presentation/file-workspace-view-model';
+
+  type AdminFileWorkspaceListRouteProps = {
+    readonly controlClient: ControlClient;
+  };
+
+  let { controlClient }: AdminFileWorkspaceListRouteProps = $props();
+  let workspaces = $state<readonly FileWorkspaceResource[]>([]);
+  let fileCounts = $state<Readonly<Record<string, number | null>>>({});
+  let loading = $state(false);
+  let creating = $state(false);
+  let error = $state<string | null>(null);
+  let search = $state('');
+  let name = $state('');
+  let description = $state('');
+  let labels = $state('purpose=admin-input');
+  let lastRefreshedAt = $state<string | null>(null);
+
+  const viewModel = $derived(FileWorkspaceViewModelBuilder.list({ workspaces, search }));
+
+  onMount(() => {
+    void loadWorkspaces();
+  });
+
+  async function loadWorkspaces(): Promise<void> {
+    loading = true;
+    error = null;
+    try {
+      const response = await controlClient.listFileWorkspaces();
+      workspaces = response.workspaces;
+      lastRefreshedAt = new Date().toISOString();
+      void loadFileCounts(response.workspaces);
+    } catch (loadError) {
+      error = errorMessage(loadError, 'Unexpected file workspace list error');
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadFileCounts(nextWorkspaces: readonly FileWorkspaceResource[]): Promise<void> {
+    const entries = await Promise.all(nextWorkspaces.map(async (workspace) => {
+      try {
+        return [workspace.id, (await controlClient.listFileWorkspaceFiles(workspace.id)).files.length] as const;
+      } catch {
+        return [workspace.id, null] as const;
+      }
+    }));
+    fileCounts = Object.fromEntries(entries);
+  }
+
+  async function createWorkspace(): Promise<void> {
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      error = 'Workspace name is required.';
+      return;
+    }
+    creating = true;
+    error = null;
+    try {
+      const created = await controlClient.createFileWorkspace({
+        name: trimmedName,
+        description: description.trim() || null,
+        labels: parseLabels(labels),
+      });
+      workspaces = [created, ...workspaces.filter((workspace) => workspace.id !== created.id)];
+      await goto(workspaceHref(created.id));
+    } catch (createError) {
+      error = errorMessage(createError, 'Unexpected file workspace create error');
+    } finally {
+      creating = false;
+    }
+  }
+
+  function workspaceHref(workspaceId: string): string {
+    return `${base}/files/workspaces/${encodeURIComponent(workspaceId)}`;
+  }
+
+  function formatDate(value: string | null): string {
+    return value ? new Date(value).toLocaleString() : 'not refreshed';
+  }
+
+  function fileCountLabel(workspaceId: string): string {
+    const count = fileCounts[workspaceId];
+    if (count === null || count === undefined) {
+      return 'files unavailable';
+    }
+    return count === 1 ? '1 file' : `${count} files`;
+  }
+
+  function parseLabels(value: string): Readonly<Record<string, string>> {
+    const parsed: Record<string, string> = {};
+    for (const rawPart of value.split(/[\n,]/u)) {
+      const part = rawPart.trim();
+      if (!part) {
+        continue;
+      }
+      const separator = part.indexOf('=');
+      if (separator <= 0) {
+        throw new Error(`Label "${part}" must use key=value.`);
+      }
+      const key = part.slice(0, separator).trim();
+      const labelValue = part.slice(separator + 1).trim();
+      if (!key || !labelValue) {
+        throw new Error(`Label "${part}" must use non-empty key and value.`);
+      }
+      parsed[key] = labelValue;
+    }
+    return parsed;
+  }
+
+  function errorMessage(value: unknown, fallback: string): string {
+    return value instanceof Error ? value.message : fallback;
+  }
+</script>
+
+<section class="grid gap-5" data-testid="file-workspace-list">
+  <div class="admin-panel mt-0">
+    <div class="admin-header">
+      <div>
+        <p class="admin-eyebrow">File workspaces</p>
+        <h1 class="admin-section-title">Reusable input files</h1>
+      </div>
+      <div class="admin-actions">
+        <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <a class="admin-button-ghost" href={`${base}/sessions`}>Sessions</a>
+        <a class="admin-button-ghost" href={`${base}/workflows`}>Workflow catalog</a>
+        <button
+          class="admin-button-primary"
+          type="button"
+          data-testid="file-workspace-refresh"
+          disabled={loading || creating}
+          onclick={() => void loadWorkspaces()}
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+    <div class="mt-4 grid gap-3 md:grid-cols-[minmax(220px,360px)_1fr] md:items-end">
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Search
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="file-workspace-search"
+          placeholder="Workspace name, label, description"
+          bind:value={search}
+        />
+      </label>
+      <p class="m-0 text-sm text-admin-ink/62" data-testid="file-workspace-count">
+        {viewModel.rows.length} of {viewModel.totalCount} visible workspaces | Last refreshed {formatDate(lastRefreshedAt)}
+      </p>
+    </div>
+  </div>
+
+  <section class="admin-panel mt-0">
+    <div class="admin-header">
+      <div>
+        <p class="admin-eyebrow">Create workspace</p>
+        <h2 class="admin-section-title">Prepare reusable inputs</h2>
+      </div>
+    </div>
+    <form
+      class="mt-4 grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(220px,1.2fr)_minmax(180px,1fr)_auto]"
+      onsubmit={(event) => {
+        event.preventDefault();
+        void createWorkspace();
+      }}
+    >
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Name
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="file-workspace-create-name"
+          placeholder="Admin input files"
+          bind:value={name}
+        />
+      </label>
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Description
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="file-workspace-create-description"
+          placeholder="CSV and documents for workflow runs"
+          bind:value={description}
+        />
+      </label>
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Labels
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="file-workspace-create-labels"
+          placeholder="key=value"
+          bind:value={labels}
+        />
+      </label>
+      <button
+        class="admin-button-primary self-end"
+        type="submit"
+        data-testid="file-workspace-create-submit"
+        disabled={creating || loading}
+      >
+        {creating ? 'Creating...' : 'Create'}
+      </button>
+    </form>
+  </section>
+
+  {#if error}
+    <section class="admin-panel mt-0">
+      <p class="admin-error mt-0" data-testid="file-workspace-error">{error}</p>
+    </section>
+  {:else if loading && workspaces.length === 0}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0">Loading file workspaces...</p>
+    </section>
+  {:else if viewModel.rows.length === 0}
+    <section class="admin-panel mt-0">
+      <p class="admin-empty mt-0" data-testid="file-workspace-empty">{viewModel.emptyMessage}</p>
+    </section>
+  {:else}
+    <section class="grid gap-2" aria-label="File workspace table">
+      {#each viewModel.rows as row}
+        <a
+          class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-panel/82 p-4 text-admin-ink no-underline transition hover:border-admin-leaf/42 hover:bg-admin-field/78 lg:grid-cols-[minmax(0,1fr)_minmax(180px,260px)]"
+          href={workspaceHref(row.id)}
+          data-testid="file-workspace-row"
+          data-workspace-id={row.id}
+        >
+          <span class="grid min-w-0 gap-1">
+            <strong class="truncate text-base" data-testid="file-workspace-row-title" title={row.name}>{row.name}</strong>
+            <span class="line-clamp-2 text-sm text-admin-ink/66">{row.description}</span>
+            <span class="truncate text-xs text-admin-ink/54">{row.labels}</span>
+          </span>
+          <span class="grid min-w-0 gap-1 text-xs text-admin-ink/62">
+            <span><strong class="text-admin-ink/78">Files:</strong> {fileCountLabel(row.id)}</span>
+            <span><strong class="text-admin-ink/78">Updated:</strong> {row.updatedAt}</span>
+            <span><strong class="text-admin-ink/78">Created:</strong> {row.createdAt}</span>
+          </span>
+        </a>
+      {/each}
+    </section>
+  {/if}
+</section>

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -2,11 +2,16 @@
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import { ControlApiError, type ControlClient } from '../api/control-client';
-  import type { SessionFileResource, SessionResource } from '../api/control-types';
+  import type {
+    SessionFileBindingResource,
+    SessionFileResource,
+    SessionResource,
+  } from '../api/control-types';
   import type { SessionRecordingPlaybackResource, SessionRecordingResource } from '../api/recording-types';
   import type { SessionStatus } from '../api/session-status-types';
   import SessionDetailPanel from '../presentation/SessionDetailPanel.svelte';
   import { SessionViewModelBuilder } from '../presentation/session-view-model';
+  import SessionFileBindingsSurface from './SessionFileBindingsSurface.svelte';
 
   type AdminSessionDetailRouteProps = {
     readonly controlClient: ControlClient;
@@ -17,6 +22,7 @@
   let session = $state<SessionResource | null>(null);
   let status = $state<SessionStatus | null>(null);
   let files = $state<readonly SessionFileResource[]>([]);
+  let bindings = $state<readonly SessionFileBindingResource[]>([]);
   let recordings = $state<readonly SessionRecordingResource[]>([]);
   let playback = $state<SessionRecordingPlaybackResource | null>(null);
   let loading = $state(false);
@@ -57,8 +63,9 @@
   }
 
   async function loadRelatedResources(): Promise<void> {
-    const [fileResult, recordingResult, playbackResult] = await Promise.allSettled([
+    const [fileResult, bindingResult, recordingResult, playbackResult] = await Promise.allSettled([
       controlClient.listSessionFiles(sessionId),
+      controlClient.listSessionFileBindings(sessionId),
       controlClient.listSessionRecordings(sessionId),
       controlClient.getSessionRecordingPlayback(sessionId),
     ]);
@@ -68,6 +75,12 @@
     } else {
       files = [];
       errors.push(errorMessage(fileResult.reason, 'Session file summary failed'));
+    }
+    if (bindingResult.status === 'fulfilled') {
+      bindings = bindingResult.value.bindings;
+    } else {
+      bindings = [];
+      errors.push(errorMessage(bindingResult.reason, 'Session file binding summary failed'));
     }
     if (recordingResult.status === 'fulfilled') {
       recordings = recordingResult.value.recordings;
@@ -156,6 +169,7 @@
   const readyRecordingCount = $derived(recordings.filter((entry) => entry.state === 'ready').length);
   const activeRecordingCount = $derived(recordings.filter((entry) => entry.state === 'recording').length);
   const fileBytes = $derived(files.reduce((total, file) => total + file.byte_count, 0));
+  const bindingBytes = $derived(bindings.reduce((total, binding) => total + binding.byte_count, 0));
 </script>
 
 <section class="grid gap-5" data-testid="session-inspector-detail">
@@ -169,6 +183,7 @@
       </div>
       <div class="admin-actions">
         <a class="admin-button-ghost" href={`${base}/sessions`}>Sessions</a>
+        <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
         <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
         <button
           class="admin-button-primary"
@@ -206,13 +221,21 @@
       />
     </section>
 
-    <section class="grid gap-3 md:grid-cols-3" aria-label="Related session resources">
+    <section class="grid gap-3 md:grid-cols-4" aria-label="Related session resources">
       <article class="rounded-2xl border border-admin-ink/10 bg-admin-panel/82 p-4">
         <p class="admin-eyebrow">Runtime files</p>
         <strong class="block text-2xl text-admin-ink" data-testid="session-inspector-files-count">
           {files.length}
         </strong>
         <p class="m-0 mt-2 text-sm text-admin-ink/62">{byteLabel(fileBytes)} retained runtime data</p>
+      </article>
+
+      <article class="rounded-2xl border border-admin-ink/10 bg-admin-panel/82 p-4">
+        <p class="admin-eyebrow">Input bindings</p>
+        <strong class="block text-2xl text-admin-ink" data-testid="session-inspector-binding-count">
+          {bindings.length}
+        </strong>
+        <p class="m-0 mt-2 text-sm text-admin-ink/62">{byteLabel(bindingBytes)} mounted workspace inputs</p>
       </article>
 
       <article class="rounded-2xl border border-admin-ink/10 bg-admin-panel/82 p-4">
@@ -239,5 +262,16 @@
     {#if relatedError}
       <p class="admin-error" data-testid="session-inspector-related-error">{relatedError}</p>
     {/if}
+
+    <SessionFileBindingsSurface
+      {controlClient}
+      {sessionId}
+      onBindingCountChange={(count) => {
+        if (count === bindings.length) {
+          return;
+        }
+        void loadRelatedResources();
+      }}
+    />
   {/if}
 </section>

--- a/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
@@ -95,6 +95,7 @@
       </div>
       <div class="admin-actions">
         <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
         <button
           class="admin-button-primary"
           type="button"

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowCatalogRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowCatalogRoute.svelte
@@ -107,6 +107,7 @@
       </div>
       <div class="admin-actions">
         <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
+        <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
         <a class="admin-button-ghost" href={`${base}/workflow-runs`}>Workflow runs</a>
         <a class="admin-button-ghost" href={`${base}/sessions`}>Sessions</a>
         <button

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
@@ -102,6 +102,7 @@
       <div class="admin-actions">
         <a class="admin-button-ghost" href={`${base}/workflows`}>Workflow catalog</a>
         <a class="admin-button-ghost" href={`${base}/workflow-runs`}>Workflow runs</a>
+        <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
         <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
         <button
           class="admin-button-primary"

--- a/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
@@ -1,0 +1,384 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import type { ControlClient } from '../api/control-client';
+  import type {
+    FileWorkspaceFileResource,
+    FileWorkspaceResource,
+    SessionFileBindingMode,
+    SessionFileBindingResource,
+  } from '../api/control-types';
+  import {
+    FileWorkspaceViewModelBuilder,
+    validateSessionMountPath,
+    type SessionFileBindingViewModel,
+  } from '../presentation/file-workspace-view-model';
+
+  type SessionFileBindingsSurfaceProps = {
+    readonly controlClient: ControlClient;
+    readonly sessionId: string;
+    readonly refreshVersion?: number;
+    readonly onBindingCountChange?: (count: number) => void;
+  };
+
+  let {
+    controlClient,
+    sessionId,
+    refreshVersion = 0,
+    onBindingCountChange,
+  }: SessionFileBindingsSurfaceProps = $props();
+  let loadedSessionId = $state<string | null>(null);
+  let lastRefreshVersion = $state(0);
+  let selectedWorkspaceId = $state('');
+  let loadedWorkspaceId = $state<string | null>(null);
+  let selectedFileId = $state('');
+  let mountPath = $state('');
+  let mode = $state<SessionFileBindingMode>('read_only');
+  let workspaces = $state<readonly FileWorkspaceResource[]>([]);
+  let workspaceFiles = $state<readonly FileWorkspaceFileResource[]>([]);
+  let bindings = $state<readonly SessionFileBindingResource[]>([]);
+  let loading = $state(false);
+  let loadingFiles = $state(false);
+  let mutating = $state(false);
+  let downloadingBindingId = $state<string | null>(null);
+  let error = $state<string | null>(null);
+  let actionMessage = $state<string | null>(null);
+
+  const bindingRows = $derived(bindings.map((binding) => FileWorkspaceViewModelBuilder.sessionBinding(binding)));
+  const validation = $derived(validateSessionMountPath(
+    mountPath,
+    bindings
+      .filter((binding) => binding.state !== 'removed')
+      .map((binding) => binding.mount_path),
+  ));
+  const selectedWorkspace = $derived(workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? null);
+  const selectedFile = $derived(workspaceFiles.find((file) => file.id === selectedFileId) ?? null);
+
+  $effect(() => {
+    if (sessionId === loadedSessionId) {
+      return;
+    }
+    loadedSessionId = sessionId;
+    void loadBindingsAndWorkspaces();
+  });
+
+  $effect(() => {
+    if (refreshVersion === lastRefreshVersion) {
+      return;
+    }
+    lastRefreshVersion = refreshVersion;
+    void loadBindingsAndWorkspaces();
+  });
+
+  $effect(() => {
+    if (!selectedWorkspaceId || selectedWorkspaceId === loadedWorkspaceId) {
+      return;
+    }
+    loadedWorkspaceId = selectedWorkspaceId;
+    void loadWorkspaceFiles(selectedWorkspaceId);
+  });
+
+  async function loadBindingsAndWorkspaces(): Promise<void> {
+    loading = true;
+    error = null;
+    actionMessage = null;
+    try {
+      const [bindingResult, workspaceResult] = await Promise.allSettled([
+        controlClient.listSessionFileBindings(sessionId),
+        controlClient.listFileWorkspaces(),
+      ]);
+      if (bindingResult.status === 'fulfilled') {
+        bindings = bindingResult.value.bindings;
+        onBindingCountChange?.(bindingResult.value.bindings.length);
+      } else {
+        bindings = [];
+        onBindingCountChange?.(0);
+        error = errorMessage(bindingResult.reason, 'Session file bindings are unavailable.');
+      }
+      if (workspaceResult.status === 'fulfilled') {
+        workspaces = workspaceResult.value.workspaces;
+        if (!selectedWorkspaceId || !workspaceResult.value.workspaces.some((workspace) => workspace.id === selectedWorkspaceId)) {
+          selectedWorkspaceId = workspaceResult.value.workspaces[0]?.id ?? '';
+          loadedWorkspaceId = null;
+        }
+      } else {
+        workspaces = [];
+        selectedWorkspaceId = '';
+        selectedFileId = '';
+        error = [error, errorMessage(workspaceResult.reason, 'File workspaces are unavailable.')]
+          .filter(Boolean)
+          .join(' | ');
+      }
+    } finally {
+      loading = false;
+    }
+  }
+
+  async function loadWorkspaceFiles(workspaceId: string): Promise<void> {
+    loadingFiles = true;
+    error = null;
+    try {
+      const response = await controlClient.listFileWorkspaceFiles(workspaceId);
+      workspaceFiles = response.files;
+      selectedFileId = response.files[0]?.id ?? '';
+      if (selectedFileId && !mountPath.trim()) {
+        mountPath = `uploads/${response.files[0]?.name ?? 'input-file'}`;
+      }
+    } catch (loadError) {
+      workspaceFiles = [];
+      selectedFileId = '';
+      error = errorMessage(loadError, 'Workspace files are unavailable.');
+    } finally {
+      loadingFiles = false;
+    }
+  }
+
+  async function createBinding(): Promise<void> {
+    if (!selectedWorkspaceId || !selectedFileId) {
+      error = 'Choose a workspace file before creating a binding.';
+      return;
+    }
+    if (!validation.valid) {
+      error = validation.message;
+      return;
+    }
+    mutating = true;
+    error = null;
+    actionMessage = null;
+    try {
+      const created = await controlClient.createSessionFileBinding(sessionId, {
+        workspace_id: selectedWorkspaceId,
+        file_id: selectedFileId,
+        mount_path: validation.value,
+        mode,
+        labels: { source: 'admin' },
+      });
+      bindings = [created, ...bindings.filter((binding) => binding.id !== created.id)];
+      onBindingCountChange?.(bindings.length);
+      actionMessage = `Bound ${created.file_name} to ${created.mount_path}.`;
+      mountPath = '';
+    } catch (createError) {
+      error = errorMessage(createError, 'Unexpected session file binding create error');
+    } finally {
+      mutating = false;
+    }
+  }
+
+  async function removeBinding(bindingId: string): Promise<void> {
+    mutating = true;
+    error = null;
+    actionMessage = null;
+    try {
+      const removed = await controlClient.removeSessionFileBinding(sessionId, bindingId);
+      bindings = bindings.filter((binding) => binding.id !== bindingId);
+      onBindingCountChange?.(bindings.length);
+      actionMessage = `Removed binding for ${removed.file_name}.`;
+    } catch (removeError) {
+      error = errorMessage(removeError, 'Unexpected session file binding remove error');
+    } finally {
+      mutating = false;
+    }
+  }
+
+  async function downloadBinding(bindingId: string): Promise<void> {
+    const binding = bindings.find((entry) => entry.id === bindingId);
+    if (!binding) {
+      return;
+    }
+    downloadingBindingId = bindingId;
+    error = null;
+    try {
+      const blob = await controlClient.downloadSessionFileBindingContent(binding);
+      triggerDownload(blob, binding.file_name);
+    } catch (downloadError) {
+      error = errorMessage(downloadError, 'Unexpected session file binding download error');
+    } finally {
+      downloadingBindingId = null;
+    }
+  }
+
+  function triggerDownload(blob: Blob, fileName: string): void {
+    const url = URL.createObjectURL(blob);
+    try {
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      document.body.append(link);
+      link.click();
+      link.remove();
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  function workspaceHref(workspaceId: string): string {
+    return `${base}/files/workspaces/${encodeURIComponent(workspaceId)}`;
+  }
+
+  function errorMessage(value: unknown, fallback: string): string {
+    return value instanceof Error ? value.message : fallback;
+  }
+</script>
+
+<section class="admin-panel mt-0 grid gap-4" data-testid="session-file-bindings">
+  <div class="admin-header">
+    <div>
+      <p class="admin-eyebrow">Session file bindings</p>
+      <h2 class="admin-section-title">Mounted workspace inputs</h2>
+    </div>
+    <div class="admin-actions">
+      <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
+      <button
+        class="admin-button-primary"
+        type="button"
+        data-testid="session-file-bindings-refresh"
+        disabled={loading || mutating}
+        onclick={() => void loadBindingsAndWorkspaces()}
+      >
+        Refresh bindings
+      </button>
+    </div>
+  </div>
+
+  <form
+    class="grid gap-3 xl:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)_minmax(180px,1fr)_minmax(130px,160px)_auto]"
+    onsubmit={(event) => {
+      event.preventDefault();
+      void createBinding();
+    }}
+  >
+    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      Workspace
+      <select
+        class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="session-file-binding-workspace"
+        bind:value={selectedWorkspaceId}
+        disabled={loading || mutating || workspaces.length === 0}
+      >
+        {#each workspaces as workspace}
+          <option value={workspace.id}>{workspace.name}</option>
+        {/each}
+      </select>
+    </label>
+    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      Workspace file
+      <select
+        class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="session-file-binding-file"
+        bind:value={selectedFileId}
+        disabled={loadingFiles || mutating || workspaceFiles.length === 0}
+      >
+        {#each workspaceFiles as file}
+          <option value={file.id}>{file.name}</option>
+        {/each}
+      </select>
+    </label>
+    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      Mount path
+      <input
+        class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="session-file-binding-mount-path"
+        placeholder="uploads/customer-sample.csv"
+        bind:value={mountPath}
+      />
+    </label>
+    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      Mode
+      <select
+        class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="session-file-binding-mode"
+        bind:value={mode}
+        disabled={mutating}
+      >
+        <option value="read_only">read only</option>
+        <option value="read_write">read write</option>
+        <option value="scratch_output">scratch output</option>
+      </select>
+    </label>
+    <button
+      class="admin-button-primary self-end"
+      type="submit"
+      data-testid="session-file-binding-create"
+      disabled={loading || loadingFiles || mutating || !selectedWorkspaceId || !selectedFileId || !validation.valid}
+    >
+      {mutating ? 'Saving...' : 'Bind file'}
+    </button>
+  </form>
+
+  <div class="grid gap-2 text-xs text-admin-ink/58 md:grid-cols-2">
+    <span data-testid="session-file-binding-path-validation">{mountPath ? validation.message : 'Mount path must be a relative file path.'}</span>
+    <span>
+      Selected:
+      {#if selectedWorkspace && selectedFile}
+        <a class="text-admin-leaf" href={workspaceHref(selectedWorkspace.id)}>{selectedWorkspace.name}</a>
+        / {selectedFile.name}
+      {:else}
+        No workspace file selected
+      {/if}
+    </span>
+  </div>
+
+  {#if error}
+    <p class="admin-error mt-0" data-testid="session-file-bindings-error">{error}</p>
+  {/if}
+  {#if actionMessage}
+    <p class="m-0 text-sm font-bold text-admin-leaf" data-testid="session-file-bindings-message">{actionMessage}</p>
+  {/if}
+
+  {#if loading && bindings.length === 0}
+    <p class="admin-empty mt-0">Loading session file bindings...</p>
+  {:else if workspaces.length === 0}
+    <p class="admin-empty mt-0" data-testid="session-file-bindings-empty">
+      No file workspaces are available. Create a workspace before binding inputs into this session.
+    </p>
+  {:else if bindingRows.length === 0}
+    <p class="admin-empty mt-0" data-testid="session-file-bindings-empty">
+      No workspace files are bound to this session yet.
+    </p>
+  {:else}
+    <div class="grid gap-3">
+      {#each bindingRows as binding}
+        {@render BindingRow(binding)}
+      {/each}
+    </div>
+  {/if}
+</section>
+
+{#snippet BindingRow(binding: SessionFileBindingViewModel)}
+  <article
+    class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-field p-4 lg:grid-cols-[minmax(0,1fr)_auto]"
+    data-testid="session-file-binding-row"
+    data-binding-id={binding.id}
+  >
+    <div class="grid min-w-0 gap-1">
+      <strong class="[overflow-wrap:anywhere]" data-testid="session-file-binding-file-name">{binding.fileName}</strong>
+      <span class="font-mono text-xs text-admin-ink/70" data-testid="session-file-binding-mount">{binding.mountPath}</span>
+      <span class="text-xs text-admin-ink/62">{binding.size} | {binding.mediaType} | {binding.mode} | {binding.state}</span>
+      <span class="font-mono text-xs text-admin-ink/58">{binding.digest}</span>
+      <span class="text-xs text-admin-ink/58">{binding.provenance}</span>
+      {#if binding.error !== 'No materialization error.'}
+        <span class="text-xs text-admin-danger">{binding.error}</span>
+      {/if}
+    </div>
+    <div class="flex flex-wrap items-start gap-2">
+      <a class="admin-button-ghost" href={workspaceHref(binding.workspaceId)}>Workspace</a>
+      <button
+        class="admin-button-primary"
+        type="button"
+        data-testid="session-file-binding-download"
+        disabled={Boolean(downloadingBindingId) || mutating}
+        onclick={() => void downloadBinding(binding.id)}
+      >
+        {downloadingBindingId === binding.id ? 'Downloading...' : 'Download'}
+      </button>
+      <button
+        class="admin-button-ghost"
+        type="button"
+        data-testid="session-file-binding-remove"
+        disabled={Boolean(downloadingBindingId) || mutating}
+        onclick={() => void removeBinding(binding.id)}
+      >
+        Remove
+      </button>
+    </div>
+  </article>
+{/snippet}

--- a/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { base } from '$app/paths';
   import type { ControlClient } from '../api/control-client';
   import type { SessionFileResource, SessionResource } from '../api/control-types';
   import SessionFileCard from '../presentation/SessionFileCard.svelte';
@@ -103,15 +104,18 @@
     <span class="text-sm font-bold text-admin-ink/68">
       {session ? `${files.length} session file${files.length === 1 ? '' : 's'}` : 'No session selected'}
     </span>
-    <button
-      class="admin-button-primary"
-      type="button"
-      data-testid="session-files-refresh"
-      disabled={!session || loading || Boolean(downloadingFileId)}
-      onclick={() => void loadFiles()}
-    >
-      {loading ? 'Loading...' : 'Refresh files'}
-    </button>
+    <div class="flex flex-wrap gap-2">
+      <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
+      <button
+        class="admin-button-primary"
+        type="button"
+        data-testid="session-files-refresh"
+        disabled={!session || loading || Boolean(downloadingFileId)}
+        onclick={() => void loadFiles()}
+      >
+        {loading ? 'Loading...' : 'Refresh files'}
+      </button>
+    </div>
   </div>
 
   {#if error}

--- a/code/web/bpane-admin/src/lib/presentation/file-workspace-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/file-workspace-view-model.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  FileWorkspaceFileResource,
+  FileWorkspaceResource,
+  SessionFileBindingResource,
+} from '../api/control-types';
+import {
+  FileWorkspaceViewModelBuilder,
+  validateSessionMountPath,
+} from './file-workspace-view-model';
+
+describe('FileWorkspaceViewModelBuilder', () => {
+  it('filters workspace rows and keeps labels visible', () => {
+    const viewModel = FileWorkspaceViewModelBuilder.list({
+      workspaces: [WORKSPACE],
+      search: 'support',
+    });
+
+    expect(viewModel.rows).toHaveLength(1);
+    expect(viewModel.rows[0]?.labels).toBe('purpose=support');
+    expect(viewModel.emptyMessage).toBe('No file workspaces match the current filter.');
+  });
+
+  it('summarizes workspace files and binding metadata', () => {
+    const file = FileWorkspaceViewModelBuilder.workspaceFile(WORKSPACE_FILE);
+    const binding = FileWorkspaceViewModelBuilder.sessionBinding(BINDING);
+
+    expect(file.digest).toBe('sha256 64ec88ca00b268e5...');
+    expect(file.provenance).toContain('source=admin-upload');
+    expect(binding.mode).toBe('read only');
+    expect(binding.state).toBe('pending');
+    expect(binding.error).toBe('No materialization error.');
+  });
+});
+
+describe('validateSessionMountPath', () => {
+  it('accepts normalized relative session paths', () => {
+    expect(validateSessionMountPath(' uploads/customer-sample.csv ').value)
+      .toBe('uploads/customer-sample.csv');
+  });
+
+  it('rejects unsafe or colliding session paths', () => {
+    expect(validateSessionMountPath('').message).toBe('Mount path is required.');
+    expect(validateSessionMountPath('/tmp/file.csv').message).toBe('Mount path must be relative.');
+    expect(validateSessionMountPath('../file.csv').message).toBe('Mount path must not contain traversal components.');
+    expect(validateSessionMountPath('inputs//file.csv').message)
+      .toBe('Mount path must not contain empty path components.');
+    expect(validateSessionMountPath('inputs\\file.csv').message)
+      .toBe('Mount path must use forward slashes.');
+    expect(validateSessionMountPath('inputs/file.csv', ['inputs/file.csv']).message)
+      .toBe('Mount path is already bound for this session.');
+  });
+});
+
+const WORKSPACE: FileWorkspaceResource = {
+  id: 'workspace-1',
+  name: 'Admin inputs',
+  description: 'Support reproduction files',
+  labels: { purpose: 'support' },
+  files_path: '/api/v1/file-workspaces/workspace-1/files',
+  created_at: '2026-05-04T19:00:00Z',
+  updated_at: '2026-05-04T19:01:00Z',
+};
+
+const WORKSPACE_FILE: FileWorkspaceFileResource = {
+  id: 'file-1',
+  workspace_id: WORKSPACE.id,
+  name: 'customer-sample.csv',
+  media_type: 'text/csv',
+  byte_count: 22,
+  sha256_hex: '64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c',
+  provenance: { source: 'admin-upload' },
+  content_path: '/api/v1/file-workspaces/workspace-1/files/file-1/content',
+  created_at: '2026-05-04T19:02:00Z',
+  updated_at: '2026-05-04T19:03:00Z',
+};
+
+const BINDING: SessionFileBindingResource = {
+  id: 'binding-1',
+  session_id: 'session-1',
+  workspace_id: WORKSPACE.id,
+  file_id: WORKSPACE_FILE.id,
+  file_name: WORKSPACE_FILE.name,
+  media_type: 'text/csv',
+  byte_count: WORKSPACE_FILE.byte_count,
+  sha256_hex: WORKSPACE_FILE.sha256_hex,
+  provenance: WORKSPACE_FILE.provenance,
+  mount_path: 'uploads/customer-sample.csv',
+  mode: 'read_only',
+  state: 'pending',
+  error: null,
+  labels: {},
+  content_path: '/api/v1/sessions/session-1/file-bindings/binding-1/content',
+  created_at: '2026-05-04T19:04:00Z',
+  updated_at: '2026-05-04T19:05:00Z',
+};

--- a/code/web/bpane-admin/src/lib/presentation/file-workspace-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/file-workspace-view-model.ts
@@ -1,0 +1,209 @@
+import type {
+  FileWorkspaceFileResource,
+  FileWorkspaceResource,
+  SessionFileBindingResource,
+} from '../api/control-types';
+import {
+  formatSessionFileBytes,
+  formatSessionFileTimestamp,
+  shortSessionFileDigest,
+} from './session-file-format';
+
+export type FileWorkspaceListViewModel = {
+  readonly rows: readonly FileWorkspaceRowViewModel[];
+  readonly totalCount: number;
+  readonly emptyMessage: string;
+};
+
+export type FileWorkspaceRowViewModel = {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly labels: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+};
+
+export type FileWorkspaceFileViewModel = {
+  readonly id: string;
+  readonly workspaceId: string;
+  readonly name: string;
+  readonly mediaType: string;
+  readonly size: string;
+  readonly digest: string;
+  readonly provenance: string;
+  readonly createdAt: string;
+};
+
+export type SessionFileBindingViewModel = {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly workspaceId: string;
+  readonly fileId: string;
+  readonly fileName: string;
+  readonly mountPath: string;
+  readonly mediaType: string;
+  readonly size: string;
+  readonly digest: string;
+  readonly mode: string;
+  readonly state: string;
+  readonly error: string;
+  readonly provenance: string;
+  readonly createdAt: string;
+};
+
+export type SessionMountPathValidation = {
+  readonly valid: boolean;
+  readonly value: string;
+  readonly message: string;
+};
+
+export class FileWorkspaceViewModelBuilder {
+  static list(input: {
+    readonly workspaces: readonly FileWorkspaceResource[];
+    readonly search: string;
+  }): FileWorkspaceListViewModel {
+    const normalized = input.search.trim().toLowerCase();
+    const rows = input.workspaces
+      .map((workspace) => this.workspaceRow(workspace))
+      .filter((row) => workspaceRowMatches(row, normalized));
+    return {
+      rows,
+      totalCount: input.workspaces.length,
+      emptyMessage: normalized
+        ? 'No file workspaces match the current filter.'
+        : 'No file workspaces are available yet.',
+    };
+  }
+
+  static workspaceRow(workspace: FileWorkspaceResource): FileWorkspaceRowViewModel {
+    return {
+      id: workspace.id,
+      name: workspace.name,
+      description: workspace.description ?? 'No description available.',
+      labels: labelSummary(workspace.labels),
+      createdAt: formatSessionFileTimestamp(workspace.created_at),
+      updatedAt: formatSessionFileTimestamp(workspace.updated_at),
+    };
+  }
+
+  static workspaceFile(file: FileWorkspaceFileResource): FileWorkspaceFileViewModel {
+    return {
+      id: file.id,
+      workspaceId: file.workspace_id,
+      name: file.name,
+      mediaType: file.media_type ?? 'application/octet-stream',
+      size: formatSessionFileBytes(file.byte_count),
+      digest: `sha256 ${shortSessionFileDigest(file.sha256_hex)}`,
+      provenance: provenanceSummary(file.provenance),
+      createdAt: formatSessionFileTimestamp(file.created_at),
+    };
+  }
+
+  static sessionBinding(binding: SessionFileBindingResource): SessionFileBindingViewModel {
+    return {
+      id: binding.id,
+      sessionId: binding.session_id,
+      workspaceId: binding.workspace_id,
+      fileId: binding.file_id,
+      fileName: binding.file_name,
+      mountPath: binding.mount_path,
+      mediaType: binding.media_type ?? 'application/octet-stream',
+      size: formatSessionFileBytes(binding.byte_count),
+      digest: `sha256 ${shortSessionFileDigest(binding.sha256_hex)}`,
+      mode: binding.mode.replaceAll('_', ' '),
+      state: binding.state.replaceAll('_', ' '),
+      error: binding.error ?? 'No materialization error.',
+      provenance: provenanceSummary(binding.provenance),
+      createdAt: formatSessionFileTimestamp(binding.created_at),
+    };
+  }
+}
+
+export function validateSessionMountPath(
+  rawValue: string,
+  existingMountPaths: readonly string[] = [],
+): SessionMountPathValidation {
+  const value = rawValue.trim();
+  if (!value) {
+    return invalid(value, 'Mount path is required.');
+  }
+  if (value.startsWith('/')) {
+    return invalid(value, 'Mount path must be relative.');
+  }
+  if (value.includes('\\')) {
+    return invalid(value, 'Mount path must use forward slashes.');
+  }
+  if (value.includes('\0')) {
+    return invalid(value, 'Mount path must not contain control characters.');
+  }
+  const parts = value.split('/');
+  if (parts.some((part) => part.length === 0)) {
+    return invalid(value, 'Mount path must not contain empty path components.');
+  }
+  if (parts.some((part) => part === '.' || part === '..')) {
+    return invalid(value, 'Mount path must not contain traversal components.');
+  }
+  if (existingMountPaths.includes(value)) {
+    return invalid(value, 'Mount path is already bound for this session.');
+  }
+  return {
+    valid: true,
+    value,
+    message: 'Mount path is valid.',
+  };
+}
+
+function invalid(value: string, message: string): SessionMountPathValidation {
+  return { valid: false, value, message };
+}
+
+function workspaceRowMatches(row: FileWorkspaceRowViewModel, normalized: string): boolean {
+  if (!normalized) {
+    return true;
+  }
+  return [
+    row.id,
+    row.name,
+    row.description,
+    row.labels,
+    row.createdAt,
+    row.updatedAt,
+  ].some((value) => value.toLowerCase().includes(normalized));
+}
+
+function labelSummary(labels: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return 'No labels';
+  }
+  return entries.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+function provenanceSummary(provenance: Readonly<Record<string, unknown>> | null): string {
+  if (!provenance) {
+    return 'Provenance unavailable';
+  }
+  const entries = Object.entries(provenance)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .slice(0, 4)
+    .map(([key, value]) => `${key}=${stringifyMetadataValue(value)}`);
+  if (entries.length === 0) {
+    return 'Provenance unavailable';
+  }
+  return entries.join(', ');
+}
+
+function stringifyMetadataValue(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  if (value === null || value === undefined) {
+    return 'unavailable';
+  }
+  const serialized = JSON.stringify(value);
+  return serialized.length > 80 ? `${serialized.slice(0, 80)}...` : serialized;
+}

--- a/code/web/bpane-admin/src/routes/files/workspaces/+page.svelte
+++ b/code/web/bpane-admin/src/routes/files/workspaces/+page.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import AdminRouteShell from '$lib/application/AdminRouteShell.svelte';
+  import AdminFileWorkspaceListRoute from '$lib/application/AdminFileWorkspaceListRoute.svelte';
+</script>
+
+<AdminRouteShell title="BrowserPane File Workspaces">
+  {#snippet children(route)}
+    <AdminFileWorkspaceListRoute controlClient={route.controlClient} />
+  {/snippet}
+</AdminRouteShell>

--- a/code/web/bpane-admin/src/routes/files/workspaces/[workspace_id]/+page.svelte
+++ b/code/web/bpane-admin/src/routes/files/workspaces/[workspace_id]/+page.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import AdminRouteShell from '$lib/application/AdminRouteShell.svelte';
+  import AdminFileWorkspaceDetailRoute from '$lib/application/AdminFileWorkspaceDetailRoute.svelte';
+
+  let { data }: { data: { workspaceId: string } } = $props();
+</script>
+
+<AdminRouteShell title="BrowserPane File Workspace Detail">
+  {#snippet children(route)}
+    <AdminFileWorkspaceDetailRoute
+      controlClient={route.controlClient}
+      workspaceId={data.workspaceId}
+    />
+  {/snippet}
+</AdminRouteShell>

--- a/code/web/bpane-admin/src/routes/files/workspaces/[workspace_id]/+page.ts
+++ b/code/web/bpane-admin/src/routes/files/workspaces/[workspace_id]/+page.ts
@@ -1,0 +1,5 @@
+export function load({ params }: { params: { workspace_id: string } }): { workspaceId: string } {
+  return {
+    workspaceId: params.workspace_id,
+  };
+}

--- a/code/web/bpane-client/package.json
+++ b/code/web/bpane-client/package.json
@@ -17,6 +17,7 @@
     "smoke:admin-realtime": "node scripts/run-admin-realtime-smoke.mjs",
     "smoke:admin-event-reconnect": "node scripts/run-admin-event-reconnect-smoke.mjs",
     "smoke:admin-session-files": "node scripts/run-admin-session-files-smoke.mjs",
+    "smoke:admin-file-workspaces": "node scripts/run-admin-file-workspaces-smoke.mjs",
     "smoke:admin-metrics": "node scripts/run-admin-metrics-smoke.mjs",
     "smoke:admin-mcp": "node scripts/run-admin-mcp-smoke.mjs",
     "smoke:mcp-session-endpoints": "node scripts/run-mcp-session-endpoints-smoke.mjs",

--- a/code/web/bpane-client/scripts/admin-smoke-lib.mjs
+++ b/code/web/bpane-client/scripts/admin-smoke-lib.mjs
@@ -151,7 +151,8 @@ async function waitForAdminAuthenticated(page, options) {
 
 async function adminAuthenticatedVisible(page) {
   return await page.getByTestId('session-new').isVisible().catch(() => false)
-    || await page.getByTestId('session-inspector-new').isVisible().catch(() => false);
+    || await page.getByTestId('session-inspector-new').isVisible().catch(() => false)
+    || await page.getByTestId('file-workspace-create-submit').isVisible().catch(() => false);
 }
 
 async function waitForSessionClients(page, options, sessionId, expectedClients) {

--- a/code/web/bpane-client/scripts/run-admin-file-workspaces-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-file-workspaces-smoke.mjs
@@ -1,0 +1,275 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { chromium } from 'playwright-core';
+import { ensureAdminLoggedIn, getAdminAccessToken } from './admin-smoke-lib.mjs';
+import {
+  DEFAULTS,
+  createLogger,
+  deleteSession,
+  fetchJson,
+  launchChrome,
+  parseSmokeArgs,
+  poll,
+} from './workflow-smoke-lib.mjs';
+
+async function run() {
+  const options = parseSmokeArgs(process.argv.slice(2), 'run-admin-file-workspaces-smoke.mjs');
+  const rootOptions = { ...options, pageUrl: new URL('/', options.pageUrl).origin };
+  const adminOptions = {
+    ...options,
+    pageUrl: new URL('/admin/files/workspaces', rootOptions.pageUrl).toString(),
+  };
+  const log = createLogger('admin-file-workspaces-smoke');
+  const browser = await launchChrome(chromium, options);
+  const context = await browser.newContext({
+    acceptDownloads: true,
+    viewport: { width: 1440, height: 980 },
+  });
+  const page = await context.newPage();
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'bpane-admin-file-workspaces-'));
+  const uploadPath = path.join(tempDir, 'customer-sample.csv');
+  const deleteProbePath = path.join(tempDir, 'delete-probe.txt');
+  const uploadText = `customer,total\nadmin-smoke-${Date.now()},42\n`;
+  const deleteProbeText = `delete probe ${Date.now()}\n`;
+  const workspaceName = `Admin file workspace smoke ${Date.now()}`;
+  const mountPath = `uploads/admin-file-workspace-smoke-${Date.now()}.csv`;
+  let accessToken = '';
+  let sessionId = '';
+  let workspaceId = '';
+  let fileId = '';
+  let bindingId = '';
+  let verifiedBindingId = '';
+  let boundWorkspaceFile = false;
+
+  try {
+    await fs.writeFile(uploadPath, uploadText, 'utf8');
+    await fs.writeFile(deleteProbePath, deleteProbeText, 'utf8');
+    log(`Opening ${adminOptions.pageUrl}`);
+    await ensureAdminLoggedIn(page, adminOptions);
+    accessToken = await getAdminAccessToken(page);
+    if (!accessToken) {
+      throw new Error('No admin access token available after login.');
+    }
+
+    await createWorkspaceFromUi(page, options, workspaceName);
+    workspaceId = workspaceIdFromUrl(page.url());
+    await uploadWorkspaceFileFromUi(page, options, uploadPath);
+    fileId = await workspaceFileIdFromUi(page, options, 'customer-sample.csv');
+    const downloadedWorkspaceText = await downloadWorkspaceFileFromUi(page, 'customer-sample.csv');
+    if (downloadedWorkspaceText !== uploadText) {
+      throw new Error('Workspace file download did not match uploaded payload.');
+    }
+    await uploadWorkspaceFileFromUi(page, options, deleteProbePath, 'delete-probe.txt');
+    const deleteProbeFileId = await workspaceFileIdFromUi(page, options, 'delete-probe.txt');
+    await deleteWorkspaceFileFromUi(page, options, deleteProbeFileId);
+
+    sessionId = await createSession(accessToken, rootOptions);
+    await openSessionDetail(page, rootOptions, sessionId, options);
+    await createBindingFromUi(page, options, workspaceId, fileId, mountPath);
+    bindingId = await bindingIdFromUi(page, options, mountPath);
+    verifiedBindingId = bindingId;
+    boundWorkspaceFile = true;
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForBinding(page, options, mountPath);
+    const downloadedBindingText = await downloadBindingFromUi(page, mountPath);
+    if (downloadedBindingText !== uploadText) {
+      throw new Error('Session binding download did not match uploaded workspace payload.');
+    }
+
+    await removeBindingFromUi(page, options, bindingId);
+    bindingId = '';
+    await deleteSession(accessToken, rootOptions, sessionId);
+    sessionId = '';
+
+    const summary = {
+      pageUrl: adminOptions.pageUrl,
+      workspaceId,
+      fileId,
+      bindingId: verifiedBindingId,
+      mountPath,
+      uploadedBytes: Buffer.byteLength(uploadText),
+      bindingVerifiedAfterReload: true,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    if (options.outputPath) {
+      await fs.writeFile(options.outputPath, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+      log(`Wrote summary to ${options.outputPath}`);
+    }
+  } finally {
+    if (accessToken && bindingId && sessionId) {
+      await removeBinding(accessToken, rootOptions, sessionId, bindingId).catch(() => {});
+    }
+    if (accessToken && workspaceId && fileId && !boundWorkspaceFile) {
+      await deleteWorkspaceFile(accessToken, rootOptions, workspaceId, fileId).catch(() => {});
+    }
+    if (accessToken && sessionId) {
+      await deleteSession(accessToken, rootOptions, sessionId).catch(() => {});
+    }
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    await context.close();
+    await browser.close();
+  }
+}
+
+async function createWorkspaceFromUi(page, options, workspaceName) {
+  await page.getByTestId('file-workspace-create-name').fill(workspaceName);
+  await page.getByTestId('file-workspace-create-description').fill('Admin smoke reusable inputs');
+  await page.getByTestId('file-workspace-create-labels').fill('suite=smoke');
+  await page.getByTestId('file-workspace-create-submit').click();
+  await poll(
+    'workspace detail navigation',
+    async () => page.url(),
+    (url) => url.includes('/admin/files/workspaces/') && !url.endsWith('/workspaces'),
+    options.connectTimeoutMs,
+  );
+  await page.getByTestId('file-workspace-detail-title').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+}
+
+async function uploadWorkspaceFileFromUi(page, options, uploadPath, fileName = 'customer-sample.csv') {
+  await page.getByTestId('file-workspace-upload-input').setInputFiles(uploadPath);
+  await page.getByTestId('file-workspace-upload-submit').click();
+  await page.getByTestId('file-workspace-file-row').filter({ hasText: fileName }).waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+}
+
+async function workspaceFileIdFromUi(page, options, fileName) {
+  const row = page.getByTestId('file-workspace-file-row').filter({ hasText: fileName }).first();
+  await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  const fileId = await row.getAttribute('data-file-id');
+  if (!fileId) {
+    throw new Error('Workspace file row did not expose a file id.');
+  }
+  return fileId;
+}
+
+async function downloadWorkspaceFileFromUi(page, fileName) {
+  const row = page.getByTestId('file-workspace-file-row').filter({ hasText: fileName }).first();
+  const downloadPromise = page.waitForEvent('download');
+  await row.getByTestId('file-workspace-file-download').click();
+  return await readDownloadText(await downloadPromise);
+}
+
+async function deleteWorkspaceFileFromUi(page, options, fileId) {
+  const row = page.locator(`[data-testid="file-workspace-file-row"][data-file-id="${fileId}"]`);
+  await row.getByTestId('file-workspace-file-delete').click();
+  await row.waitFor({ state: 'detached', timeout: options.connectTimeoutMs });
+}
+
+async function createSession(accessToken, options) {
+  const session = await fetchJson(`${options.pageUrl}/api/v1/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ labels: { suite: 'admin-file-workspaces-smoke' } }),
+  });
+  return session.id;
+}
+
+async function openSessionDetail(page, rootOptions, sessionId, options) {
+  await page.goto(new URL(`/admin/sessions/${sessionId}`, rootOptions.pageUrl).toString(), {
+    waitUntil: 'domcontentloaded',
+  });
+  await page.getByTestId('session-file-bindings').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+}
+
+async function createBindingFromUi(page, options, workspaceId, fileId, mountPath) {
+  await page.getByTestId('session-file-binding-workspace').selectOption(workspaceId);
+  await poll(
+    'workspace file option',
+    async () => await page.getByTestId('session-file-binding-file').locator(`option[value="${fileId}"]`).count(),
+    (count) => count > 0,
+    options.connectTimeoutMs,
+  );
+  await page.getByTestId('session-file-binding-file').selectOption(fileId);
+  await page.getByTestId('session-file-binding-mount-path').fill(mountPath);
+  await page.getByTestId('session-file-binding-create').click();
+  await waitForBinding(page, options, mountPath);
+}
+
+async function waitForBinding(page, options, mountPath) {
+  await page.getByTestId('session-file-binding-row').filter({ hasText: mountPath }).waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+}
+
+async function bindingIdFromUi(page, options, mountPath) {
+  const row = page.getByTestId('session-file-binding-row').filter({ hasText: mountPath }).first();
+  await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  const bindingId = await row.getAttribute('data-binding-id');
+  if (!bindingId) {
+    throw new Error('Session file binding row did not expose a binding id.');
+  }
+  return bindingId;
+}
+
+async function downloadBindingFromUi(page, mountPath) {
+  const row = page.getByTestId('session-file-binding-row').filter({ hasText: mountPath }).first();
+  const downloadPromise = page.waitForEvent('download');
+  await row.getByTestId('session-file-binding-download').click();
+  return await readDownloadText(await downloadPromise);
+}
+
+async function removeBindingFromUi(page, options, bindingId) {
+  const row = page.locator(`[data-testid="session-file-binding-row"][data-binding-id="${bindingId}"]`);
+  await row.getByTestId('session-file-binding-remove').click();
+  await row.waitFor({ state: 'detached', timeout: options.connectTimeoutMs });
+}
+
+async function readDownloadText(download) {
+  const downloadPath = await download.path();
+  if (!downloadPath) {
+    throw new Error('Download did not produce a local file.');
+  }
+  return await fs.readFile(downloadPath, 'utf8');
+}
+
+async function removeBinding(accessToken, options, sessionId, bindingId) {
+  const response = await fetch(`${options.pageUrl}/api/v1/sessions/${sessionId}/file-bindings/${bindingId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok && response.status !== 404) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+  }
+}
+
+async function deleteWorkspaceFile(accessToken, options, workspaceId, fileId) {
+  const response = await fetch(`${options.pageUrl}/api/v1/file-workspaces/${workspaceId}/files/${fileId}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!response.ok && response.status !== 404) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+  }
+}
+
+function workspaceIdFromUrl(rawUrl) {
+  const url = new URL(rawUrl);
+  const parts = url.pathname.split('/').filter(Boolean);
+  const workspaceId = parts.at(-1);
+  if (!workspaceId || workspaceId === 'workspaces') {
+    throw new Error(`Could not parse workspace id from ${rawUrl}`);
+  }
+  return decodeURIComponent(workspaceId);
+}
+
+run().catch((error) => {
+  console.error(`[admin-file-workspaces-smoke] ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/code/web/bpane-client/scripts/run-admin-file-workspaces-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-file-workspaces-smoke.mjs
@@ -5,7 +5,6 @@ import process from 'node:process';
 import { chromium } from 'playwright-core';
 import { ensureAdminLoggedIn, getAdminAccessToken } from './admin-smoke-lib.mjs';
 import {
-  DEFAULTS,
   createLogger,
   deleteSession,
   fetchJson,


### PR DESCRIPTION
## Summary

Implements #91 by adding route-level admin file workspace management and session file binding controls.

- Adds `/admin/files/workspaces` and workspace detail pages for reusable input files.
- Adds typed admin client/mappers for file workspaces, workspace files, and session file bindings.
- Adds session detail controls to bind a workspace file into a session at a validated relative mount path.
- Keeps reusable workspace files, session bindings, runtime files, and workflow outputs visually distinct.
- Adds `smoke:admin-file-workspaces` for the end-to-end admin path.

## Validation

- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && node --check scripts/run-admin-file-workspaces-smoke.mjs`
- `cd code/web/bpane-client && npm run smoke:admin-file-workspaces -- --headless`

## Note

The smoke validates delete on an unbound probe file. A workspace file with session binding history is currently retained by backend referential constraints, so deleting historically bound input files remains a separate lifecycle decision.

Closes #91
