### PR TITLE
BPANE-0093 admin session configurator and feedback coverage

### DIFF
--- a/code/web/bpane-admin/src/app.css
+++ b/code/web/bpane-admin/src/app.css
@@ -82,18 +82,6 @@
     @apply inline-flex min-h-[42px] cursor-pointer items-center rounded-xl border border-[#90a6cc]/20 bg-admin-panel/80 px-4 font-bold text-admin-ink no-underline;
   }
 
-  .admin-empty {
-    @apply mt-[18px] mb-0 text-[#c1d0e8] leading-normal;
-  }
-
-  .admin-empty-spacious {
-    @apply mt-[22px];
-  }
-
-  .admin-error {
-    @apply mt-4 mb-0 text-admin-danger leading-normal;
-  }
-
   .admin-code-pill {
     @apply rounded-[7px] bg-admin-leaf/12 px-1.5 py-0.5;
   }

--- a/code/web/bpane-admin/src/lib/api/admin-event-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/admin-event-client.test.ts
@@ -218,6 +218,40 @@ describe('AdminEventClient', () => {
     subscription.close();
     vi.useRealTimers();
   });
+
+  it('routes failed websocket authentication through the shared auth handler', async () => {
+    const sockets: FakeAdminEventWebSocket[] = [];
+    const authFailures: number[] = [];
+    const fetchImpl = vi.fn(async () => new Response('expired', { status: 401 }));
+    const client = new AdminEventClient({
+      baseUrl: 'http://localhost:8080/admin/',
+      accessTokenProvider: () => 'expired-token',
+      fetchImpl,
+      onAuthenticationFailure: (error) => authFailures.push(error.status),
+      webSocketFactory: (url) => {
+        sockets.push(new FakeAdminEventWebSocket(url));
+        return sockets.at(-1)!;
+      },
+    });
+    const subscription = client.subscribe({ onEvent: () => undefined });
+    await flushMicrotasks();
+
+    sockets[0]?.networkError();
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('http://localhost:8080/api/v1/sessions'),
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          authorization: 'Bearer expired-token',
+        }),
+      }),
+    );
+    expect(authFailures).toEqual([401]);
+    subscription.close();
+  });
 });
 
 class FakeAdminEventWebSocket implements AdminEventWebSocket {
@@ -238,6 +272,10 @@ class FakeAdminEventWebSocket implements AdminEventWebSocket {
 
   serverClose(): void {
     this.onclose?.();
+  }
+
+  networkError(): void {
+    this.onerror?.();
   }
 
   message(payload: unknown): void {

--- a/code/web/bpane-admin/src/lib/api/admin-event-client.ts
+++ b/code/web/bpane-admin/src/lib/api/admin-event-client.ts
@@ -1,5 +1,10 @@
 import { AdminEventMapper, type AdminEvent } from './admin-event-mapper';
-import type { AccessTokenProvider } from './control-client';
+import {
+  sendAuthenticatedRequest,
+  type AccessTokenProvider,
+  type AuthenticationFailureHandler,
+  type FetchLike,
+} from './authenticated-api';
 
 export type AdminEventConnectionStatus = 'connecting' | 'open' | 'closed' | 'reconnecting';
 
@@ -16,6 +21,8 @@ export type AdminEventWebSocketFactory = (url: string) => AdminEventWebSocket;
 export type AdminEventClientOptions = {
   readonly baseUrl: string | URL;
   readonly accessTokenProvider: AccessTokenProvider;
+  readonly onAuthenticationFailure?: AuthenticationFailureHandler;
+  readonly fetchImpl?: FetchLike;
   readonly webSocketFactory?: AdminEventWebSocketFactory;
   readonly reconnectDelayMs?: number;
 };
@@ -33,12 +40,16 @@ export type AdminEventSubscription = {
 export class AdminEventClient {
   readonly #baseUrl: URL;
   readonly #accessTokenProvider: AccessTokenProvider;
+  readonly #onAuthenticationFailure: AuthenticationFailureHandler | undefined;
+  readonly #fetchImpl: FetchLike;
   readonly #webSocketFactory: AdminEventWebSocketFactory;
   readonly #reconnectDelayMs: number;
 
   constructor(options: AdminEventClientOptions) {
     this.#baseUrl = new URL(options.baseUrl);
     this.#accessTokenProvider = options.accessTokenProvider;
+    this.#onAuthenticationFailure = options.onAuthenticationFailure;
+    this.#fetchImpl = options.fetchImpl ?? fetch;
     this.#webSocketFactory = options.webSocketFactory ?? defaultWebSocketFactory;
     this.#reconnectDelayMs = options.reconnectDelayMs ?? 1_500;
   }
@@ -71,11 +82,23 @@ export class AdminEventClient {
         if (closed) {
           return;
         }
+        let opened = false;
         socket = this.#webSocketFactory(url);
-        socket.onopen = () => emitStatus('open');
+        socket.onopen = () => {
+          opened = true;
+          emitStatus('open');
+        };
         socket.onmessage = (event) => handleMessage(event.data, handlers, emitError);
-        socket.onerror = () => emitError(new Error('admin event stream websocket error'));
-        socket.onclose = () => scheduleReconnect();
+        socket.onerror = () => {
+          emitError(new Error('admin event stream websocket error'));
+          void this.#probeAuthentication();
+        };
+        socket.onclose = () => {
+          if (!closed && !opened) {
+            void this.#probeAuthentication();
+          }
+          scheduleReconnect();
+        };
       } catch (error) {
         emitError(error);
         scheduleReconnect();
@@ -93,6 +116,27 @@ export class AdminEventClient {
         emitStatus('closed');
       },
     };
+  }
+
+  async #probeAuthentication(): Promise<void> {
+    if (!this.#onAuthenticationFailure) {
+      return;
+    }
+    try {
+      const response = await sendAuthenticatedRequest({
+        baseUrl: this.#baseUrl,
+        accessTokenProvider: this.#accessTokenProvider,
+        fetchImpl: this.#fetchImpl,
+        onAuthenticationFailure: this.#onAuthenticationFailure,
+        method: 'GET',
+        path: '/api/v1/sessions',
+        accept: 'application/json',
+      });
+      await response.body?.cancel();
+    } catch {
+      // The stream error remains the user-visible symptom; the probe only exists
+      // to route HTTP 401s through the shared auth-failure handler.
+    }
   }
 }
 

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -15,6 +15,7 @@ import {
   expectNumber,
   expectRecord,
   expectString,
+  expectStringRecord,
   optionalString,
 } from './control-wire';
 
@@ -38,6 +39,8 @@ export class ControlSessionMapper {
       id: expectString(object.id, 'session resource id'),
       state: expectString(object.state, 'session resource state'),
       owner_mode: expectString(object.owner_mode, 'session resource owner_mode'),
+      idle_timeout_sec: optionalNumber(object.idle_timeout_sec, 'session resource idle_timeout_sec') ?? null,
+      labels: expectStringRecord(object.labels ?? {}, 'session resource labels'),
       ...(automationDelegate !== undefined ? { automation_delegate: automationDelegate } : {}),
       connect: toConnectInfo(object.connect),
       runtime: toRuntimeInfo(object.runtime),
@@ -58,6 +61,13 @@ export class ControlSessionMapper {
       connect: toConnectInfo(object.connect),
     };
   }
+}
+
+function optionalNumber(value: unknown, label: string): number | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return expectNumber(value, label);
 }
 
 function toConnectInfo(value: unknown): SessionConnectInfo {

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -48,6 +48,8 @@ export type SessionResource = {
   readonly id: string;
   readonly state: string;
   readonly owner_mode: string;
+  readonly idle_timeout_sec?: number | null;
+  readonly labels?: Readonly<Record<string, string>>;
   readonly automation_delegate?: SessionAutomationDelegate | null;
   readonly connect: SessionConnectInfo;
   readonly runtime: SessionRuntimeInfo;

--- a/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
@@ -6,6 +6,7 @@
     FileWorkspaceFileResource,
     FileWorkspaceResource,
   } from '../api/control-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
   import {
     FileWorkspaceViewModelBuilder,
     type FileWorkspaceFileViewModel,
@@ -31,10 +32,10 @@
   const fileRows = $derived(files.map((file) => FileWorkspaceViewModelBuilder.workspaceFile(file)));
 
   onMount(() => {
-    void loadDetail();
+    void loadDetail(false);
   });
 
-  async function loadDetail(): Promise<void> {
+  async function loadDetail(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
     actionMessage = null;
@@ -46,8 +47,12 @@
       workspace = nextWorkspace;
       files = nextFiles.files;
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionMessage = `Refreshed ${nextFiles.files.length} workspace file${nextFiles.files.length === 1 ? '' : 's'}.`;
+      }
     } catch (loadError) {
       error = errorMessage(loadError, 'Unexpected file workspace detail error');
+      actionMessage = null;
     } finally {
       loading = false;
     }
@@ -55,13 +60,13 @@
 
   async function uploadFile(): Promise<void> {
     const selectedFile = fileInput?.files?.[0];
+    actionMessage = null;
     if (!selectedFile) {
       error = 'Choose a file before uploading.';
       return;
     }
     uploading = true;
     error = null;
-    actionMessage = null;
     try {
       const uploaded = await controlClient.uploadFileWorkspaceFile(workspaceId, {
         fileName: selectedFile.name,
@@ -91,9 +96,11 @@
     }
     downloadingFileId = fileId;
     error = null;
+    actionMessage = null;
     try {
       const blob = await controlClient.downloadFileWorkspaceFileContent(file);
       triggerDownload(blob, file.name);
+      actionMessage = `Download started for ${file.name}.`;
     } catch (downloadError) {
       error = errorMessage(downloadError, 'Unexpected workspace file download error');
     } finally {
@@ -173,11 +180,11 @@
 
   {#if loading && !workspace}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading file workspace...</p>
+      <AdminMessage variant="loading" message="Loading file workspace..." compact={true} />
     </section>
   {:else if error && !workspace}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="file-workspace-detail-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="file-workspace-detail-error" compact={true} />
     </section>
   {:else}
     {#if workspace}
@@ -227,10 +234,10 @@
     </section>
 
     {#if error}
-      <p class="admin-error" data-testid="file-workspace-action-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="file-workspace-action-error" compact={true} />
     {/if}
     {#if actionMessage}
-      <p class="m-0 text-sm font-bold text-admin-leaf" data-testid="file-workspace-action-message">{actionMessage}</p>
+      <AdminMessage variant="success" message={actionMessage} testId="file-workspace-action-message" compact={true} />
     {/if}
 
     <section class="admin-panel mt-0 grid gap-3">
@@ -241,7 +248,12 @@
         </div>
       </div>
       {#if fileRows.length === 0}
-        <p class="admin-empty mt-0" data-testid="file-workspace-files-empty">No files have been uploaded to this workspace yet.</p>
+        <AdminMessage
+          variant="empty"
+          message="No files have been uploaded to this workspace yet."
+          testId="file-workspace-files-empty"
+          compact={true}
+        />
       {:else}
         <div class="grid gap-3">
           {#each fileRows as file}

--- a/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceDetailRoute.svelte
@@ -36,6 +36,7 @@
   });
 
   async function loadDetail(showFeedback = true): Promise<void> {
+    const previousFileCount = files.length;
     loading = true;
     error = null;
     actionMessage = null;
@@ -48,7 +49,9 @@
       files = nextFiles.files;
       lastRefreshedAt = new Date().toISOString();
       if (showFeedback) {
-        actionMessage = `Refreshed ${nextFiles.files.length} workspace file${nextFiles.files.length === 1 ? '' : 's'}.`;
+        actionMessage = previousFileCount !== nextFiles.files.length
+          ? `Workspace file count changed from ${previousFileCount} to ${nextFiles.files.length}.`
+          : `Refreshed ${nextFiles.files.length} workspace file${nextFiles.files.length === 1 ? '' : 's'}.`;
       }
     } catch (loadError) {
       error = errorMessage(loadError, 'Unexpected file workspace detail error');

--- a/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminFileWorkspaceListRoute.svelte
@@ -4,6 +4,8 @@
   import { onMount } from 'svelte';
   import type { ControlClient } from '../api/control-client';
   import type { FileWorkspaceResource } from '../api/control-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import { FileWorkspaceViewModelBuilder } from '../presentation/file-workspace-view-model';
 
   type AdminFileWorkspaceListRouteProps = {
@@ -16,6 +18,7 @@
   let loading = $state(false);
   let creating = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let search = $state('');
   let name = $state('');
   let description = $state('');
@@ -25,19 +28,24 @@
   const viewModel = $derived(FileWorkspaceViewModelBuilder.list({ workspaces, search }));
 
   onMount(() => {
-    void loadWorkspaces();
+    void loadWorkspaces(false);
   });
 
-  async function loadWorkspaces(): Promise<void> {
+  async function loadWorkspaces(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
       const response = await controlClient.listFileWorkspaces();
       workspaces = response.workspaces;
       lastRefreshedAt = new Date().toISOString();
       void loadFileCounts(response.workspaces);
+      if (showFeedback) {
+        actionFeedback = successFeedback(`${response.workspaces.length} workspace${response.workspaces.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (loadError) {
       error = errorMessage(loadError, 'Unexpected file workspace list error');
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -56,6 +64,7 @@
 
   async function createWorkspace(): Promise<void> {
     const trimmedName = name.trim();
+    actionFeedback = null;
     if (!trimmedName) {
       error = 'Workspace name is required.';
       return;
@@ -116,6 +125,10 @@
 
   function errorMessage(value: unknown, fallback: string): string {
     return value instanceof Error ? value.message : fallback;
+  }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'File workspaces refreshed', message, testId: 'file-workspace-list-message' };
   }
 </script>
 
@@ -209,17 +222,32 @@
     </form>
   </section>
 
+  {#if actionFeedback}
+    <AdminMessage
+      variant={actionFeedback.variant}
+      title={actionFeedback.title}
+      message={actionFeedback.message}
+      testId={actionFeedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if error}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="file-workspace-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="file-workspace-error" compact={true} />
     </section>
   {:else if loading && workspaces.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading file workspaces...</p>
+      <AdminMessage variant="loading" message="Loading file workspaces..." compact={true} />
     </section>
   {:else if viewModel.rows.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0" data-testid="file-workspace-empty">{viewModel.emptyMessage}</p>
+      <AdminMessage
+        variant="empty"
+        message={viewModel.emptyMessage}
+        testId="file-workspace-empty"
+        compact={true}
+      />
     </section>
   {:else}
     <section class="grid gap-2" aria-label="File workspace table">

--- a/code/web/bpane-admin/src/lib/application/AdminRouteShell.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminRouteShell.svelte
@@ -8,6 +8,7 @@
   import { OidcAuthClient } from '../auth/oidc-auth-client';
   import type { AuthSnapshot } from '../auth/oidc-types';
   import AdminHeader from '../presentation/AdminHeader.svelte';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
   import type { AdminRouteContext } from './admin-route-context';
 
   type AdminRouteShellProps = {
@@ -121,6 +122,7 @@
     adminEventClient = new AdminEventClient({
       baseUrl: window.location.origin,
       accessTokenProvider: requireAccessToken,
+      onAuthenticationFailure: handleAuthenticationIssue,
     });
     workflowClient = new WorkflowClient({
       baseUrl: window.location.origin,
@@ -183,7 +185,7 @@
 <main class={contentClass}>
   {#if authError && !auth?.authenticated}
     <section class="admin-panel">
-      <p class="admin-error mt-0">{authError}</p>
+      <AdminMessage variant="error" message={authError} compact={true} />
     </section>
   {/if}
 

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -9,6 +9,8 @@
   } from '../api/control-types';
   import type { SessionRecordingPlaybackResource, SessionRecordingResource } from '../api/recording-types';
   import type { SessionStatus } from '../api/session-status-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import SessionDetailPanel from '../presentation/SessionDetailPanel.svelte';
   import { SessionViewModelBuilder } from '../presentation/session-view-model';
   import SessionFileBindingsSurface from './SessionFileBindingsSurface.svelte';
@@ -28,6 +30,7 @@
   let loading = $state(false);
   let error = $state<string | null>(null);
   let relatedError = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let lastRefreshedAt = $state<string | null>(null);
 
   const viewModel = $derived(SessionViewModelBuilder.detail({
@@ -39,13 +42,14 @@
   }));
 
   onMount(() => {
-    void refreshInspector();
+    void refreshInspector(false);
   });
 
-  async function refreshInspector(): Promise<void> {
+  async function refreshInspector(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
     relatedError = null;
+    actionFeedback = null;
     try {
       const [nextSession, nextStatus] = await Promise.all([
         controlClient.getSession(sessionId),
@@ -55,8 +59,12 @@
       status = nextStatus;
       await loadRelatedResources();
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionFeedback = lifecycleFeedback('success', 'Session refreshed', 'Session detail refreshed.');
+      }
     } catch (refreshError) {
       error = errorMessage(refreshError, 'Unexpected session detail error');
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -98,45 +106,75 @@
   }
 
   async function stopSession(): Promise<void> {
-    await mutateSession(() => controlClient.stopSession(sessionId));
+    await mutateSession(
+      'Stopping selected session...',
+      'Selected session stopped.',
+      () => controlClient.stopSession(sessionId),
+    );
   }
 
   async function killSession(): Promise<void> {
-    await mutateSession(() => controlClient.killSession(sessionId));
+    await mutateSession(
+      'Killing selected session...',
+      'Selected session was force killed.',
+      () => controlClient.killSession(sessionId),
+    );
   }
 
   async function disconnectConnection(connectionId: number): Promise<void> {
-    await mutateStatus(() => controlClient.disconnectSessionConnection(sessionId, connectionId));
+    await mutateStatus(
+      `Disconnecting client #${connectionId}...`,
+      `Disconnected client #${connectionId}.`,
+      () => controlClient.disconnectSessionConnection(sessionId, connectionId),
+    );
   }
 
   async function disconnectAllConnections(): Promise<void> {
-    await mutateStatus(() => controlClient.disconnectAllSessionConnections(sessionId));
+    await mutateStatus(
+      'Disconnecting all live clients...',
+      'Disconnected all live clients.',
+      () => controlClient.disconnectAllSessionConnections(sessionId),
+    );
   }
 
-  async function mutateSession(action: () => Promise<SessionResource>): Promise<void> {
+  async function mutateSession(
+    progressMessage: string,
+    successMessage: string,
+    action: () => Promise<SessionResource>,
+  ): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = lifecycleFeedback('loading', 'Lifecycle operation', progressMessage);
     try {
       session = await action();
       status = await controlClient.getSessionStatus(sessionId);
       await loadRelatedResources();
       lastRefreshedAt = new Date().toISOString();
+      actionFeedback = lifecycleFeedback('success', 'Lifecycle updated', successMessage);
     } catch (mutationError) {
       error = errorMessage(mutationError, 'Unexpected session action error');
+      actionFeedback = null;
     } finally {
       loading = false;
     }
   }
 
-  async function mutateStatus(action: () => Promise<SessionStatus>): Promise<void> {
+  async function mutateStatus(
+    progressMessage: string,
+    successMessage: string,
+    action: () => Promise<SessionStatus>,
+  ): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = lifecycleFeedback('loading', 'Connection operation', progressMessage);
     try {
       status = await action();
       session = await controlClient.getSession(sessionId);
       lastRefreshedAt = new Date().toISOString();
+      actionFeedback = lifecycleFeedback('success', 'Connections updated', successMessage);
     } catch (mutationError) {
       error = errorMessage(mutationError, 'Unexpected connection action error');
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -164,6 +202,14 @@
       return `${(value / 1024).toFixed(1)} KiB`;
     }
     return `${(value / 1024 / 1024).toFixed(1)} MiB`;
+  }
+
+  function lifecycleFeedback(
+    variant: AdminMessageFeedback['variant'],
+    title: string,
+    message: string,
+  ): AdminMessageFeedback {
+    return { variant, title, message, testId: 'session-detail-action-message' };
   }
 
   const readyRecordingCount = $derived(recordings.filter((entry) => entry.state === 'ready').length);
@@ -203,16 +249,17 @@
 
   {#if loading && !session}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading session...</p>
+      <AdminMessage variant="loading" message="Loading session..." compact={true} />
     </section>
   {:else if error && !session}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="session-inspector-detail-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="session-inspector-detail-error" compact={true} />
     </section>
   {:else}
     <section class="admin-panel mt-0">
       <SessionDetailPanel
         {viewModel}
+        feedback={actionFeedback}
         onRefresh={() => void refreshInspector()}
         onStop={() => void stopSession()}
         onKill={() => void killSession()}
@@ -260,7 +307,7 @@
     </section>
 
     {#if relatedError}
-      <p class="admin-error" data-testid="session-inspector-related-error">{relatedError}</p>
+      <AdminMessage variant="error" message={relatedError} testId="session-inspector-related-error" compact={true} />
     {/if}
 
     <SessionFileBindingsSurface

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -46,6 +46,7 @@
   });
 
   async function refreshInspector(showFeedback = true): Promise<void> {
+    const previousState = session?.state ?? null;
     loading = true;
     error = null;
     relatedError = null;
@@ -60,7 +61,13 @@
       await loadRelatedResources();
       lastRefreshedAt = new Date().toISOString();
       if (showFeedback) {
-        actionFeedback = lifecycleFeedback('success', 'Session refreshed', 'Session detail refreshed.');
+        actionFeedback = lifecycleFeedback(
+          'success',
+          'Session refreshed',
+          previousState && previousState !== nextSession.state
+            ? `Session state changed from ${previousState} to ${nextSession.state}.`
+            : 'Session detail refreshed.',
+        );
       }
     } catch (refreshError) {
       error = errorMessage(refreshError, 'Unexpected session detail error');

--- a/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
@@ -3,7 +3,10 @@
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import type { ControlClient } from '../api/control-client';
-  import type { SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
+  import SessionCreateConfigurator from '../presentation/SessionCreateConfigurator.svelte';
   import { SessionViewModelBuilder, type SessionListItemViewModel } from '../presentation/session-view-model';
 
   type AdminSessionListRouteProps = {
@@ -14,6 +17,7 @@
   let sessions = $state<readonly SessionResource[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let search = $state('');
 
   const viewModel = $derived(SessionViewModelBuilder.list({
@@ -26,26 +30,32 @@
   const filteredSessions = $derived(filterSessions(viewModel.sessions, search));
 
   onMount(() => {
-    void loadSessions();
+    void loadSessions(false);
   });
 
-  async function loadSessions(): Promise<void> {
+  async function loadSessions(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
       sessions = (await controlClient.listSessions()).sessions;
+      if (showFeedback) {
+        actionFeedback = successFeedback(`${sessions.length} session${sessions.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (loadError) {
       error = errorMessage(loadError);
+      actionFeedback = null;
     } finally {
       loading = false;
     }
   }
 
-  async function createSession(): Promise<void> {
+  async function createSession(command: CreateSessionCommand): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
-      const created = await controlClient.createSession();
+      const created = await controlClient.createSession(command);
       sessions = [created, ...sessions.filter((session) => session.id !== created.id)];
       await goto(detailHref(created.id));
     } catch (createError) {
@@ -74,6 +84,7 @@
       session.runtime,
       session.presence,
       session.mcpDelegation,
+      session.labels,
     ].some((value) => value.toLowerCase().includes(normalized)));
   }
 
@@ -83,6 +94,10 @@
 
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected session list error';
+  }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Sessions refreshed', message, testId: 'session-inspector-list-message' };
   }
 </script>
 
@@ -96,15 +111,6 @@
       <div class="admin-actions">
         <a class="admin-button-ghost" href={`${base}/`}>Live workspace</a>
         <a class="admin-button-ghost" href={`${base}/files/workspaces`}>File workspaces</a>
-        <button
-          class="admin-button-primary"
-          type="button"
-          data-testid="session-inspector-new"
-          disabled={loading}
-          onclick={() => void createSession()}
-        >
-          New session
-        </button>
         <button
           class="admin-button-primary"
           type="button"
@@ -132,19 +138,41 @@
     </div>
   </div>
 
+  <SessionCreateConfigurator
+    loading={loading}
+    submitTestId="session-inspector-new"
+    submitLabel="Create and inspect"
+    variant="panel"
+    payloadInitiallyOpen={true}
+    onCreateSession={(command) => void createSession(command)}
+  />
+
+  {#if actionFeedback}
+    <AdminMessage
+      variant={actionFeedback.variant}
+      title={actionFeedback.title}
+      message={actionFeedback.message}
+      testId={actionFeedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if loading && sessions.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading sessions...</p>
+      <AdminMessage variant="loading" message="Loading sessions..." compact={true} />
     </section>
   {:else if error}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="session-inspector-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="session-inspector-error" compact={true} />
     </section>
   {:else if filteredSessions.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0" data-testid="session-inspector-empty">
-        No sessions match the current filter.
-      </p>
+      <AdminMessage
+        variant="empty"
+        message="No sessions match the current filter."
+        testId="session-inspector-empty"
+        compact={true}
+      />
     </section>
   {:else}
     <section class="grid gap-2" aria-label="Session table">
@@ -158,7 +186,7 @@
           <span class="grid min-w-0 gap-1">
             <strong class="truncate font-mono text-sm" title={session.id}>{session.id}</strong>
             <span class="truncate text-xs text-admin-ink/58">
-              {session.mcpDelegation} | updated {session.updatedAt}
+              {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
             </span>
           </span>
           <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { AdminEventClient } from '../api/admin-event-client';
+  import type { AdminEventClient, AdminEventConnectionStatus } from '../api/admin-event-client';
+  import type {
+    AdminMcpDelegationSnapshot,
+    AdminRecordingsSnapshot,
+    AdminSessionFilesSnapshot,
+    AdminWorkflowRunSnapshot,
+  } from '../api/admin-event-snapshots';
   import type { ControlClient } from '../api/control-client';
-  import type { SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { McpBridgeConfig } from '../auth/auth-config';
   import BrowserEmbedPanel from '../presentation/BrowserEmbedPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import type { AdminLogEntry } from '../presentation/logs-view-model';
   import { AdminWorkspaceViewModelBuilder } from '../presentation/admin-workspace-view-model';
   import { SessionViewModelBuilder } from '../presentation/session-view-model';
@@ -14,6 +21,17 @@
   import AdminWorkspaceTabs from './AdminWorkspaceTabs.svelte';
   import { AdminLogEntryFactory } from './admin-log-entries';
   import { AdminSessionSelection } from './admin-session-selection';
+  import {
+    eventStreamStatusMessage,
+    globalAdminMessage,
+    mcpDelegationSnapshotMessage,
+    recordingsSnapshotMessage,
+    selectedSessionDiffMessage,
+    sessionFilesSnapshotMessage,
+    shortAdminId,
+    workflowFollowMessage,
+    workflowRunsSnapshotMessage,
+  } from './admin-feedback-notifications';
   import { subscribeAdminSessionEvents } from './admin-session-event-sync';
   import { AdminWorkflowSessionFollower } from './admin-workflow-follow';
   import BrowserWorkspaceOverlayLayout from './BrowserWorkspaceOverlayLayout.svelte';
@@ -30,6 +48,7 @@
   let selectedSession = $state<SessionResource | null>(null);
   let sessionsLoading = $state(false);
   let sessionsError = $state<string | null>(null);
+  let globalMessage = $state<AdminMessageFeedback | null>(null);
   let pendingSelectedSessionId = $state<string | null>(null);
   let browserConnecting = $state(false);
   let browserError = $state<string | null>(null);
@@ -42,11 +61,21 @@
   let logEntries = $state<readonly AdminLogEntry[]>([]);
   let lastLogSignature = $state('');
   let browserPreferences = $state<BrowserSessionConnectPreferences>({ ...DEFAULT_BROWSER_SESSION_CONNECT_PREFERENCES });
+  let sessionSnapshotSeen = false;
+  let eventStreamStatus: AdminEventConnectionStatus | null = null;
+  let sessionFileCounts: ReadonlyMap<string, number> = new Map();
+  let recordingSnapshots: ReadonlyMap<string, AdminRecordingsSnapshot> = new Map();
+  let mcpSnapshots: ReadonlyMap<string, AdminMcpDelegationSnapshot> = new Map();
+  let workflowRunStates: ReadonlyMap<string, string> = new Map();
   const browserConnected = $derived(Boolean(liveConnection && liveConnection.sessionId === selectedSession?.id));
   const workflowFollower = $derived(new AdminWorkflowSessionFollower({
     controlClient, getSessions: () => sessions, getConnectedSessionId: () => liveConnection?.sessionId ?? null,
     upsertSession, requestBrowserConnect,
-    onError: (message) => { sessionsError = message; },
+    onFollow: notifyWorkflowFollow,
+    onError: (message) => {
+      sessionsError = message;
+      showGlobalMessage('error', 'Workflow follow failed', message);
+    },
   }));
   const workspaceViewModel = $derived(AdminWorkspaceViewModelBuilder.build({
     browserStatus, selectedSessionId: selectedSession?.id ?? null,
@@ -65,37 +94,54 @@
   });
   onMount(() => {
     const subscription = subscribeAdminSessionEvents(adminEventClient, {
-      onSessions: setSessionList,
+      onSessions: (next) => setSessionList(next, 'event'),
       onLoadingChange: (loading) => { sessionsLoading = loading; },
-      onError: (error) => { sessionsError = error; },
+      onError: (error) => {
+        sessionsError = error;
+        if (error) {
+          showGlobalMessage('error', 'Admin event stream', error);
+        }
+      },
       onLog: appendLog,
-      onSessionFilesSnapshot: () => { sessionFilesRefreshVersion += 1; },
-      onRecordingsSnapshot: () => { recordingsRefreshVersion += 1; },
-      onMcpDelegationSnapshot: () => { mcpDelegationRefreshVersion += 1; },
-      onWorkflowRunsSnapshot: (runs) => void workflowFollower.followRuns(runs),
+      onConnectionStatus: handleEventStreamStatus,
+      onSessionFilesSnapshot: handleSessionFilesSnapshot,
+      onRecordingsSnapshot: handleRecordingsSnapshot,
+      onMcpDelegationSnapshot: handleMcpDelegationSnapshot,
+      onWorkflowRunsSnapshot: (runs) => {
+        handleWorkflowRunsSnapshot(runs);
+        void workflowFollower.followRuns(runs);
+      },
     });
     void loadSessions();
     return () => { subscription.close(); disconnectBrowser(false); };
   });
-  async function loadSessions(): Promise<void> {
+  async function loadSessions(showFeedback = false): Promise<void> {
     sessionsLoading = true;
     sessionsError = null;
     try {
-      setSessionList((await controlClient.listSessions()).sessions);
+      const nextSessions = (await controlClient.listSessions()).sessions;
+      setSessionList(nextSessions, 'manual');
+      if (showFeedback) {
+        showGlobalMessage('success', 'Sessions refreshed', `${nextSessions.length} session${nextSessions.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (error) {
       sessionsError = errorMessage(error);
+      if (showFeedback) {
+        showGlobalMessage('error', 'Session refresh failed', sessionsError);
+      }
     } finally {
       sessionsLoading = false;
     }
   }
-  async function createSession(): Promise<void> {
+  async function createSession(command: CreateSessionCommand = {}): Promise<void> {
     sessionsLoading = true;
     sessionsError = null;
     try {
-      const created = await controlClient.createSession();
+      const created = await controlClient.createSession(command);
       pendingSelectedSessionId = created.id;
       upsertSession(created);
-      setSessionList((await controlClient.listSessions()).sessions);
+      setSessionList((await controlClient.listSessions()).sessions, 'local');
+      showGlobalMessage('success', 'Session created', `Created session ${shortAdminId(created.id)}.`);
       requestBrowserConnect();
     } catch (error) {
       sessionsError = errorMessage(error);
@@ -121,6 +167,7 @@
       upsertSession(updated);
     } catch (error) {
       sessionsError = errorMessage(error);
+      throw error;
     } finally {
       sessionsLoading = false;
     }
@@ -131,31 +178,47 @@
     browserConnecting = true;
     browserError = null;
     browserStatus = `Connecting to ${selectedSession.id}`;
+    showGlobalMessage('loading', 'Browser connection', `Connecting to session ${shortAdminId(selectedSession.id)}...`);
     try {
       liveConnection = await browserConnector.connect(selectedSession, container, browserPreferences);
       browserStatus = `Connected to ${selectedSession.id}`;
+      showGlobalMessage('success', 'Browser connected', `Connected to session ${shortAdminId(selectedSession.id)}.`);
       await refreshSelectedSession();
     } catch (error) {
       browserError = errorMessage(error);
       browserStatus = 'Connection failed';
+      showGlobalMessage('error', 'Browser connection failed', browserError);
     } finally {
       browserConnecting = false;
     }
   }
   function disconnectBrowser(refreshAfterDisconnect = false): void {
     const hadLiveConnection = Boolean(liveConnection);
+    const disconnectedSessionId = liveConnection?.sessionId ?? null;
     liveConnection?.handle.disconnect();
     liveConnection = null;
     browserStatus = 'Disconnected';
+    if (hadLiveConnection) {
+      showGlobalMessage(
+        'info',
+        'Browser disconnected',
+        disconnectedSessionId ? `Disconnected from session ${shortAdminId(disconnectedSessionId)}.` : 'Browser disconnected.',
+      );
+    }
     if (hadLiveConnection && refreshAfterDisconnect) {
       window.setTimeout(() => void refreshSelectedSession(), 250);
     }
   }
-  function setSessionList(next: readonly SessionResource[]): void {
+  function setSessionList(next: readonly SessionResource[], source: 'event' | 'manual' | 'local' = 'manual'): void {
+    const previousSelected = selectedSession;
     sessions = next;
     const selection = AdminSessionSelection.afterList({ sessions, selectedSession, pendingSelectedSessionId });
     selectedSession = selection.selectedSession;
     pendingSelectedSessionId = selection.pendingSelectedSessionId;
+    if (source === 'event') {
+      notifySelectedSessionDiff(previousSelected, selectedSession);
+      sessionSnapshotSeen = true;
+    }
   }
   function upsertSession(session: SessionResource): void {
     selectedSession = session;
@@ -166,9 +229,59 @@
   function selectSession(sessionId: string): void {
     pendingSelectedSessionId = null;
     selectedSession = sessions.find((session) => session.id === sessionId) ?? selectedSession;
+    showGlobalMessage('info', 'Session selected', `Selected session ${shortAdminId(selectedSession?.id ?? sessionId)}.`);
   }
   function requestBrowserConnect(): void { browserConnectRequestVersion += 1; }
   function appendLog(entry: AdminLogEntry): void { logEntries = AdminLogEntryFactory.append(logEntries, entry); }
+  function handleEventStreamStatus(status: AdminEventConnectionStatus): void {
+    const message = eventStreamStatusMessage(eventStreamStatus, status);
+    eventStreamStatus = status;
+    showGlobalNotification(message);
+  }
+  function handleSessionFilesSnapshot(snapshot: readonly AdminSessionFilesSnapshot[]): void {
+    sessionFilesRefreshVersion += 1;
+    const result = sessionFilesSnapshotMessage(selectedSession?.id ?? null, snapshot, sessionFileCounts);
+    sessionFileCounts = result.counts;
+    showGlobalNotification(result.message);
+  }
+  function handleRecordingsSnapshot(snapshot: readonly AdminRecordingsSnapshot[]): void {
+    recordingsRefreshVersion += 1;
+    const result = recordingsSnapshotMessage(selectedSession?.id ?? null, snapshot, recordingSnapshots);
+    recordingSnapshots = result.snapshots;
+    showGlobalNotification(result.message);
+  }
+  function handleMcpDelegationSnapshot(snapshot: readonly AdminMcpDelegationSnapshot[]): void {
+    mcpDelegationRefreshVersion += 1;
+    const result = mcpDelegationSnapshotMessage(selectedSession?.id ?? null, snapshot, mcpSnapshots);
+    mcpSnapshots = result.snapshots;
+    showGlobalNotification(result.message);
+  }
+  function handleWorkflowRunsSnapshot(runs: readonly AdminWorkflowRunSnapshot[]): void {
+    const result = workflowRunsSnapshotMessage(selectedSession?.id ?? null, runs, workflowRunStates);
+    workflowRunStates = result.states;
+    showGlobalNotification(result.message);
+  }
+  function notifyWorkflowFollow(run: AdminWorkflowRunSnapshot): void {
+    showGlobalNotification(workflowFollowMessage(run));
+  }
+  function notifySelectedSessionDiff(previous: SessionResource | null, current: SessionResource | null): void {
+    showGlobalNotification(selectedSessionDiffMessage(previous, current, sessionSnapshotSeen));
+  }
+  function showGlobalMessage(
+    variant: AdminMessageFeedback['variant'],
+    title: string,
+    message: string,
+  ): void {
+    globalMessage = globalAdminMessage(variant, title, message);
+  }
+  function showGlobalNotification(message: AdminMessageFeedback | null): void {
+    if (message) {
+      globalMessage = message;
+    }
+  }
+  function dismissGlobalMessage(): void {
+    globalMessage = null;
+  }
   function errorMessage(error: unknown): string { return error instanceof Error ? error.message : 'Unexpected admin console error'; }
 </script>
 <section class="relative h-[calc(100dvh-96px)] min-h-[520px]">
@@ -184,14 +297,15 @@
     {#snippet admin()}
     <AdminWorkspaceTabs
       {controlClient} {workflowClient} {selectedSession} {mcpBridge} {liveConnection}
-      {browserPreferences} {browserConnected} {workspaceViewModel} {sessionListViewModel} {logEntries}
+      {browserPreferences} {browserConnected} {workspaceViewModel} {sessionListViewModel} {logEntries} {globalMessage}
       {sessionFilesRefreshVersion} {recordingsRefreshVersion} {mcpDelegationRefreshVersion} onRefreshSessions={loadSessions}
-      onCreateSession={() => void createSession()} onJoinSelectedSession={requestBrowserConnect}
+      onCreateSession={(command) => void createSession(command)} onJoinSelectedSession={requestBrowserConnect}
       onSelectSessionId={selectSession} onRefreshSelectedSession={refreshSelectedSession}
-      onStopSession={() => void runLifecycle('stop')} onKillSession={() => void runLifecycle('kill')} onDisconnectEmbeddedBrowser={() => disconnectBrowser(false)}
+      onStopSession={() => runLifecycle('stop')} onKillSession={() => runLifecycle('kill')} onDisconnectEmbeddedBrowser={() => disconnectBrowser(false)}
       onFileCountChange={(count) => { sessionFileCount = count; }}
       onClearLogs={() => { logEntries = []; }}
       onBrowserPreferencesChange={(next) => { browserPreferences = next; }}
+      onDismissGlobalMessage={dismissGlobalMessage}
     />
     {/snippet}
   </BrowserWorkspaceOverlayLayout>

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -145,16 +145,32 @@
       requestBrowserConnect();
     } catch (error) {
       sessionsError = errorMessage(error);
+      showGlobalMessage('error', 'Session create failed', sessionsError);
     } finally {
       sessionsLoading = false;
     }
   }
-  async function refreshSelectedSession(): Promise<void> {
+  async function refreshSelectedSession(options: { readonly showGlobalError?: boolean } = {}): Promise<void> {
     if (!selectedSession) return;
     sessionsLoading = true;
+    sessionsError = null;
     try { upsertSession(await controlClient.getSession(selectedSession.id)); }
-    catch (error) { sessionsError = errorMessage(error); }
+    catch (error) {
+      sessionsError = errorMessage(error);
+      if (options.showGlobalError) {
+        showGlobalMessage('warning', 'Session refresh failed', sessionsError);
+      }
+      throw error;
+    }
     finally { sessionsLoading = false; }
+  }
+  async function refreshSelectedSessionInBackground(): Promise<void> {
+    try {
+      await refreshSelectedSession({ showGlobalError: true });
+    } catch {
+      // The foreground action already succeeded; keep its state instead of
+      // turning a follow-up refresh failure into a failed action.
+    }
   }
   async function runLifecycle(action: 'stop' | 'kill'): Promise<void> {
     if (!selectedSession) return;
@@ -183,7 +199,7 @@
       liveConnection = await browserConnector.connect(selectedSession, container, browserPreferences);
       browserStatus = `Connected to ${selectedSession.id}`;
       showGlobalMessage('success', 'Browser connected', `Connected to session ${shortAdminId(selectedSession.id)}.`);
-      await refreshSelectedSession();
+      void refreshSelectedSessionInBackground();
     } catch (error) {
       browserError = errorMessage(error);
       browserStatus = 'Connection failed';
@@ -206,7 +222,7 @@
       );
     }
     if (hadLiveConnection && refreshAfterDisconnect) {
-      window.setTimeout(() => void refreshSelectedSession(), 250);
+      window.setTimeout(() => void refreshSelectedSessionInBackground(), 250);
     }
   }
   function setSessionList(next: readonly SessionResource[], source: 'event' | 'manual' | 'local' = 'manual'): void {

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowCatalogRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowCatalogRoute.svelte
@@ -15,6 +15,8 @@
     WorkflowTemplateCatalogViewModelBuilder,
     type WorkflowCatalogItem,
   } from '../presentation/workflow-template-catalog-view-model';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import { WorkflowOperationsService } from './workflow-operations-service';
 
   type AdminWorkflowCatalogRouteProps = {
@@ -27,6 +29,7 @@
   let hiddenCount = $state(0);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let search = $state('');
   let lastRefreshedAt = $state<string | null>(null);
 
@@ -37,12 +40,13 @@
   }));
 
   onMount(() => {
-    void loadCatalog();
+    void loadCatalog(false);
   });
 
-  async function loadCatalog(): Promise<void> {
+  async function loadCatalog(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
       const definitions = (await workflowClient.listDefinitions()).workflows;
       const withTemplate = await workflowService.ensureBrowserPaneTourTemplate(definitions);
@@ -52,8 +56,12 @@
       hiddenCount = includeHiddenWorkflowDefinitions() ? 0 : hiddenWorkflowDefinitions(withTemplate).length;
       items = await loadCatalogItems(visible);
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionFeedback = successFeedback(`${items.length} workflow template${items.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (loadError) {
       error = errorMessage(loadError);
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -96,6 +104,10 @@
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected workflow catalog error';
   }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Workflow catalog refreshed', message, testId: 'workflow-catalog-message' };
+  }
 </script>
 
 <section class="grid gap-5" data-testid="workflow-catalog">
@@ -137,17 +149,32 @@
     </div>
   </div>
 
+  {#if actionFeedback}
+    <AdminMessage
+      variant={actionFeedback.variant}
+      title={actionFeedback.title}
+      message={actionFeedback.message}
+      testId={actionFeedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if loading && items.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading workflow templates...</p>
+      <AdminMessage variant="loading" message="Loading workflow templates..." compact={true} />
     </section>
   {:else if error}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="workflow-catalog-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-catalog-error" compact={true} />
     </section>
   {:else if viewModel.rows.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0" data-testid="workflow-catalog-empty">{viewModel.emptyMessage}</p>
+      <AdminMessage
+        variant="empty"
+        message={viewModel.emptyMessage}
+        testId="workflow-catalog-empty"
+        compact={true}
+      />
     </section>
   {:else}
     <section class="grid gap-2" aria-label="Workflow catalog table">

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
@@ -43,6 +43,8 @@
   });
 
   async function loadDetail(showFeedback = true): Promise<void> {
+    const previousLatestVersion = definition?.latest_version ?? null;
+    const previousRunCount = runs.length;
     loading = true;
     error = null;
     actionFeedback = null;
@@ -58,7 +60,12 @@
       selectedVersion = selectedVersionFor(definitionResource, versionList.versions, selectedVersion);
       lastRefreshedAt = new Date().toISOString();
       if (showFeedback) {
-        actionFeedback = successFeedback('Workflow template detail refreshed.');
+        actionFeedback = successFeedback(refreshMessage(
+          previousLatestVersion,
+          definitionResource.latest_version,
+          previousRunCount,
+          runList.runs.length,
+        ));
       }
     } catch (loadError) {
       error = errorMessage(loadError);
@@ -92,6 +99,21 @@
 
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected workflow definition detail error';
+  }
+
+  function refreshMessage(
+    previousLatestVersion: string | null,
+    nextLatestVersion: string | null,
+    previousRunCount: number,
+    nextRunCount: number,
+  ): string {
+    if (previousLatestVersion && previousLatestVersion !== nextLatestVersion) {
+      return `Latest workflow version changed from ${previousLatestVersion} to ${nextLatestVersion ?? 'none'}.`;
+    }
+    if (previousRunCount !== nextRunCount) {
+      return `Workflow run count changed from ${previousRunCount} to ${nextRunCount}.`;
+    }
+    return 'Workflow template detail refreshed.';
   }
 
   function successFeedback(message: string): AdminMessageFeedback {

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowDefinitionDetailRoute.svelte
@@ -7,6 +7,8 @@
     WorkflowDefinitionVersionResource,
     WorkflowRunResource,
   } from '../api/workflow-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import {
     WorkflowTemplateCatalogViewModelBuilder,
     type MetadataRow,
@@ -24,6 +26,7 @@
   let selectedVersion = $state('');
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let lastRefreshedAt = $state<string | null>(null);
 
   const viewModel = $derived(definition
@@ -36,12 +39,13 @@
     : null);
 
   onMount(() => {
-    void loadDetail();
+    void loadDetail(false);
   });
 
-  async function loadDetail(): Promise<void> {
+  async function loadDetail(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
       const [definitionResource, versionList, runList] = await Promise.all([
         workflowClient.getDefinition(workflowId),
@@ -53,8 +57,12 @@
       runs = runList.runs;
       selectedVersion = selectedVersionFor(definitionResource, versionList.versions, selectedVersion);
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionFeedback = successFeedback('Workflow template detail refreshed.');
+      }
     } catch (loadError) {
       error = errorMessage(loadError);
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -84,6 +92,10 @@
 
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected workflow definition detail error';
+  }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Workflow template refreshed', message, testId: 'workflow-definition-detail-message' };
   }
 </script>
 
@@ -122,15 +134,24 @@
 
   {#if loading && !viewModel}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading workflow template...</p>
+      <AdminMessage variant="loading" message="Loading workflow template..." compact={true} />
     </section>
   {:else if error && !viewModel}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="workflow-definition-detail-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-definition-detail-error" compact={true} />
     </section>
   {:else if viewModel}
     {#if error}
-      <p class="admin-error" data-testid="workflow-definition-detail-action-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-definition-detail-action-error" compact={true} />
+    {/if}
+    {#if actionFeedback}
+      <AdminMessage
+        variant={actionFeedback.variant}
+        title={actionFeedback.title}
+        message={actionFeedback.message}
+        testId={actionFeedback.testId}
+        compact={true}
+      />
     {/if}
 
     <section class="grid gap-3 md:grid-cols-4" aria-label="Workflow definition facts">
@@ -157,7 +178,7 @@
       <div class="admin-panel mt-0 grid self-start gap-2">
         <p class="admin-eyebrow">Versions</p>
         {#if viewModel.versionRows.length === 0}
-          <p class="admin-empty mt-0">No workflow versions are published yet.</p>
+          <AdminMessage variant="empty" message="No workflow versions are published yet." compact={true} />
         {:else}
           {#each viewModel.versionRows as version}
             <button
@@ -209,7 +230,7 @@
             {@render MetadataPanel('Schemas', viewModel.selectedVersion.schemaRows, 'workflow-definition-schemas')}
           </div>
         {:else}
-          <p class="admin-empty mt-0">No version metadata is available.</p>
+          <AdminMessage variant="empty" message="No version metadata is available." compact={true} />
         {/if}
       </div>
     </section>
@@ -222,7 +243,7 @@
         </div>
       </div>
       {#if viewModel.recentRuns.length === 0}
-        <p class="admin-empty mt-0">No workflow runs found for this definition.</p>
+        <AdminMessage variant="empty" message="No workflow runs found for this definition." compact={true} />
       {:else}
         <div class="grid gap-2">
           {#each viewModel.recentRuns as run}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
@@ -8,6 +8,8 @@
     WorkflowRunProducedFileResource,
     WorkflowRunResource,
   } from '../api/workflow-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
 
   type AdminWorkflowRunDetailRouteProps = {
     readonly workflowClient: WorkflowClient;
@@ -22,6 +24,7 @@
   let loading = $state(false);
   let actionInFlight = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let evidenceError = $state<string | null>(null);
   let lastRefreshedAt = $state<string | null>(null);
   let operatorInputText = $state('{}');
@@ -32,19 +35,26 @@
   const operatorInputValid = $derived(isJson(operatorInputText));
 
   onMount(() => {
-    void refreshInspector();
+    void refreshInspector(false);
   });
 
-  async function refreshInspector(): Promise<void> {
+  async function refreshInspector(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
     evidenceError = null;
+    if (showFeedback) {
+      actionFeedback = null;
+    }
     try {
       run = await workflowClient.getRun(runId);
       await loadEvidence();
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionFeedback = successFeedback('Workflow run detail refreshed.');
+      }
     } catch (refreshError) {
       error = errorMessage(refreshError, 'Unexpected workflow run detail error');
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -78,15 +88,21 @@
     evidenceError = errors.length > 0 ? errors.join(' | ') : null;
   }
 
-  async function mutateRun(action: () => Promise<WorkflowRunResource>): Promise<void> {
+  async function mutateRun(
+    action: () => Promise<WorkflowRunResource>,
+    successMessage: (updated: WorkflowRunResource) => string,
+  ): Promise<void> {
     actionInFlight = true;
     error = null;
+    actionFeedback = null;
     try {
       run = await action();
       await loadEvidence();
       lastRefreshedAt = new Date().toISOString();
+      actionFeedback = successFeedback(successMessage(run));
     } catch (mutationError) {
       error = errorMessage(mutationError, 'Unexpected workflow run action error');
+      actionFeedback = null;
     } finally {
       actionInFlight = false;
     }
@@ -97,6 +113,8 @@
     if (!file) {
       return;
     }
+    error = null;
+    actionFeedback = null;
     try {
       const url = URL.createObjectURL(await workflowClient.downloadProducedFileContent(file));
       const link = document.createElement('a');
@@ -106,20 +124,23 @@
       link.click();
       link.remove();
       URL.revokeObjectURL(url);
+      actionFeedback = successFeedback(`Produced file ${file.file_name} download started.`);
     } catch (downloadError) {
       error = errorMessage(downloadError, 'Produced file download failed');
+      actionFeedback = null;
     }
   }
 
   function submitInput(): void {
     if (!operatorInputValid) {
       error = 'Operator input must be valid JSON.';
+      actionFeedback = null;
       return;
     }
     void mutateRun(() => workflowClient.submitRunInput(runId, {
       input: parseJson(operatorInputText),
       comment: 'operator input from workflow run detail',
-    }));
+    }), () => 'Operator input submitted.');
   }
 
   function formatDate(value: string | null | undefined): string {
@@ -165,6 +186,10 @@
     return value instanceof Error ? value.message : fallback;
   }
 
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Workflow run updated', message, testId: 'workflow-run-detail-action-message' };
+  }
+
   function workflowHref(workflowId: string): string {
     return `${base}/workflows/${encodeURIComponent(workflowId)}`;
   }
@@ -204,15 +229,24 @@
 
   {#if loading && !run}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading workflow run...</p>
+      <AdminMessage variant="loading" message="Loading workflow run..." compact={true} />
     </section>
   {:else if error && !run}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="workflow-run-inspector-detail-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-run-inspector-detail-error" compact={true} />
     </section>
   {:else if run}
     {#if error}
-      <p class="admin-error" data-testid="workflow-run-inspector-action-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-run-inspector-action-error" compact={true} />
+    {/if}
+    {#if actionFeedback}
+      <AdminMessage
+        variant={actionFeedback.variant}
+        title={actionFeedback.title}
+        message={actionFeedback.message}
+        testId={actionFeedback.testId}
+        compact={true}
+      />
     {/if}
 
     <section class="grid gap-3 md:grid-cols-4" aria-label="Workflow run facts">
@@ -242,7 +276,7 @@
         </div>
       </div>
       {#if run.error}
-        <p class="admin-error m-0" data-testid="workflow-run-detail-terminal-error">{run.error}</p>
+        <AdminMessage variant="error" message={run.error} testId="workflow-run-detail-terminal-error" compact={true} />
       {/if}
     </section>
 
@@ -258,7 +292,7 @@
             type="button"
             data-testid="workflow-run-detail-cancel"
             disabled={terminal || actionInFlight}
-            onclick={() => void mutateRun(() => workflowClient.cancelRun(runId))}
+            onclick={() => void mutateRun(() => workflowClient.cancelRun(runId), () => 'Workflow run cancellation requested.')}
           >
             Cancel
           </button>
@@ -267,7 +301,10 @@
             type="button"
             data-testid="workflow-run-detail-resume"
             disabled={!pendingRequest || actionInFlight}
-            onclick={() => void mutateRun(() => workflowClient.resumeRun(runId, { comment: 'released from workflow run detail' }))}
+            onclick={() => void mutateRun(
+              () => workflowClient.resumeRun(runId, { comment: 'released from workflow run detail' }),
+              () => 'Workflow run resumed.',
+            )}
           >
             Resume
           </button>
@@ -310,7 +347,10 @@
           type="button"
           data-testid="workflow-run-detail-reject"
           disabled={!pendingRequest || rejectReason.trim().length === 0 || actionInFlight}
-          onclick={() => void mutateRun(() => workflowClient.rejectRun(runId, { reason: rejectReason.trim() }))}
+          onclick={() => void mutateRun(
+            () => workflowClient.rejectRun(runId, { reason: rejectReason.trim() }),
+            () => 'Workflow run input request rejected.',
+          )}
         >
           Reject
         </button>
@@ -338,7 +378,7 @@
         </span>
       </div>
       {#if files.length === 0}
-        <p class="admin-empty mt-0">No produced files loaded.</p>
+        <AdminMessage variant="empty" message="No produced files loaded." compact={true} />
       {:else}
         <div class="grid gap-2">
           {#each files as file}
@@ -355,7 +395,7 @@
         </div>
       {/if}
       {#if evidenceError}
-        <p class="admin-error" data-testid="workflow-run-inspector-evidence-error">{evidenceError}</p>
+        <AdminMessage variant="error" message={evidenceError} testId="workflow-run-inspector-evidence-error" compact={true} />
       {/if}
     </section>
   {/if}
@@ -384,7 +424,7 @@
       </div>
     </div>
     {#if rows.length === 0}
-      <p class="admin-empty mt-0">{empty}</p>
+      <AdminMessage variant="empty" message={empty} compact={true} />
     {:else}
       <div class="mt-3 grid gap-2">
         {#each rows.slice(-8).reverse() as row}
@@ -407,7 +447,7 @@
       </div>
     </div>
     {#if rows.length === 0}
-      <p class="admin-empty mt-0">{empty}</p>
+      <AdminMessage variant="empty" message={empty} compact={true} />
     {:else}
       <div class="mt-3 grid gap-2">
         {#each rows.slice(-8).reverse() as row}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowRunDetailRoute.svelte
@@ -39,6 +39,7 @@
   });
 
   async function refreshInspector(showFeedback = true): Promise<void> {
+    const previousState = run?.state ?? null;
     loading = true;
     error = null;
     evidenceError = null;
@@ -50,7 +51,11 @@
       await loadEvidence();
       lastRefreshedAt = new Date().toISOString();
       if (showFeedback) {
-        actionFeedback = successFeedback('Workflow run detail refreshed.');
+        actionFeedback = successFeedback(
+          previousState && previousState !== run.state
+            ? `Workflow run state changed from ${previousState} to ${run.state}.`
+            : 'Workflow run detail refreshed.',
+        );
       }
     } catch (refreshError) {
       error = errorMessage(refreshError, 'Unexpected workflow run detail error');
@@ -90,11 +95,12 @@
 
   async function mutateRun(
     action: () => Promise<WorkflowRunResource>,
+    progressMessage: string,
     successMessage: (updated: WorkflowRunResource) => string,
   ): Promise<void> {
     actionInFlight = true;
     error = null;
-    actionFeedback = null;
+    actionFeedback = detailFeedback('loading', 'Workflow run action', progressMessage);
     try {
       run = await action();
       await loadEvidence();
@@ -114,7 +120,7 @@
       return;
     }
     error = null;
-    actionFeedback = null;
+    actionFeedback = detailFeedback('loading', 'Produced file download', `Preparing download for ${file.file_name}.`);
     try {
       const url = URL.createObjectURL(await workflowClient.downloadProducedFileContent(file));
       const link = document.createElement('a');
@@ -140,7 +146,7 @@
     void mutateRun(() => workflowClient.submitRunInput(runId, {
       input: parseJson(operatorInputText),
       comment: 'operator input from workflow run detail',
-    }), () => 'Operator input submitted.');
+    }), 'Submitting operator input...', () => 'Operator input submitted.');
   }
 
   function formatDate(value: string | null | undefined): string {
@@ -187,7 +193,15 @@
   }
 
   function successFeedback(message: string): AdminMessageFeedback {
-    return { variant: 'success', title: 'Workflow run updated', message, testId: 'workflow-run-detail-action-message' };
+    return detailFeedback('success', 'Workflow run updated', message);
+  }
+
+  function detailFeedback(
+    variant: AdminMessageFeedback['variant'],
+    title: string,
+    message: string,
+  ): AdminMessageFeedback {
+    return { variant, title, message, testId: 'workflow-run-detail-action-message' };
   }
 
   function workflowHref(workflowId: string): string {
@@ -292,7 +306,11 @@
             type="button"
             data-testid="workflow-run-detail-cancel"
             disabled={terminal || actionInFlight}
-            onclick={() => void mutateRun(() => workflowClient.cancelRun(runId), () => 'Workflow run cancellation requested.')}
+            onclick={() => void mutateRun(
+              () => workflowClient.cancelRun(runId),
+              'Requesting workflow run cancellation...',
+              () => 'Workflow run cancellation requested.',
+            )}
           >
             Cancel
           </button>
@@ -303,6 +321,7 @@
             disabled={!pendingRequest || actionInFlight}
             onclick={() => void mutateRun(
               () => workflowClient.resumeRun(runId, { comment: 'released from workflow run detail' }),
+              'Releasing workflow run hold...',
               () => 'Workflow run resumed.',
             )}
           >
@@ -349,6 +368,7 @@
           disabled={!pendingRequest || rejectReason.trim().length === 0 || actionInFlight}
           onclick={() => void mutateRun(
             () => workflowClient.rejectRun(runId, { reason: rejectReason.trim() }),
+            'Rejecting workflow run input request...',
             () => 'Workflow run input request rejected.',
           )}
         >

--- a/code/web/bpane-admin/src/lib/application/AdminWorkflowRunListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkflowRunListRoute.svelte
@@ -3,6 +3,8 @@
   import { onMount } from 'svelte';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { WorkflowRunResource } from '../api/workflow-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
 
   type AdminWorkflowRunListRouteProps = {
     readonly workflowClient: WorkflowClient;
@@ -12,23 +14,29 @@
   let runs = $state<readonly WorkflowRunResource[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let search = $state('');
   let lastRefreshedAt = $state<string | null>(null);
 
   const filteredRuns = $derived(filterRuns(runs, search));
 
   onMount(() => {
-    void loadRuns();
+    void loadRuns(false);
   });
 
-  async function loadRuns(): Promise<void> {
+  async function loadRuns(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    actionFeedback = null;
     try {
       runs = (await workflowClient.listRuns()).runs;
       lastRefreshedAt = new Date().toISOString();
+      if (showFeedback) {
+        actionFeedback = successFeedback(`${runs.length} workflow run${runs.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (loadError) {
       error = errorMessage(loadError);
+      actionFeedback = null;
     } finally {
       loading = false;
     }
@@ -77,6 +85,10 @@
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected workflow run list error';
   }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Workflow runs refreshed', message, testId: 'workflow-run-inspector-message' };
+  }
 </script>
 
 <section class="grid gap-5" data-testid="workflow-run-inspector-list">
@@ -117,19 +129,32 @@
     </div>
   </div>
 
+  {#if actionFeedback}
+    <AdminMessage
+      variant={actionFeedback.variant}
+      title={actionFeedback.title}
+      message={actionFeedback.message}
+      testId={actionFeedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if loading && runs.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0">Loading workflow runs...</p>
+      <AdminMessage variant="loading" message="Loading workflow runs..." compact={true} />
     </section>
   {:else if error}
     <section class="admin-panel mt-0">
-      <p class="admin-error mt-0" data-testid="workflow-run-inspector-error">{error}</p>
+      <AdminMessage variant="error" message={error} testId="workflow-run-inspector-error" compact={true} />
     </section>
   {:else if filteredRuns.length === 0}
     <section class="admin-panel mt-0">
-      <p class="admin-empty mt-0" data-testid="workflow-run-inspector-empty">
-        No workflow runs match the current filter.
-      </p>
+      <AdminMessage
+        variant="empty"
+        message="No workflow runs match the current filter."
+        testId="workflow-run-inspector-empty"
+        compact={true}
+      />
     </section>
   {:else}
     <section class="grid gap-2" aria-label="Workflow run table">

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -11,11 +11,13 @@
     Video,
   } from 'lucide-svelte';
   import type { ControlClient } from '../api/control-client';
-  import type { SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { McpBridgeConfig } from '../auth/auth-config';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
   import FeaturePlaceholderPanel from '../presentation/FeaturePlaceholderPanel.svelte';
   import SessionListPanel from '../presentation/SessionListPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import {
     type AdminFeaturePanelId,
     type AdminFeaturePanelViewModel,
@@ -46,20 +48,22 @@
     readonly workspaceViewModel: AdminWorkspaceViewModel;
     readonly sessionListViewModel: SessionListPanelViewModel;
     readonly logEntries: readonly AdminLogEntry[];
+    readonly globalMessage?: AdminMessageFeedback | null;
     readonly sessionFilesRefreshVersion: number;
     readonly recordingsRefreshVersion: number;
     readonly mcpDelegationRefreshVersion: number;
-    readonly onRefreshSessions: () => Promise<void>;
-    readonly onCreateSession: () => void;
+    readonly onRefreshSessions: (showFeedback?: boolean) => Promise<void>;
+    readonly onCreateSession: (command?: CreateSessionCommand) => void;
     readonly onJoinSelectedSession: () => void;
     readonly onSelectSessionId: (sessionId: string) => void;
     readonly onRefreshSelectedSession: () => Promise<void>;
-    readonly onStopSession: () => void;
-    readonly onKillSession: () => void;
+    readonly onStopSession: () => Promise<void>;
+    readonly onKillSession: () => Promise<void>;
     readonly onDisconnectEmbeddedBrowser: () => void;
     readonly onFileCountChange: (count: number) => void;
     readonly onClearLogs: () => void;
     readonly onBrowserPreferencesChange: (preferences: BrowserSessionConnectPreferences) => void;
+    readonly onDismissGlobalMessage?: () => void;
   };
 
   let props: AdminWorkspaceTabsProps = $props();
@@ -83,7 +87,7 @@
   } satisfies Record<AdminFeaturePanelId, typeof Activity>;
 </script>
 
-<section class="grid h-full min-w-0 grid-rows-[auto_auto_minmax(0,1fr)] overflow-hidden" data-testid="admin-workspace-tabs">
+<section class="grid h-full min-w-0 grid-rows-[auto_auto_auto_minmax(0,1fr)] overflow-hidden" data-testid="admin-workspace-tabs">
   <LiveSessionActionsSurface liveConnection={props.liveConnection} connected={props.browserConnected} />
   <div class="border-b border-[#90a6cc]/18 p-3">
     <div class="grid grid-cols-2 gap-2 sm:grid-cols-3" role="tablist" aria-label="Admin panels">
@@ -107,6 +111,19 @@
       {/each}
     </div>
   </div>
+  <div class={`border-b border-[#90a6cc]/18 p-3 ${props.globalMessage ? '' : 'hidden'}`} data-testid="admin-global-message-region">
+    {#if props.globalMessage}
+      <AdminMessage
+        variant={props.globalMessage.variant}
+        title={props.globalMessage.title}
+        message={props.globalMessage.message}
+        testId={props.globalMessage.testId ?? 'admin-global-message'}
+        compact={true}
+        onDismiss={props.onDismissGlobalMessage}
+        dismissTestId="admin-global-message-dismiss"
+      />
+    {/if}
+  </div>
 
   {#if activePanel}
     <div
@@ -129,7 +146,7 @@
         {#if activePanel.id === 'sessions'}
         <SessionListPanel
           viewModel={props.sessionListViewModel}
-          onRefresh={() => void props.onRefreshSessions()}
+          onRefresh={() => void props.onRefreshSessions(true)}
           onCreateSession={props.onCreateSession}
           onJoinSession={props.onJoinSelectedSession}
           onSelectSessionId={props.onSelectSessionId}
@@ -139,7 +156,7 @@
           selectedSession={props.selectedSession}
           mcpBridge={props.mcpBridge}
           refreshVersion={props.mcpDelegationRefreshVersion}
-          onRefreshSessions={props.onRefreshSessions}
+          onRefreshSessions={() => props.onRefreshSessions(false)}
           onRefreshSelectedSession={props.onRefreshSelectedSession}
         />
       {:else if activePanel.id === 'lifecycle'}

--- a/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
@@ -38,11 +38,16 @@
   });
 
   async function copyProbeCommand(): Promise<void> {
-    if (!viewModel.probeCommand) {
+    const requestSessionId = currentSessionId;
+    const probeCommand = viewModel.probeCommand;
+    if (!probeCommand || !requestSessionId) {
       return;
     }
     try {
-      await navigator.clipboard.writeText(viewModel.probeCommand);
+      await navigator.clipboard.writeText(probeCommand);
+      if (currentSessionId !== requestSessionId) {
+        return;
+      }
       copied = true;
       feedback = {
         variant: 'success',
@@ -58,19 +63,28 @@
         copyTimer = null;
       }, 1600);
     } catch (error) {
-      feedback = {
-        variant: 'error',
-        title: 'Copy failed',
-        message: error instanceof Error ? error.message : 'Could not copy policy probe command.',
-        testId: 'policy-message',
-      };
+      if (currentSessionId === requestSessionId) {
+        feedback = {
+          variant: 'error',
+          title: 'Copy failed',
+          message: error instanceof Error ? error.message : 'Could not copy policy probe command.',
+          testId: 'policy-message',
+        };
+      }
     }
   }
 
   async function refreshPolicy(): Promise<void> {
+    const requestSessionId = currentSessionId;
+    if (!requestSessionId) {
+      return;
+    }
     feedback = null;
     try {
       await onRefreshSelectedSession();
+      if (currentSessionId !== requestSessionId) {
+        return;
+      }
       feedback = {
         variant: 'success',
         title: 'Policy refreshed',
@@ -78,12 +92,14 @@
         testId: 'policy-message',
       };
     } catch (error) {
-      feedback = {
-        variant: 'error',
-        title: 'Policy refresh failed',
-        message: error instanceof Error ? error.message : 'Could not refresh selected session policy data.',
-        testId: 'policy-message',
-      };
+      if (currentSessionId === requestSessionId) {
+        feedback = {
+          variant: 'error',
+          title: 'Policy refresh failed',
+          message: error instanceof Error ? error.message : 'Could not refresh selected session policy data.',
+          testId: 'policy-message',
+        };
+      }
     }
   }
 </script>

--- a/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import type { SessionResource } from '../api/control-types';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import BrowserPolicyPanel from '../presentation/BrowserPolicyPanel.svelte';
   import { BrowserPolicyViewModelBuilder } from '../presentation/browser-policy-view-model';
 
@@ -11,6 +12,7 @@
 
   let { selectedSession, onRefreshSelectedSession }: BrowserPolicySurfaceProps = $props();
   let copied = $state(false);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   const viewModel = $derived(BrowserPolicyViewModelBuilder.build(selectedSession));
 
@@ -24,21 +26,57 @@
     if (!viewModel.probeCommand) {
       return;
     }
-    await navigator.clipboard.writeText(viewModel.probeCommand);
-    copied = true;
-    if (copyTimer) {
-      clearTimeout(copyTimer);
+    try {
+      await navigator.clipboard.writeText(viewModel.probeCommand);
+      copied = true;
+      feedback = {
+        variant: 'success',
+        title: 'Policy command copied',
+        message: 'CDP local-file policy probe command copied.',
+        testId: 'policy-message',
+      };
+      if (copyTimer) {
+        clearTimeout(copyTimer);
+      }
+      copyTimer = setTimeout(() => {
+        copied = false;
+        copyTimer = null;
+      }, 1600);
+    } catch (error) {
+      feedback = {
+        variant: 'error',
+        title: 'Copy failed',
+        message: error instanceof Error ? error.message : 'Could not copy policy probe command.',
+        testId: 'policy-message',
+      };
     }
-    copyTimer = setTimeout(() => {
-      copied = false;
-      copyTimer = null;
-    }, 1600);
+  }
+
+  async function refreshPolicy(): Promise<void> {
+    feedback = null;
+    try {
+      await onRefreshSelectedSession();
+      feedback = {
+        variant: 'success',
+        title: 'Policy refreshed',
+        message: 'Selected session policy data refreshed.',
+        testId: 'policy-message',
+      };
+    } catch (error) {
+      feedback = {
+        variant: 'error',
+        title: 'Policy refresh failed',
+        message: error instanceof Error ? error.message : 'Could not refresh selected session policy data.',
+        testId: 'policy-message',
+      };
+    }
   }
 </script>
 
 <BrowserPolicyPanel
   {viewModel}
   {copied}
-  onRefresh={() => void onRefreshSelectedSession()}
+  {feedback}
+  onRefresh={() => void refreshPolicy()}
   onCopyProbeCommand={() => void copyProbeCommand()}
 />

--- a/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/BrowserPolicySurface.svelte
@@ -11,10 +11,25 @@
   };
 
   let { selectedSession, onRefreshSelectedSession }: BrowserPolicySurfaceProps = $props();
+  let currentSessionId = $state<string | null>(null);
   let copied = $state(false);
   let feedback = $state<AdminMessageFeedback | null>(null);
   let copyTimer: ReturnType<typeof setTimeout> | null = null;
   const viewModel = $derived(BrowserPolicyViewModelBuilder.build(selectedSession));
+
+  $effect(() => {
+    const nextSessionId = selectedSession?.id ?? null;
+    if (nextSessionId === currentSessionId) {
+      return;
+    }
+    currentSessionId = nextSessionId;
+    copied = false;
+    feedback = null;
+    if (copyTimer) {
+      clearTimeout(copyTimer);
+      copyTimer = null;
+    }
+  });
 
   onDestroy(() => {
     if (copyTimer) {

--- a/code/web/bpane-admin/src/lib/application/DisplayControlsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/DisplayControlsSurface.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import DisplayControlsPanel from '../presentation/DisplayControlsPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import { DisplaySettingsViewModelBuilder } from '../presentation/display-settings-view-model';
   import type {
     BrowserSessionConnectPreferences,
@@ -17,19 +18,36 @@
     preferences,
     onPreferencesChange,
   }: DisplayControlsSurfaceProps = $props();
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const viewModel = $derived(DisplaySettingsViewModelBuilder.build({
     preferences,
     connected,
   }));
 
-  function updatePreference(patch: Partial<BrowserSessionConnectPreferences>): void {
+  function updatePreference(patch: Partial<BrowserSessionConnectPreferences>, message: string): void {
     onPreferencesChange({ ...preferences, ...patch });
+    feedback = {
+      variant: 'info',
+      title: 'Display preference saved',
+      message,
+      testId: 'display-message',
+    };
   }
 </script>
 
 <DisplayControlsPanel
   {viewModel}
-  onRenderBackendChange={(renderBackend: BrowserSessionRenderBackend) => updatePreference({ renderBackend })}
-  onHiDpiChange={(hiDpi) => updatePreference({ hiDpi })}
-  onScrollCopyChange={(scrollCopy) => updatePreference({ scrollCopy })}
+  {feedback}
+  onRenderBackendChange={(renderBackend: BrowserSessionRenderBackend) => updatePreference(
+    { renderBackend },
+    connected ? 'Render backend will apply after reconnect.' : 'Render backend will apply on the next connect.',
+  )}
+  onHiDpiChange={(hiDpi) => updatePreference(
+    { hiDpi },
+    connected ? 'HiDPI preference will apply after reconnect.' : 'HiDPI preference will apply on the next connect.',
+  )}
+  onScrollCopyChange={(scrollCopy) => updatePreference(
+    { scrollCopy },
+    connected ? 'Scroll-copy preference will apply after reconnect.' : 'Scroll-copy preference will apply on the next connect.',
+  )}
 />

--- a/code/web/bpane-admin/src/lib/application/LiveSessionActionsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/LiveSessionActionsSurface.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import LiveSessionActionsPanel from '../presentation/LiveSessionActionsPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import {
     type LiveSessionActionId,
     LiveSessionActionsViewModelBuilder,
@@ -16,6 +17,7 @@
   let cameraActive = $state(false);
   let busyAction = $state<LiveSessionActionId | null>(null);
   let error = $state<string | null>(null);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const viewModel = $derived(LiveSessionActionsViewModelBuilder.build({
     connected,
     cameraAvailable: Boolean(liveConnection?.handle.startCamera && liveConnection?.handle.stopCamera),
@@ -33,6 +35,7 @@
       cameraActive = false;
       busyAction = null;
       error = null;
+      feedback = null;
     }
   });
 
@@ -40,7 +43,7 @@
     const handle = liveConnection?.handle;
     if (!handle) return;
     if (microphoneActive) {
-      await runLiveAction('microphone', async () => {
+      await runLiveAction('microphone', 'Microphone stopped.', async () => {
         handle.stopMicrophone?.();
         microphoneActive = false;
       });
@@ -48,9 +51,10 @@
     }
     if (!handle.startMicrophone) {
       error = 'The connected browser handle does not expose microphone control.';
+      feedback = null;
       return;
     }
-    await runLiveAction('microphone', async () => {
+    await runLiveAction('microphone', 'Microphone started.', async () => {
       await handle.startMicrophone?.();
       microphoneActive = true;
     });
@@ -60,7 +64,7 @@
     const handle = liveConnection?.handle;
     if (!handle) return;
     if (cameraActive) {
-      await runLiveAction('camera', async () => {
+      await runLiveAction('camera', 'Camera stopped.', async () => {
         handle.stopCamera?.();
         cameraActive = false;
       });
@@ -68,9 +72,10 @@
     }
     if (!handle.startCamera) {
       error = 'The connected browser handle does not expose camera control.';
+      feedback = null;
       return;
     }
-    await runLiveAction('camera', async () => {
+    await runLiveAction('camera', 'Camera started.', async () => {
       await handle.startCamera?.();
       cameraActive = true;
     });
@@ -80,18 +85,31 @@
     const handle = liveConnection?.handle;
     if (!handle?.uploadFiles) {
       error = 'The connected browser handle does not expose file upload.';
+      feedback = null;
       return;
     }
-    await runLiveAction('upload', async () => handle.uploadFiles?.(files));
+    const count = files.length;
+    await runLiveAction(
+      'upload',
+      `${count} ${count === 1 ? 'file was' : 'files were'} sent to the session.`,
+      async () => handle.uploadFiles?.(files),
+    );
   }
 
-  async function runLiveAction(action: LiveSessionActionId, operation: () => Promise<void>): Promise<void> {
+  async function runLiveAction(
+    action: LiveSessionActionId,
+    successMessage: string,
+    operation: () => Promise<void>,
+  ): Promise<void> {
     busyAction = action;
     error = null;
+    feedback = null;
     try {
       await operation();
+      feedback = { variant: 'success', title: 'Operation complete', message: successMessage, testId: 'display-message' };
     } catch (actionError) {
       error = actionError instanceof Error ? actionError.message : 'Live session action failed';
+      feedback = null;
     } finally {
       busyAction = null;
     }
@@ -100,6 +118,7 @@
 
 <LiveSessionActionsPanel
   {viewModel}
+  {feedback}
   onCameraToggle={() => void toggleCamera()}
   onMicrophoneToggle={() => void toggleMicrophone()}
   onUploadFiles={(files) => void uploadFiles(files)}

--- a/code/web/bpane-admin/src/lib/application/LiveSessionActionsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/LiveSessionActionsSurface.svelte
@@ -18,6 +18,8 @@
   let busyAction = $state<LiveSessionActionId | null>(null);
   let error = $state<string | null>(null);
   let feedback = $state<AdminMessageFeedback | null>(null);
+  let observedConnectionSessionId = $state<string | null>(null);
+  const currentConnectionSessionId = $derived(connected ? liveConnection?.sessionId ?? null : null);
   const viewModel = $derived(LiveSessionActionsViewModelBuilder.build({
     connected,
     cameraAvailable: Boolean(liveConnection?.handle.startCamera && liveConnection?.handle.stopCamera),
@@ -30,66 +32,76 @@
   }));
 
   $effect(() => {
-    if (!connected) {
-      microphoneActive = false;
-      cameraActive = false;
-      busyAction = null;
-      error = null;
-      feedback = null;
+    if (currentConnectionSessionId === observedConnectionSessionId) {
+      return;
     }
+    observedConnectionSessionId = currentConnectionSessionId;
+    microphoneActive = false;
+    cameraActive = false;
+    busyAction = null;
+    error = null;
+    feedback = null;
   });
 
   async function toggleMicrophone(): Promise<void> {
     const handle = liveConnection?.handle;
-    if (!handle) return;
+    const requestSessionId = currentConnectionSessionId;
+    if (!handle || !requestSessionId) return;
     if (microphoneActive) {
-      await runLiveAction('microphone', 'Microphone stopped.', async () => {
+      await runLiveAction(requestSessionId, 'microphone', 'Microphone stopped.', async () => {
         handle.stopMicrophone?.();
+      }, () => {
         microphoneActive = false;
       });
       return;
     }
     if (!handle.startMicrophone) {
-      error = 'The connected browser handle does not expose microphone control.';
-      feedback = null;
+      showCurrentError(requestSessionId, 'The connected browser handle does not expose microphone control.');
       return;
     }
-    await runLiveAction('microphone', 'Microphone started.', async () => {
+    await runLiveAction(requestSessionId, 'microphone', 'Microphone started.', async () => {
       await handle.startMicrophone?.();
+    }, () => {
       microphoneActive = true;
     });
   }
 
   async function toggleCamera(): Promise<void> {
     const handle = liveConnection?.handle;
-    if (!handle) return;
+    const requestSessionId = currentConnectionSessionId;
+    if (!handle || !requestSessionId) return;
     if (cameraActive) {
-      await runLiveAction('camera', 'Camera stopped.', async () => {
+      await runLiveAction(requestSessionId, 'camera', 'Camera stopped.', async () => {
         handle.stopCamera?.();
+      }, () => {
         cameraActive = false;
       });
       return;
     }
     if (!handle.startCamera) {
-      error = 'The connected browser handle does not expose camera control.';
-      feedback = null;
+      showCurrentError(requestSessionId, 'The connected browser handle does not expose camera control.');
       return;
     }
-    await runLiveAction('camera', 'Camera started.', async () => {
+    await runLiveAction(requestSessionId, 'camera', 'Camera started.', async () => {
       await handle.startCamera?.();
+    }, () => {
       cameraActive = true;
     });
   }
 
   async function uploadFiles(files: FileList): Promise<void> {
     const handle = liveConnection?.handle;
-    if (!handle?.uploadFiles) {
-      error = 'The connected browser handle does not expose file upload.';
-      feedback = null;
+    const requestSessionId = currentConnectionSessionId;
+    if (!handle || !requestSessionId) {
+      return;
+    }
+    if (!handle.uploadFiles) {
+      showCurrentError(requestSessionId, 'The connected browser handle does not expose file upload.');
       return;
     }
     const count = files.length;
     await runLiveAction(
+      requestSessionId,
       'upload',
       `${count} ${count === 1 ? 'file was' : 'files were'} sent to the session.`,
       async () => handle.uploadFiles?.(files),
@@ -97,22 +109,42 @@
   }
 
   async function runLiveAction(
+    sessionId: string,
     action: LiveSessionActionId,
     successMessage: string,
     operation: () => Promise<void>,
+    applySuccess?: () => void,
   ): Promise<void> {
     busyAction = action;
     error = null;
     feedback = null;
     try {
       await operation();
-      feedback = { variant: 'success', title: 'Operation complete', message: successMessage, testId: 'display-message' };
+      if (isCurrentLiveSession(sessionId)) {
+        applySuccess?.();
+        feedback = { variant: 'success', title: 'Operation complete', message: successMessage, testId: 'display-message' };
+      }
     } catch (actionError) {
-      error = actionError instanceof Error ? actionError.message : 'Live session action failed';
-      feedback = null;
+      if (isCurrentLiveSession(sessionId)) {
+        error = actionError instanceof Error ? actionError.message : 'Live session action failed';
+        feedback = null;
+      }
     } finally {
-      busyAction = null;
+      if (isCurrentLiveSession(sessionId)) {
+        busyAction = null;
+      }
     }
+  }
+
+  function showCurrentError(sessionId: string, message: string): void {
+    if (isCurrentLiveSession(sessionId)) {
+      error = message;
+      feedback = null;
+    }
+  }
+
+  function isCurrentLiveSession(sessionId: string): boolean {
+    return currentConnectionSessionId === sessionId;
   }
 </script>
 

--- a/code/web/bpane-admin/src/lib/application/LogsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/LogsSurface.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import LogsPanel from '../presentation/LogsPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import { AdminLogsViewModelBuilder, type AdminLogEntry } from '../presentation/logs-view-model';
   import { AdminLogEntryFactory } from './admin-log-entries';
 
@@ -10,22 +11,37 @@
 
   let { entries, onClear }: LogsSurfaceProps = $props();
   let copied = $state(false);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const viewModel = $derived(AdminLogsViewModelBuilder.build(entries));
 
   async function copy(): Promise<void> {
-    await navigator.clipboard?.writeText(AdminLogEntryFactory.copyText(entries));
-    copied = true;
+    feedback = null;
+    try {
+      await navigator.clipboard?.writeText(AdminLogEntryFactory.copyText(entries));
+      copied = true;
+      feedback = { variant: 'success', title: 'Logs copied', message: 'Admin diagnostic log payload copied.', testId: 'admin-log-message' };
+    } catch (error) {
+      copied = false;
+      feedback = {
+        variant: 'error',
+        title: 'Logs copy failed',
+        message: error instanceof Error ? error.message : 'Could not copy admin diagnostic logs.',
+        testId: 'admin-log-message',
+      };
+    }
   }
 
   function clear(): void {
     onClear();
     copied = false;
+    feedback = { variant: 'info', title: 'Logs cleared', message: 'Admin diagnostic logs cleared.', testId: 'admin-log-message' };
   }
 </script>
 
 <LogsPanel
   {viewModel}
   {copied}
+  {feedback}
   onClear={clear}
   onCopy={() => void copy()}
 />

--- a/code/web/bpane-admin/src/lib/application/McpDelegationSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/McpDelegationSurface.svelte
@@ -47,6 +47,7 @@
     }
     currentKey = nextKey;
     health = null;
+    loading = false;
     error = null;
     feedback = null;
     if (bridgeClient) {
@@ -65,50 +66,80 @@
   });
 
   async function refreshBridge(showFeedback = true): Promise<void> {
-    if (!bridgeClient) {
+    const client = bridgeClient;
+    const requestKey = currentKey;
+    if (!client) {
       return;
     }
     loading = true;
     error = null;
     feedback = null;
     try {
-      health = await bridgeClient.getHealth();
+      const nextHealth = await client.getHealth();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
+      health = nextHealth;
       if (showFeedback) {
         feedback = successFeedback('MCP bridge status refreshed.');
       }
     } catch (refreshError) {
-      error = errorMessage(refreshError);
-      feedback = null;
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(refreshError);
+        feedback = null;
+      }
     } finally {
-      loading = false;
+      if (isCurrentRequest(requestKey)) {
+        loading = false;
+      }
     }
   }
 
   async function authorizeSelectedSession(): Promise<void> {
-    if (!selectedSession || !mcpBridge) {
+    const session = selectedSession;
+    const bridge = mcpBridge;
+    const client = bridgeClient;
+    const requestKey = currentKey;
+    if (!session || !bridge) {
       return;
     }
     loading = true;
     error = null;
     feedback = null;
     try {
-      await authorizeSession(selectedSession.id);
+      await authorizeSession(session.id, bridge);
       await onRefreshSessions();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       await onRefreshSelectedSession();
-      health = await bridgeClient?.getHealth() ?? health;
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
+      health = await client?.getHealth() ?? health;
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       feedback = successFeedback('MCP authorized for the selected session.');
     } catch (delegateError) {
-      error = errorMessage(delegateError);
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(delegateError);
+      }
     } finally {
-      loading = false;
+      if (isCurrentRequest(requestKey)) {
+        loading = false;
+      }
     }
   }
 
   async function revokeSelectedSession(): Promise<void> {
-    if (!selectedSession) {
+    const session = selectedSession;
+    const client = bridgeClient;
+    const requestKey = currentKey;
+    if (!session) {
       return;
     }
-    if (health?.control_session_id === selectedSession.id) {
+    if (health?.control_session_id === session.id) {
       error = 'Clear the default MCP session before revoking this authorization.';
       feedback = null;
       return;
@@ -117,87 +148,141 @@
     error = null;
     feedback = null;
     try {
-      await controlClient.clearAutomationDelegate(selectedSession.id);
+      await controlClient.clearAutomationDelegate(session.id);
       await onRefreshSessions();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       await onRefreshSelectedSession();
-      health = await bridgeClient?.getHealth() ?? health;
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
+      health = await client?.getHealth() ?? health;
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       feedback = successFeedback('MCP authorization was revoked for the selected session.');
     } catch (clearError) {
-      error = errorMessage(clearError);
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(clearError);
+      }
     } finally {
-      loading = false;
+      if (isCurrentRequest(requestKey)) {
+        loading = false;
+      }
     }
   }
 
   async function setDefaultSession(): Promise<void> {
-    if (!selectedSession || !mcpBridge || !bridgeClient) {
+    const session = selectedSession;
+    const bridge = mcpBridge;
+    const client = bridgeClient;
+    const requestKey = currentKey;
+    if (!session || !bridge || !client) {
       return;
     }
     loading = true;
     error = null;
     feedback = null;
     try {
-      if (!isDelegatedToBridge(selectedSession)) {
-        await authorizeSession(selectedSession.id);
+      if (!isDelegatedToBridge(session, bridge)) {
+        await authorizeSession(session.id, bridge);
       }
-      await bridgeClient.setControlSession(selectedSession.id);
+      await client.setControlSession(session.id);
       await onRefreshSessions();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       await onRefreshSelectedSession();
-      health = await bridgeClient.getHealth();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
+      health = await client.getHealth();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       feedback = successFeedback('Selected session is now the default MCP session.');
     } catch (clearError) {
-      error = errorMessage(clearError);
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(clearError);
+      }
     } finally {
-      loading = false;
+      if (isCurrentRequest(requestKey)) {
+        loading = false;
+      }
     }
   }
 
   async function clearDefaultSession(): Promise<void> {
-    if (!bridgeClient) {
+    const client = bridgeClient;
+    const requestKey = currentKey;
+    if (!client) {
       return;
     }
     loading = true;
     error = null;
     feedback = null;
     try {
-      await bridgeClient.clearControlSession();
+      await client.clearControlSession();
       await onRefreshSessions();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       await onRefreshSelectedSession();
-      health = await bridgeClient.getHealth();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
+      health = await client.getHealth();
+      if (!isCurrentRequest(requestKey)) {
+        return;
+      }
       feedback = successFeedback('Default MCP session was cleared.');
     } catch (clearError) {
-      error = errorMessage(clearError);
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(clearError);
+      }
     } finally {
-      loading = false;
+      if (isCurrentRequest(requestKey)) {
+        loading = false;
+      }
     }
   }
 
   async function copyEndpoint(): Promise<void> {
-    if (!viewModel.endpointUrl) {
+    const endpointUrl = viewModel.endpointUrl;
+    const requestKey = currentKey;
+    if (!endpointUrl) {
       return;
     }
     error = null;
     feedback = null;
     try {
-      await navigator.clipboard.writeText(viewModel.endpointUrl);
-      feedback = successFeedback('Session MCP endpoint copied.');
+      await navigator.clipboard.writeText(endpointUrl);
+      if (isCurrentRequest(requestKey)) {
+        feedback = successFeedback('Session MCP endpoint copied.');
+      }
     } catch (copyError) {
-      error = errorMessage(copyError);
+      if (isCurrentRequest(requestKey)) {
+        error = errorMessage(copyError);
+      }
     }
   }
 
-  async function authorizeSession(sessionId: string): Promise<void> {
-    if (!mcpBridge) return;
+  async function authorizeSession(sessionId: string, bridge: McpBridgeConfig): Promise<void> {
     await controlClient.setAutomationDelegate(sessionId, {
-      client_id: mcpBridge.clientId,
-      issuer: mcpBridge.issuer,
-      display_name: mcpBridge.displayName,
+      client_id: bridge.clientId,
+      issuer: bridge.issuer,
+      display_name: bridge.displayName,
     });
   }
 
-  function isDelegatedToBridge(session: SessionResource): boolean {
+  function isDelegatedToBridge(session: SessionResource, bridge = mcpBridge): boolean {
     const delegate = session.automation_delegate;
-    return Boolean(delegate && mcpBridge && delegate.client_id === mcpBridge.clientId && (!mcpBridge.issuer || delegate.issuer === mcpBridge.issuer));
+    return Boolean(delegate && bridge && delegate.client_id === bridge.clientId && (!bridge.issuer || delegate.issuer === bridge.issuer));
+  }
+
+  function isCurrentRequest(requestKey: string): boolean {
+    return requestKey === currentKey;
   }
 
   function errorMessage(value: unknown): string {

--- a/code/web/bpane-admin/src/lib/application/McpDelegationSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/McpDelegationSurface.svelte
@@ -4,6 +4,7 @@
   import type { McpBridgeHealth } from '../api/mcp-bridge-client';
   import type { SessionResource } from '../api/control-types';
   import type { McpBridgeConfig } from '../auth/auth-config';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import McpDelegationPanel from '../presentation/McpDelegationPanel.svelte';
   import { McpDelegationViewModelBuilder } from '../presentation/mcp-delegation-view-model';
 
@@ -29,6 +30,7 @@
   let health = $state<McpBridgeHealth | null>(null);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const bridgeClient = $derived(mcpBridge ? new McpBridgeClient({ controlUrl: mcpBridge.controlUrl }) : null);
   const viewModel = $derived(McpDelegationViewModelBuilder.build({
     bridge: mcpBridge,
@@ -46,8 +48,9 @@
     currentKey = nextKey;
     health = null;
     error = null;
+    feedback = null;
     if (bridgeClient) {
-      void refreshBridge();
+      void refreshBridge(false);
     }
   });
 
@@ -57,20 +60,25 @@
     }
     lastRefreshVersion = refreshVersion;
     if (bridgeClient) {
-      void refreshBridge();
+      void refreshBridge(false);
     }
   });
 
-  async function refreshBridge(): Promise<void> {
+  async function refreshBridge(showFeedback = true): Promise<void> {
     if (!bridgeClient) {
       return;
     }
     loading = true;
     error = null;
+    feedback = null;
     try {
       health = await bridgeClient.getHealth();
+      if (showFeedback) {
+        feedback = successFeedback('MCP bridge status refreshed.');
+      }
     } catch (refreshError) {
       error = errorMessage(refreshError);
+      feedback = null;
     } finally {
       loading = false;
     }
@@ -82,11 +90,13 @@
     }
     loading = true;
     error = null;
+    feedback = null;
     try {
       await authorizeSession(selectedSession.id);
       await onRefreshSessions();
       await onRefreshSelectedSession();
       health = await bridgeClient?.getHealth() ?? health;
+      feedback = successFeedback('MCP authorized for the selected session.');
     } catch (delegateError) {
       error = errorMessage(delegateError);
     } finally {
@@ -100,15 +110,18 @@
     }
     if (health?.control_session_id === selectedSession.id) {
       error = 'Clear the default MCP session before revoking this authorization.';
+      feedback = null;
       return;
     }
     loading = true;
     error = null;
+    feedback = null;
     try {
       await controlClient.clearAutomationDelegate(selectedSession.id);
       await onRefreshSessions();
       await onRefreshSelectedSession();
       health = await bridgeClient?.getHealth() ?? health;
+      feedback = successFeedback('MCP authorization was revoked for the selected session.');
     } catch (clearError) {
       error = errorMessage(clearError);
     } finally {
@@ -122,6 +135,7 @@
     }
     loading = true;
     error = null;
+    feedback = null;
     try {
       if (!isDelegatedToBridge(selectedSession)) {
         await authorizeSession(selectedSession.id);
@@ -130,6 +144,7 @@
       await onRefreshSessions();
       await onRefreshSelectedSession();
       health = await bridgeClient.getHealth();
+      feedback = successFeedback('Selected session is now the default MCP session.');
     } catch (clearError) {
       error = errorMessage(clearError);
     } finally {
@@ -143,11 +158,13 @@
     }
     loading = true;
     error = null;
+    feedback = null;
     try {
       await bridgeClient.clearControlSession();
       await onRefreshSessions();
       await onRefreshSelectedSession();
       health = await bridgeClient.getHealth();
+      feedback = successFeedback('Default MCP session was cleared.');
     } catch (clearError) {
       error = errorMessage(clearError);
     } finally {
@@ -160,8 +177,13 @@
       return;
     }
     error = null;
-    try { await navigator.clipboard.writeText(viewModel.endpointUrl); }
-    catch (copyError) { error = errorMessage(copyError); }
+    feedback = null;
+    try {
+      await navigator.clipboard.writeText(viewModel.endpointUrl);
+      feedback = successFeedback('Session MCP endpoint copied.');
+    } catch (copyError) {
+      error = errorMessage(copyError);
+    }
   }
 
   async function authorizeSession(sessionId: string): Promise<void> {
@@ -181,10 +203,15 @@
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected MCP delegation error';
   }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'MCP updated', message, testId: 'mcp-message' };
+  }
 </script>
 
 <McpDelegationPanel
   {viewModel}
+  {feedback}
   onRefresh={() => void refreshBridge()}
   onAuthorize={() => void authorizeSelectedSession()}
   onRevoke={() => void revokeSelectedSession()}

--- a/code/web/bpane-admin/src/lib/application/MetricsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/MetricsSurface.svelte
@@ -5,6 +5,7 @@
     MetricsViewModelBuilder,
     type MetricsSampleSummary,
   } from '../presentation/metrics-view-model';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import type { MetricsRawSample } from '../presentation/metrics-diagnostics-payload';
   import { MetricsSampleExtremaBuilder, type MetricsSampleExtrema } from '../presentation/metrics-sample-extrema';
   import type { LiveBrowserSessionConnection } from '../session/browser-session-types';
@@ -20,6 +21,7 @@
   let extrema = $state<MetricsSampleExtrema | null>(null);
   let summary = $state<MetricsSampleSummary | null>(null);
   let copied = $state(false);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const viewModel = $derived(MetricsViewModelBuilder.build({ liveConnection, active, summary }));
 
   $effect(() => {
@@ -37,6 +39,7 @@
     summary = MetricsSampleSummaryBuilder.fromSamples(startSample, startSample, extrema);
     active = true;
     copied = false;
+    feedback = { variant: 'info', title: 'Metrics sampling', message: 'Metrics sample started.', testId: 'metrics-message' };
   }
 
   function stop(): void {
@@ -45,14 +48,25 @@
     }
     updateActiveSummary();
     active = false;
+    feedback = { variant: 'success', title: 'Metrics sample ready', message: 'Metrics sample stopped and summary is ready.', testId: 'metrics-message' };
   }
 
   async function copy(): Promise<void> {
     if (!summary) {
       return;
     }
-    await navigator.clipboard?.writeText(JSON.stringify(summary.payload, null, 2));
-    copied = true;
+    try {
+      await navigator.clipboard?.writeText(JSON.stringify(summary.payload, null, 2));
+      copied = true;
+      feedback = { variant: 'success', title: 'Metrics copied', message: 'Metrics diagnostics payload copied.', testId: 'metrics-message' };
+    } catch (error) {
+      feedback = {
+        variant: 'error',
+        title: 'Metrics copy failed',
+        message: error instanceof Error ? error.message : 'Could not copy metrics diagnostics payload.',
+        testId: 'metrics-message',
+      };
+    }
   }
 
   function reset(): void {
@@ -62,6 +76,7 @@
     extrema = null;
     summary = null;
     copied = false;
+    feedback = { variant: 'info', title: 'Metrics reset', message: 'Metrics sample state cleared.', testId: 'metrics-message' };
   }
 
   function updateActiveSummary(): void {
@@ -90,6 +105,7 @@
 <MetricsPanel
   {viewModel}
   {copied}
+  {feedback}
   onStart={start}
   onStop={stop}
   onCopy={() => void copy()}

--- a/code/web/bpane-admin/src/lib/application/MetricsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/MetricsSurface.svelte
@@ -22,7 +22,43 @@
   let summary = $state<MetricsSampleSummary | null>(null);
   let copied = $state(false);
   let feedback = $state<AdminMessageFeedback | null>(null);
+  let observedConnectionSessionId = $state<string | null>(null);
+  let connectionInitialized = false;
   const viewModel = $derived(MetricsViewModelBuilder.build({ liveConnection, active, summary }));
+
+  $effect(() => {
+    const nextSessionId = liveConnection?.sessionId ?? null;
+    if (!connectionInitialized) {
+      connectionInitialized = true;
+      observedConnectionSessionId = nextSessionId;
+      return;
+    }
+    if (nextSessionId === observedConnectionSessionId) {
+      return;
+    }
+    const previousSessionId = observedConnectionSessionId;
+    observedConnectionSessionId = nextSessionId;
+    copied = false;
+    if (active) {
+      active = false;
+      feedback = {
+        variant: 'warning',
+        title: 'Metrics sampling stopped',
+        message: 'The browser connection changed before the metrics sample was stopped.',
+        testId: 'metrics-message',
+      };
+      return;
+    }
+    if (summary && nextSessionId && previousSessionId && nextSessionId !== previousSessionId) {
+      clearSampleState();
+      feedback = {
+        variant: 'info',
+        title: 'Metrics reset',
+        message: 'Previous metrics were cleared for the new browser session.',
+        testId: 'metrics-message',
+      };
+    }
+  });
 
   $effect(() => {
     if (!active) {
@@ -70,13 +106,17 @@
   }
 
   function reset(): void {
+    clearSampleState();
+    feedback = { variant: 'info', title: 'Metrics reset', message: 'Metrics sample state cleared.', testId: 'metrics-message' };
+  }
+
+  function clearSampleState(): void {
     active = false;
     startSample = null;
     previousSample = null;
     extrema = null;
     summary = null;
     copied = false;
-    feedback = { variant: 'info', title: 'Metrics reset', message: 'Metrics sample state cleared.', testId: 'metrics-message' };
   }
 
   function updateActiveSummary(): void {

--- a/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
@@ -4,6 +4,7 @@
   import type { SessionResource } from '../api/control-types';
   import type { SessionRecordingPlaybackResource, SessionRecordingResource } from '../api/recording-types';
   import type { LiveBrowserSessionConnection } from '../session/browser-session-types';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import RecordingPanel from '../presentation/RecordingPanel.svelte';
   import { RecordingViewModelBuilder } from '../presentation/recording-view-model';
   import { saveBlob } from './recording-downloads';
@@ -33,6 +34,7 @@
   let lastBlob = $state<Blob | null>(null);
   let lastArtifactName = $state<string | null>(null);
   let error = $state<string | null>(null);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const activeConnection = $derived(liveConnection?.sessionId === currentSessionId ? liveConnection : null);
   const viewModel = $derived(RecordingViewModelBuilder.build({
     liveConnection: activeConnection,
@@ -52,7 +54,7 @@
 
   onMount(() => {
     const timer = window.setInterval(() => {
-      if (shouldReconcileLibrary()) void loadLibrary(currentSessionId);
+      if (shouldReconcileLibrary()) void loadLibrary(currentSessionId, false);
     }, LIBRARY_RECONCILE_INTERVAL_MS);
     return () => window.clearInterval(timer);
   });
@@ -63,10 +65,10 @@
       return;
     }
     currentSessionId = nextSessionId;
-    recordings = []; playback = null; libraryLoaded = false; libraryError = null;
+    recordings = []; playback = null; libraryLoaded = false; libraryError = null; feedback = null;
     libraryRequest += 1;
     if (nextSessionId) {
-      void loadLibrary(nextSessionId);
+      void loadLibrary(nextSessionId, false);
     }
   });
 
@@ -76,18 +78,21 @@
     }
     lastRefreshVersion = refreshVersion;
     if (currentSessionId) {
-      void loadLibrary(currentSessionId);
+      void loadLibrary(currentSessionId, false);
     }
   });
   $effect(() => { recording = activeConnection?.handle.isRecording?.() ?? false; });
 
-  async function loadLibrary(sessionId = currentSessionId): Promise<void> {
+  async function loadLibrary(sessionId = currentSessionId, showFeedback = true): Promise<void> {
     if (!sessionId) {
       return;
     }
     const requestId = ++libraryRequest;
     libraryLoading = true;
     libraryError = null;
+    if (showFeedback) {
+      feedback = null;
+    }
     try {
       const [recordingList, nextPlayback] = await Promise.all([
         controlClient.listSessionRecordings(sessionId),
@@ -97,6 +102,9 @@
         recordings = recordingList.recordings;
         playback = nextPlayback;
         libraryLoaded = true;
+        if (showFeedback) {
+          feedback = successFeedback(`Recording library refreshed with ${recordingList.recordings.length} segment${recordingList.recordings.length === 1 ? '' : 's'}.`);
+        }
       }
     } catch (loadError) {
       if (currentSessionId === sessionId && libraryRequest === requestId) {
@@ -104,6 +112,7 @@
         playback = null;
         libraryLoaded = true;
         libraryError = errorMessage(loadError);
+        feedback = null;
       }
     } finally {
       if (currentSessionId === sessionId && libraryRequest === requestId) {
@@ -119,9 +128,11 @@
     }
     downloadingRecordingId = recordingId;
     libraryError = null;
+    feedback = null;
     try {
       const blob = await controlClient.downloadSessionRecordingContent(segment);
       saveBlob(blob, `browserpane-${segment.session_id}-${segment.id}.webm`);
+      feedback = successFeedback('Recording segment download started.');
     } catch (downloadError) {
       libraryError = errorMessage(downloadError);
     } finally {
@@ -135,9 +146,11 @@
     }
     downloadingPlayback = true;
     libraryError = null;
+    feedback = null;
     try {
       const blob = await controlClient.downloadSessionRecordingPlaybackExport(playback);
       saveBlob(blob, `browserpane-${playback.session_id}-recording-playback.zip`);
+      feedback = successFeedback('Session recording export download started.');
     } catch (downloadError) {
       libraryError = errorMessage(downloadError);
     } finally {
@@ -151,9 +164,11 @@
     }
     busy = true;
     error = null;
+    feedback = null;
     try {
       await activeConnection.handle.startRecording({ frameRate: 24 });
       recording = true;
+      feedback = successFeedback('Recording started for the selected browser session.');
     } catch (startError) {
       error = errorMessage(startError);
     } finally {
@@ -167,10 +182,12 @@
     }
     busy = true;
     error = null;
+    feedback = null;
     try {
       lastBlob = await activeConnection.handle.stopRecording();
       lastArtifactName = `bpane-${activeConnection.sessionId}-${Date.now()}.webm`;
       recording = false;
+      feedback = successFeedback('Recording stopped. The latest WebM is ready.');
       if (autoDownload) {
         downloadLast();
       }
@@ -184,16 +201,31 @@
   function downloadLast(): void {
     if (lastBlob && lastArtifactName) {
       saveBlob(lastBlob, lastArtifactName);
+      feedback = successFeedback('Latest recording download started.');
     }
+  }
+
+  function setAutoDownload(enabled: boolean): void {
+    autoDownload = enabled;
+    feedback = {
+      variant: 'info',
+      title: 'Recording preference updated',
+      message: enabled ? 'Auto download is enabled.' : 'Auto download is disabled.',
+      testId: 'recording-message',
+    };
   }
 
   function shouldReconcileLibrary(): boolean { return Boolean(currentSessionId && !libraryLoading && !downloadingRecordingId && !downloadingPlayback); }
 
   function errorMessage(value: unknown): string { return value instanceof Error ? value.message : 'Recording operation failed'; }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Recording updated', message, testId: 'recording-message' };
+  }
 </script>
 
-<RecordingPanel {viewModel} {autoDownload}
-  onAutoDownloadChange={(enabled) => { autoDownload = enabled; }}
+<RecordingPanel {viewModel} {autoDownload} {feedback}
+  onAutoDownloadChange={setAutoDownload}
   onStart={() => void startRecording()} onStop={() => void stopRecording()} onDownload={downloadLast}
   onRefreshLibrary={() => void loadLibrary()} onDownloadSegment={(recordingId) => void downloadSegment(recordingId)}
   onDownloadPlayback={() => void downloadPlaybackExport()} />

--- a/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
@@ -65,7 +65,19 @@
       return;
     }
     currentSessionId = nextSessionId;
-    recordings = []; playback = null; libraryLoaded = false; libraryError = null; feedback = null;
+    recordings = [];
+    playback = null;
+    libraryLoading = false;
+    libraryLoaded = false;
+    libraryError = null;
+    downloadingRecordingId = null;
+    downloadingPlayback = false;
+    recording = false;
+    busy = false;
+    lastBlob = null;
+    lastArtifactName = null;
+    error = null;
+    feedback = null;
     libraryRequest += 1;
     if (nextSessionId) {
       void loadLibrary(nextSessionId, false);

--- a/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/RecordingSurface.svelte
@@ -134,8 +134,9 @@
   }
 
   async function downloadSegment(recordingId: string): Promise<void> {
+    const requestSessionId = currentSessionId;
     const segment = recordings.find((entry) => entry.id === recordingId);
-    if (!segment) {
+    if (!segment || !requestSessionId || segment.session_id !== requestSessionId) {
       return;
     }
     downloadingRecordingId = recordingId;
@@ -144,69 +145,101 @@
     try {
       const blob = await controlClient.downloadSessionRecordingContent(segment);
       saveBlob(blob, `browserpane-${segment.session_id}-${segment.id}.webm`);
-      feedback = successFeedback('Recording segment download started.');
+      if (currentSessionId === requestSessionId) {
+        feedback = successFeedback('Recording segment download started.');
+      }
     } catch (downloadError) {
-      libraryError = errorMessage(downloadError);
+      if (currentSessionId === requestSessionId) {
+        libraryError = errorMessage(downloadError);
+      }
     } finally {
-      downloadingRecordingId = null;
+      if (currentSessionId === requestSessionId) {
+        downloadingRecordingId = null;
+      }
     }
   }
 
   async function downloadPlaybackExport(): Promise<void> {
-    if (!playback) {
+    const requestSessionId = currentSessionId;
+    const activePlayback = playback;
+    if (!activePlayback || !requestSessionId || activePlayback.session_id !== requestSessionId) {
       return;
     }
     downloadingPlayback = true;
     libraryError = null;
     feedback = null;
     try {
-      const blob = await controlClient.downloadSessionRecordingPlaybackExport(playback);
-      saveBlob(blob, `browserpane-${playback.session_id}-recording-playback.zip`);
-      feedback = successFeedback('Session recording export download started.');
+      const blob = await controlClient.downloadSessionRecordingPlaybackExport(activePlayback);
+      saveBlob(blob, `browserpane-${activePlayback.session_id}-recording-playback.zip`);
+      if (currentSessionId === requestSessionId) {
+        feedback = successFeedback('Session recording export download started.');
+      }
     } catch (downloadError) {
-      libraryError = errorMessage(downloadError);
+      if (currentSessionId === requestSessionId) {
+        libraryError = errorMessage(downloadError);
+      }
     } finally {
-      downloadingPlayback = false;
+      if (currentSessionId === requestSessionId) {
+        downloadingPlayback = false;
+      }
     }
   }
 
   async function startRecording(): Promise<void> {
-    if (!activeConnection?.handle.startRecording) {
+    const connection = activeConnection;
+    const requestSessionId = connection?.sessionId ?? null;
+    if (!connection?.handle.startRecording || !requestSessionId) {
       return;
     }
     busy = true;
     error = null;
     feedback = null;
     try {
-      await activeConnection.handle.startRecording({ frameRate: 24 });
-      recording = true;
-      feedback = successFeedback('Recording started for the selected browser session.');
+      await connection.handle.startRecording({ frameRate: 24 });
+      if (currentSessionId === requestSessionId) {
+        recording = true;
+        feedback = successFeedback('Recording started for the selected browser session.');
+      }
     } catch (startError) {
-      error = errorMessage(startError);
+      if (currentSessionId === requestSessionId) {
+        error = errorMessage(startError);
+      }
     } finally {
-      busy = false;
+      if (currentSessionId === requestSessionId) {
+        busy = false;
+      }
     }
   }
 
   async function stopRecording(): Promise<void> {
-    if (!activeConnection?.handle.stopRecording) {
+    const connection = activeConnection;
+    const requestSessionId = connection?.sessionId ?? null;
+    if (!connection?.handle.stopRecording || !requestSessionId) {
       return;
     }
     busy = true;
     error = null;
     feedback = null;
     try {
-      lastBlob = await activeConnection.handle.stopRecording();
-      lastArtifactName = `bpane-${activeConnection.sessionId}-${Date.now()}.webm`;
+      const stoppedBlob = await connection.handle.stopRecording();
+      if (currentSessionId !== requestSessionId) {
+        return;
+      }
+      lastBlob = stoppedBlob;
+      lastArtifactName = `bpane-${connection.sessionId}-${Date.now()}.webm`;
       recording = false;
       feedback = successFeedback('Recording stopped. The latest WebM is ready.');
       if (autoDownload) {
         downloadLast();
       }
     } catch (stopError) {
-      error = errorMessage(stopError);
+      if (currentSessionId === requestSessionId) {
+        error = errorMessage(stopError);
+      }
     } finally {
-      busy = false;
+      if (currentSessionId === requestSessionId) {
+        busy = false;
+      }
     }
   }
 

--- a/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
@@ -92,6 +92,8 @@
 
   async function loadBindingsAndWorkspaces(showFeedback = true): Promise<void> {
     const requestSessionId = sessionId;
+    const previousBindingCount = bindings.length;
+    const previousWorkspaceCount = workspaces.length;
     loading = true;
     error = null;
     actionMessage = null;
@@ -126,7 +128,12 @@
           .join(' | ');
       }
       if (showFeedback && !error) {
-        actionMessage = `Refreshed ${bindings.length} binding${bindings.length === 1 ? '' : 's'} and ${workspaces.length} workspace${workspaces.length === 1 ? '' : 's'}.`;
+        actionMessage = refreshMessage(
+          previousBindingCount,
+          bindings.length,
+          previousWorkspaceCount,
+          workspaces.length,
+        );
       }
     } finally {
       if (loadedSessionId === requestSessionId) {
@@ -271,6 +278,21 @@
 
   function errorMessage(value: unknown, fallback: string): string {
     return value instanceof Error ? value.message : fallback;
+  }
+
+  function refreshMessage(
+    previousBindingCount: number,
+    nextBindingCount: number,
+    previousWorkspaceCount: number,
+    nextWorkspaceCount: number,
+  ): string {
+    if (previousBindingCount !== nextBindingCount) {
+      return `Binding count changed from ${previousBindingCount} to ${nextBindingCount}.`;
+    }
+    if (previousWorkspaceCount !== nextWorkspaceCount) {
+      return `Workspace count changed from ${previousWorkspaceCount} to ${nextWorkspaceCount}.`;
+    }
+    return `Refreshed ${nextBindingCount} binding${nextBindingCount === 1 ? '' : 's'} and ${nextWorkspaceCount} workspace${nextWorkspaceCount === 1 ? '' : 's'}.`;
   }
 </script>
 

--- a/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
@@ -12,6 +12,7 @@
     validateSessionMountPath,
     type SessionFileBindingViewModel,
   } from '../presentation/file-workspace-view-model';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
 
   type SessionFileBindingsSurfaceProps = {
     readonly controlClient: ControlClient;
@@ -58,7 +59,7 @@
       return;
     }
     loadedSessionId = sessionId;
-    void loadBindingsAndWorkspaces();
+    void loadBindingsAndWorkspaces(false);
   });
 
   $effect(() => {
@@ -66,7 +67,7 @@
       return;
     }
     lastRefreshVersion = refreshVersion;
-    void loadBindingsAndWorkspaces();
+    void loadBindingsAndWorkspaces(false);
   });
 
   $effect(() => {
@@ -77,7 +78,7 @@
     void loadWorkspaceFiles(selectedWorkspaceId);
   });
 
-  async function loadBindingsAndWorkspaces(): Promise<void> {
+  async function loadBindingsAndWorkspaces(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
     actionMessage = null;
@@ -108,6 +109,9 @@
           .filter(Boolean)
           .join(' | ');
       }
+      if (showFeedback && !error) {
+        actionMessage = `Refreshed ${bindings.length} binding${bindings.length === 1 ? '' : 's'} and ${workspaces.length} workspace${workspaces.length === 1 ? '' : 's'}.`;
+      }
     } finally {
       loading = false;
     }
@@ -133,6 +137,7 @@
   }
 
   async function createBinding(): Promise<void> {
+    actionMessage = null;
     if (!selectedWorkspaceId || !selectedFileId) {
       error = 'Choose a workspace file before creating a binding.';
       return;
@@ -143,7 +148,6 @@
     }
     mutating = true;
     error = null;
-    actionMessage = null;
     try {
       const created = await controlClient.createSessionFileBinding(sessionId, {
         workspace_id: selectedWorkspaceId,
@@ -186,9 +190,11 @@
     }
     downloadingBindingId = bindingId;
     error = null;
+    actionMessage = null;
     try {
       const blob = await controlClient.downloadSessionFileBindingContent(binding);
       triggerDownload(blob, binding.file_name);
+      actionMessage = `Download started for ${binding.file_name}.`;
     } catch (downloadError) {
       error = errorMessage(downloadError, 'Unexpected session file binding download error');
     } finally {
@@ -318,22 +324,28 @@
   </div>
 
   {#if error}
-    <p class="admin-error mt-0" data-testid="session-file-bindings-error">{error}</p>
+    <AdminMessage variant="error" message={error} testId="session-file-bindings-error" compact={true} />
   {/if}
   {#if actionMessage}
-    <p class="m-0 text-sm font-bold text-admin-leaf" data-testid="session-file-bindings-message">{actionMessage}</p>
+    <AdminMessage variant="success" message={actionMessage} testId="session-file-bindings-message" compact={true} />
   {/if}
 
   {#if loading && bindings.length === 0}
-    <p class="admin-empty mt-0">Loading session file bindings...</p>
+    <AdminMessage variant="loading" message="Loading session file bindings..." compact={true} />
   {:else if workspaces.length === 0}
-    <p class="admin-empty mt-0" data-testid="session-file-bindings-empty">
-      No file workspaces are available. Create a workspace before binding inputs into this session.
-    </p>
+    <AdminMessage
+      variant="empty"
+      message="No file workspaces are available. Create a workspace before binding inputs into this session."
+      testId="session-file-bindings-empty"
+      compact={true}
+    />
   {:else if bindingRows.length === 0}
-    <p class="admin-empty mt-0" data-testid="session-file-bindings-empty">
-      No workspace files are bound to this session yet.
-    </p>
+    <AdminMessage
+      variant="empty"
+      message="No workspace files are bound to this session yet."
+      testId="session-file-bindings-empty"
+      compact={true}
+    />
   {:else}
     <div class="grid gap-3">
       {#each bindingRows as binding}

--- a/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFileBindingsSurface.svelte
@@ -59,6 +59,18 @@
       return;
     }
     loadedSessionId = sessionId;
+    loadedWorkspaceId = null;
+    bindings = [];
+    workspaceFiles = [];
+    selectedFileId = '';
+    mountPath = '';
+    loading = false;
+    loadingFiles = false;
+    mutating = false;
+    downloadingBindingId = null;
+    error = null;
+    actionMessage = null;
+    onBindingCountChange?.(0);
     void loadBindingsAndWorkspaces(false);
   });
 
@@ -79,14 +91,18 @@
   });
 
   async function loadBindingsAndWorkspaces(showFeedback = true): Promise<void> {
+    const requestSessionId = sessionId;
     loading = true;
     error = null;
     actionMessage = null;
     try {
       const [bindingResult, workspaceResult] = await Promise.allSettled([
-        controlClient.listSessionFileBindings(sessionId),
+        controlClient.listSessionFileBindings(requestSessionId),
         controlClient.listFileWorkspaces(),
       ]);
+      if (loadedSessionId !== requestSessionId) {
+        return;
+      }
       if (bindingResult.status === 'fulfilled') {
         bindings = bindingResult.value.bindings;
         onBindingCountChange?.(bindingResult.value.bindings.length);
@@ -113,7 +129,9 @@
         actionMessage = `Refreshed ${bindings.length} binding${bindings.length === 1 ? '' : 's'} and ${workspaces.length} workspace${workspaces.length === 1 ? '' : 's'}.`;
       }
     } finally {
-      loading = false;
+      if (loadedSessionId === requestSessionId) {
+        loading = false;
+      }
     }
   }
 
@@ -122,21 +140,30 @@
     error = null;
     try {
       const response = await controlClient.listFileWorkspaceFiles(workspaceId);
+      if (loadedWorkspaceId !== workspaceId) {
+        return;
+      }
       workspaceFiles = response.files;
       selectedFileId = response.files[0]?.id ?? '';
       if (selectedFileId && !mountPath.trim()) {
         mountPath = `uploads/${response.files[0]?.name ?? 'input-file'}`;
       }
     } catch (loadError) {
+      if (loadedWorkspaceId !== workspaceId) {
+        return;
+      }
       workspaceFiles = [];
       selectedFileId = '';
       error = errorMessage(loadError, 'Workspace files are unavailable.');
     } finally {
-      loadingFiles = false;
+      if (loadedWorkspaceId === workspaceId) {
+        loadingFiles = false;
+      }
     }
   }
 
   async function createBinding(): Promise<void> {
+    const requestSessionId = sessionId;
     actionMessage = null;
     if (!selectedWorkspaceId || !selectedFileId) {
       error = 'Choose a workspace file before creating a binding.';
@@ -149,41 +176,57 @@
     mutating = true;
     error = null;
     try {
-      const created = await controlClient.createSessionFileBinding(sessionId, {
+      const created = await controlClient.createSessionFileBinding(requestSessionId, {
         workspace_id: selectedWorkspaceId,
         file_id: selectedFileId,
         mount_path: validation.value,
         mode,
         labels: { source: 'admin' },
       });
+      if (loadedSessionId !== requestSessionId) {
+        return;
+      }
       bindings = [created, ...bindings.filter((binding) => binding.id !== created.id)];
       onBindingCountChange?.(bindings.length);
       actionMessage = `Bound ${created.file_name} to ${created.mount_path}.`;
       mountPath = '';
     } catch (createError) {
-      error = errorMessage(createError, 'Unexpected session file binding create error');
+      if (loadedSessionId === requestSessionId) {
+        error = errorMessage(createError, 'Unexpected session file binding create error');
+      }
     } finally {
-      mutating = false;
+      if (loadedSessionId === requestSessionId) {
+        mutating = false;
+      }
     }
   }
 
   async function removeBinding(bindingId: string): Promise<void> {
+    const requestSessionId = sessionId;
     mutating = true;
     error = null;
     actionMessage = null;
     try {
-      const removed = await controlClient.removeSessionFileBinding(sessionId, bindingId);
+      const removed = await controlClient.removeSessionFileBinding(requestSessionId, bindingId);
+      if (loadedSessionId !== requestSessionId) {
+        return;
+      }
       bindings = bindings.filter((binding) => binding.id !== bindingId);
       onBindingCountChange?.(bindings.length);
       actionMessage = `Removed binding for ${removed.file_name}.`;
     } catch (removeError) {
-      error = errorMessage(removeError, 'Unexpected session file binding remove error');
+      if (loadedSessionId === requestSessionId) {
+        error = errorMessage(removeError, 'Unexpected session file binding remove error');
+      }
     } finally {
-      mutating = false;
+      if (loadedSessionId === requestSessionId) {
+        mutating = false;
+      }
     }
   }
 
   async function downloadBinding(bindingId: string): Promise<void> {
+    const requestSessionId = sessionId;
     const binding = bindings.find((entry) => entry.id === bindingId);
     if (!binding) {
       return;
@@ -194,11 +237,17 @@
     try {
       const blob = await controlClient.downloadSessionFileBindingContent(binding);
       triggerDownload(blob, binding.file_name);
-      actionMessage = `Download started for ${binding.file_name}.`;
+      if (loadedSessionId === requestSessionId) {
+        actionMessage = `Download started for ${binding.file_name}.`;
+      }
     } catch (downloadError) {
-      error = errorMessage(downloadError, 'Unexpected session file binding download error');
+      if (loadedSessionId === requestSessionId) {
+        error = errorMessage(downloadError, 'Unexpected session file binding download error');
+      }
     } finally {
-      downloadingBindingId = null;
+      if (loadedSessionId === requestSessionId) {
+        downloadingBindingId = null;
+      }
     }
   }
 

--- a/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
@@ -30,6 +30,8 @@
     currentSessionId = nextSessionId;
     files = [];
     onFileCountChange?.(0);
+    loading = false;
+    downloadingFileId = null;
     error = null;
     actionMessage = null;
     if (nextSessionId) {
@@ -76,8 +78,9 @@
   }
 
   async function downloadFile(fileId: string): Promise<void> {
+    const sessionId = currentSessionId;
     const file = files.find((entry) => entry.id === fileId);
-    if (!file) {
+    if (!file || !sessionId) {
       return;
     }
     downloadingFileId = file.id;
@@ -96,11 +99,17 @@
       } finally {
         URL.revokeObjectURL(url);
       }
-      actionMessage = `Download started for ${file.name}.`;
+      if (currentSessionId === sessionId) {
+        actionMessage = `Download started for ${file.name}.`;
+      }
     } catch (downloadError) {
-      error = errorMessage(downloadError);
+      if (currentSessionId === sessionId) {
+        error = errorMessage(downloadError);
+      }
     } finally {
-      downloadingFileId = null;
+      if (currentSessionId === sessionId) {
+        downloadingFileId = null;
+      }
     }
   }
 

--- a/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionFilesSurface.svelte
@@ -2,6 +2,7 @@
   import { base } from '$app/paths';
   import type { ControlClient } from '../api/control-client';
   import type { SessionFileResource, SessionResource } from '../api/control-types';
+  import AdminMessage from '../presentation/AdminMessage.svelte';
   import SessionFileCard from '../presentation/SessionFileCard.svelte';
   import { SessionFileViewModelBuilder } from '../presentation/session-file-view-model';
 
@@ -18,6 +19,7 @@
   let files = $state<readonly SessionFileResource[]>([]);
   let loading = $state(false);
   let error = $state<string | null>(null);
+  let actionMessage = $state<string | null>(null);
   let downloadingFileId = $state<string | null>(null);
 
   $effect(() => {
@@ -29,8 +31,9 @@
     files = [];
     onFileCountChange?.(0);
     error = null;
+    actionMessage = null;
     if (nextSessionId) {
-      void loadFiles(nextSessionId);
+      void loadFiles(nextSessionId, false);
     }
   });
 
@@ -40,25 +43,30 @@
     }
     lastRefreshVersion = refreshVersion;
     if (currentSessionId) {
-      void loadFiles(currentSessionId);
+      void loadFiles(currentSessionId, false);
     }
   });
 
-  async function loadFiles(sessionId = currentSessionId): Promise<void> {
+  async function loadFiles(sessionId = currentSessionId, showFeedback = true): Promise<void> {
     if (!sessionId) {
       return;
     }
     loading = true;
     error = null;
+    actionMessage = null;
     try {
       const response = await controlClient.listSessionFiles(sessionId);
       if (currentSessionId === sessionId) {
         files = response.files;
         onFileCountChange?.(response.files.length);
+        if (showFeedback) {
+          actionMessage = `Refreshed ${response.files.length} runtime file${response.files.length === 1 ? '' : 's'}.`;
+        }
       }
     } catch (loadError) {
       if (currentSessionId === sessionId) {
         error = errorMessage(loadError);
+        actionMessage = null;
       }
     } finally {
       if (currentSessionId === sessionId) {
@@ -74,6 +82,7 @@
     }
     downloadingFileId = file.id;
     error = null;
+    actionMessage = null;
     try {
       const blob = await controlClient.downloadSessionFileContent(file);
       const url = URL.createObjectURL(blob);
@@ -87,6 +96,7 @@
       } finally {
         URL.revokeObjectURL(url);
       }
+      actionMessage = `Download started for ${file.name}.`;
     } catch (downloadError) {
       error = errorMessage(downloadError);
     } finally {
@@ -119,13 +129,28 @@
   </div>
 
   {#if error}
-    <p class="admin-error" data-testid="session-files-error">{error}</p>
-  {:else if !session}
-    <p class="admin-empty" data-testid="session-files-empty">Select a session to inspect file artifacts.</p>
+    <AdminMessage variant="error" message={error} testId="session-files-error" compact={true} />
+  {/if}
+  {#if actionMessage}
+    <AdminMessage variant="success" message={actionMessage} testId="session-files-message" compact={true} />
+  {/if}
+
+  {#if !session}
+    <AdminMessage
+      variant="empty"
+      message="Select a session to inspect file artifacts."
+      testId="session-files-empty"
+      compact={true}
+    />
   {:else if loading}
-    <p class="admin-empty">Loading runtime upload/download artifacts...</p>
+    <AdminMessage variant="loading" message="Loading runtime upload/download artifacts..." compact={true} />
   {:else if files.length === 0}
-    <p class="admin-empty" data-testid="session-files-empty">No runtime files are recorded for this session yet.</p>
+    <AdminMessage
+      variant="empty"
+      message="No runtime files are recorded for this session yet."
+      testId="session-files-empty"
+      compact={true}
+    />
   {:else}
     <div class="mt-[18px] grid gap-3">
       {#each files as file (file.id)}

--- a/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
@@ -29,6 +29,7 @@
   }: SessionLifecycleSurfaceProps = $props();
 
   let status = $state<SessionStatus | null>(null);
+  let lifecycleSessionId = $state<string | null>(null);
   let statusSessionId = $state<string | null>(null);
   let requestedSessionId = $state<string | null>(null);
   let statusLoading = $state(false);
@@ -46,10 +47,17 @@
 
   $effect(() => {
     const sessionId = selectedSession?.id ?? null;
+    if (sessionId !== lifecycleSessionId) {
+      lifecycleSessionId = sessionId;
+      statusError = null;
+      feedback = null;
+    }
     if (!sessionId) {
       status = null;
       statusSessionId = null;
       requestedSessionId = null;
+      statusError = null;
+      feedback = null;
       return;
     }
     if (sessionId !== statusSessionId && sessionId !== requestedSessionId) {

--- a/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
@@ -3,6 +3,7 @@
   import type { SessionResource } from '../api/control-types';
   import type { SessionStatus } from '../api/session-status-types';
   import SessionDetailPanel from '../presentation/SessionDetailPanel.svelte';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import { SessionViewModelBuilder } from '../presentation/session-view-model';
 
   type SessionLifecycleSurfaceProps = {
@@ -11,8 +12,8 @@
     readonly connected: boolean;
     readonly resourceLoading: boolean;
     readonly onRefreshSelectedSession: () => Promise<void>;
-    readonly onStopSession: () => void;
-    readonly onKillSession: () => void;
+    readonly onStopSession: () => Promise<void>;
+    readonly onKillSession: () => Promise<void>;
     readonly onDisconnectEmbeddedBrowser: () => void;
   };
 
@@ -32,6 +33,7 @@
   let requestedSessionId = $state<string | null>(null);
   let statusLoading = $state(false);
   let statusError = $state<string | null>(null);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   const visibleStatus = $derived(statusSessionId === selectedSession?.id ? status : null);
   const loading = $derived(resourceLoading || statusLoading);
   const viewModel = $derived(SessionViewModelBuilder.detail({
@@ -56,8 +58,15 @@
   });
 
   async function refreshPanel(): Promise<void> {
-    await onRefreshSelectedSession();
-    await refreshStatus();
+    feedback = loadingFeedback('Refreshing session status...');
+    try {
+      await onRefreshSelectedSession();
+      await refreshStatus();
+      feedback = successFeedback('Session status refreshed.');
+    } catch (error) {
+      statusError = errorMessage(error);
+      feedback = null;
+    }
   }
 
   async function refreshStatus(): Promise<void> {
@@ -72,7 +81,12 @@
     if (!sessionId) {
       return;
     }
-    await runDisconnect(sessionId, () => controlClient.disconnectSessionConnection(sessionId, connectionId));
+    await runDisconnect(
+      sessionId,
+      `Disconnecting client #${connectionId}...`,
+      `Disconnected client #${connectionId}.`,
+      () => controlClient.disconnectSessionConnection(sessionId, connectionId),
+    );
   }
 
   async function disconnectAllConnections(): Promise<void> {
@@ -80,24 +94,50 @@
     if (!sessionId) {
       return;
     }
-    await runDisconnect(sessionId, () => controlClient.disconnectAllSessionConnections(sessionId));
+    await runDisconnect(
+      sessionId,
+      'Disconnecting all live clients...',
+      'Disconnected all live clients.',
+      () => controlClient.disconnectAllSessionConnections(sessionId),
+    );
   }
 
   async function runDisconnect(
     sessionId: string,
+    progressMessage: string,
+    successMessage: string,
     action: () => Promise<SessionStatus>,
   ): Promise<void> {
     statusLoading = true;
     statusError = null;
+    feedback = loadingFeedback(progressMessage);
     try {
       const nextStatus = await action();
       applyStatus(sessionId, nextStatus);
       syncEmbeddedBrowserAfterDisconnect(nextStatus);
       await onRefreshSelectedSession();
+      feedback = successFeedback(successMessage);
     } catch (error) {
       statusError = errorMessage(error);
+      feedback = null;
     } finally {
       statusLoading = false;
+    }
+  }
+
+  async function runLifecycleAction(
+    progressMessage: string,
+    successMessage: string,
+    action: () => Promise<void>,
+  ): Promise<void> {
+    feedback = loadingFeedback(progressMessage);
+    try {
+      await action();
+      await refreshStatus();
+      feedback = successFeedback(successMessage);
+    } catch (error) {
+      statusError = errorMessage(error);
+      feedback = null;
     }
   }
 
@@ -131,13 +171,22 @@
   function errorMessage(error: unknown): string {
     return error instanceof Error ? error.message : 'Unexpected session status error';
   }
+
+  function loadingFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'loading', title: 'Lifecycle operation', message, testId: 'session-lifecycle-message' };
+  }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Lifecycle updated', message, testId: 'session-lifecycle-message' };
+  }
 </script>
 
 <SessionDetailPanel
   {viewModel}
+  {feedback}
   onRefresh={() => void refreshPanel()}
-  onStop={onStopSession}
-  onKill={onKillSession}
+  onStop={() => void runLifecycleAction('Stopping selected session...', 'Selected session stopped.', onStopSession)}
+  onKill={() => void runLifecycleAction('Killing selected session...', 'Selected session was force killed.', onKillSession)}
   onDisconnectConnection={(connectionId) => void disconnectConnection(connectionId)}
   onDisconnectAll={() => void disconnectAllConnections()}
 />

--- a/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
@@ -49,6 +49,7 @@
     const sessionId = selectedSession?.id ?? null;
     if (sessionId !== lifecycleSessionId) {
       lifecycleSessionId = sessionId;
+      statusLoading = false;
       statusError = null;
       feedback = null;
     }
@@ -66,14 +67,25 @@
   });
 
   async function refreshPanel(): Promise<void> {
+    const requestSessionId = selectedSession?.id ?? null;
+    if (!requestSessionId) {
+      return;
+    }
     feedback = loadingFeedback('Refreshing session status...');
     try {
       await onRefreshSelectedSession();
-      await refreshStatus();
-      feedback = successFeedback('Session status refreshed.');
+      if (!isCurrentSession(requestSessionId)) {
+        return;
+      }
+      await refreshStatusFor(requestSessionId);
+      if (isCurrentSession(requestSessionId)) {
+        feedback = successFeedback('Session status refreshed.');
+      }
     } catch (error) {
-      statusError = errorMessage(error);
-      feedback = null;
+      if (isCurrentSession(requestSessionId)) {
+        statusError = errorMessage(error);
+        feedback = null;
+      }
     }
   }
 
@@ -121,15 +133,24 @@
     feedback = loadingFeedback(progressMessage);
     try {
       const nextStatus = await action();
+      if (!isCurrentSession(sessionId)) {
+        return;
+      }
       applyStatus(sessionId, nextStatus);
       syncEmbeddedBrowserAfterDisconnect(nextStatus);
       await onRefreshSelectedSession();
-      feedback = successFeedback(successMessage);
+      if (isCurrentSession(sessionId)) {
+        feedback = successFeedback(successMessage);
+      }
     } catch (error) {
-      statusError = errorMessage(error);
-      feedback = null;
+      if (isCurrentSession(sessionId)) {
+        statusError = errorMessage(error);
+        feedback = null;
+      }
     } finally {
-      statusLoading = false;
+      if (isCurrentSession(sessionId)) {
+        statusLoading = false;
+      }
     }
   }
 
@@ -138,14 +159,25 @@
     successMessage: string,
     action: () => Promise<void>,
   ): Promise<void> {
+    const requestSessionId = selectedSession?.id ?? null;
+    if (!requestSessionId) {
+      return;
+    }
     feedback = loadingFeedback(progressMessage);
     try {
       await action();
-      await refreshStatus();
-      feedback = successFeedback(successMessage);
+      if (!isCurrentSession(requestSessionId)) {
+        return;
+      }
+      await refreshStatusFor(requestSessionId);
+      if (isCurrentSession(requestSessionId)) {
+        feedback = successFeedback(successMessage);
+      }
     } catch (error) {
-      statusError = errorMessage(error);
-      feedback = null;
+      if (isCurrentSession(requestSessionId)) {
+        statusError = errorMessage(error);
+        feedback = null;
+      }
     }
   }
 
@@ -154,13 +186,20 @@
     statusLoading = true;
     statusError = null;
     try {
-      applyStatus(sessionId, await controlClient.getSessionStatus(sessionId));
+      const nextStatus = await controlClient.getSessionStatus(sessionId);
+      if (isCurrentSession(sessionId) && requestedSessionId === sessionId) {
+        applyStatus(sessionId, nextStatus);
+      }
     } catch (error) {
-      statusError = errorMessage(error);
+      if (isCurrentSession(sessionId) && requestedSessionId === sessionId) {
+        statusError = errorMessage(error);
+      }
     } finally {
       if (requestedSessionId === sessionId) {
         requestedSessionId = null;
-        statusLoading = false;
+        if (isCurrentSession(sessionId)) {
+          statusLoading = false;
+        }
       }
     }
   }
@@ -174,6 +213,10 @@
     if (connected && nextStatus.connection_counts.total_clients === 0) {
       onDisconnectEmbeddedBrowser();
     }
+  }
+
+  function isCurrentSession(sessionId: string): boolean {
+    return selectedSession?.id === sessionId;
   }
 
   function errorMessage(error: unknown): string {

--- a/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
@@ -62,6 +62,7 @@
     events = [];
     logs = [];
     files = [];
+    actionInFlight = false;
     error = null;
     feedback = null;
   });
@@ -90,6 +91,7 @@
   async function selectWorkflow(workflowId: string): Promise<void> {
     error = null;
     feedback = null;
+    actionInFlight = false;
     selectedWorkflowId = workflowId;
     selectedVersion = definitions.find((entry) => entry.id === workflowId)?.latest_version ?? '';
     selectedVersionResource = null;
@@ -99,21 +101,28 @@
   function updateSelectedVersion(version: string): void {
     selectedVersion = version.trim();
     selectedVersionResource = null;
+    actionInFlight = false;
     error = null;
     feedback = null;
   }
 
   async function loadSelectedVersion(): Promise<void> {
+    const workflowId = selectedWorkflowId;
+    const version = selectedVersion;
     selectedVersionResource = null;
-    if (!selectedWorkflowId || !selectedVersion) {
+    if (!workflowId || !version) {
       return;
     }
     await runAction(async () => {
-      selectedVersionResource = await workflowService.loadVersionOrNull(
-        selectedWorkflowId,
-        selectedVersion,
+      const resource = await workflowService.loadVersionOrNull(
+        workflowId,
+        version,
       );
-    });
+      if (!isCurrentWorkflowSelection(workflowId, version)) {
+        return false;
+      }
+      selectedVersionResource = resource;
+    }, undefined, () => isCurrentWorkflowSelection(workflowId, version));
   }
 
   async function invokeRun(): Promise<void> {
@@ -127,36 +136,56 @@
       feedback = null;
       return;
     }
+    const sessionId = selectedSession.id;
+    const workflowId = selectedWorkflowId;
+    const version = selectedVersion;
     await runAction(async () => {
-      if (!selectedVersionResource) {
-        selectedVersionResource = await workflowService.loadVersionOrNull(
-          selectedWorkflowId,
-          selectedVersion,
-        );
+      let versionResource = selectedVersionResource;
+      if (!versionResource) {
+        versionResource = await workflowService.loadVersionOrNull(workflowId, version);
+        if (!isCurrentSession(sessionId) || !isCurrentWorkflowSelection(workflowId, version)) {
+          return false;
+        }
+        selectedVersionResource = versionResource;
       }
-      currentRun = await workflowService.invokeRun({
-        sessionId: selectedSession.id,
-        workflowId: selectedWorkflowId,
-        version: selectedVersion,
+      const run = await workflowService.invokeRun({
+        sessionId,
+        workflowId,
+        version,
         runInput: parseJson(inputText),
       });
-      await refreshRunResources(false);
-    }, () => currentRun ? `Workflow run ${shortId(currentRun.id)} was invoked.` : 'Workflow run was invoked.');
+      if (!isCurrentSession(sessionId) || run.session_id !== sessionId) {
+        return false;
+      }
+      currentRun = run;
+      await refreshRunResources(false, sessionId, run.id);
+    }, () => currentRun ? `Workflow run ${shortId(currentRun.id)} was invoked.` : 'Workflow run was invoked.', () => isCurrentSession(sessionId));
   }
 
-  async function refreshRunResources(withBusy = true): Promise<void> {
-    if (!currentRun) {
+  async function refreshRunResources(
+    withBusy = true,
+    requestSessionId = currentRun?.session_id ?? currentSessionId,
+    runId = currentRun?.id ?? null,
+  ): Promise<void> {
+    if (!requestSessionId || !runId) {
       return;
     }
     const refresh = async (): Promise<void> => {
-      const snapshot = await workflowService.refreshRun(currentRun!.id);
+      const snapshot = await workflowService.refreshRun(runId);
+      if (!isCurrentSession(requestSessionId) || snapshot.run.session_id !== requestSessionId || snapshot.run.id !== runId) {
+        return;
+      }
       currentRun = snapshot.run;
       events = snapshot.events;
       logs = snapshot.logs;
       files = snapshot.files;
     };
     if (withBusy) {
-      await runAction(refresh, () => currentRun ? `Workflow run ${shortId(currentRun.id)} refreshed.` : 'Workflow run refreshed.');
+      await runAction(
+        refresh,
+        () => currentRun ? `Workflow run ${shortId(currentRun.id)} refreshed.` : 'Workflow run refreshed.',
+        () => isCurrentSession(requestSessionId) && currentRun?.id === runId,
+      );
     } else {
       await refresh();
     }
@@ -164,37 +193,53 @@
 
   async function mutateRun(
     successMessage: (run: WorkflowRunResource) => string,
-    action: () => Promise<WorkflowRunResource>,
+    action: (run: WorkflowRunResource) => Promise<WorkflowRunResource>,
   ): Promise<void> {
+    const initialRun = currentRun;
+    if (!initialRun) {
+      return;
+    }
+    const requestSessionId = initialRun.session_id;
+    const runId = initialRun.id;
     await runAction(async () => {
-      currentRun = await action();
-      await refreshRunResources(false);
-    }, () => currentRun ? successMessage(currentRun) : 'Workflow run updated.');
+      const updated = await action(initialRun);
+      if (!isCurrentSession(requestSessionId) || updated.session_id !== requestSessionId || updated.id !== runId) {
+        return false;
+      }
+      currentRun = updated;
+      await refreshRunResources(false, requestSessionId, runId);
+    }, () => currentRun ? successMessage(currentRun) : 'Workflow run updated.', () => isCurrentSession(requestSessionId) && currentRun?.id === runId);
   }
 
   async function runAction(
-    action: () => Promise<void>,
+    action: () => Promise<boolean | void>,
     successMessage?: () => string,
+    isCurrent = () => true,
   ): Promise<void> {
     actionInFlight = true;
     error = null;
     feedback = null;
     try {
-      await action();
-      if (successMessage) {
+      const applied = await action();
+      if (applied !== false && successMessage && isCurrent()) {
         feedback = successFeedback(successMessage());
       }
     } catch (actionError) {
-      error = errorMessage(actionError);
-      feedback = null;
+      if (isCurrent()) {
+        error = errorMessage(actionError);
+        feedback = null;
+      }
     } finally {
-      actionInFlight = false;
+      if (isCurrent()) {
+        actionInFlight = false;
+      }
     }
   }
 
   async function downloadProducedFile(fileId: string): Promise<void> {
+    const requestSessionId = currentRun?.session_id ?? currentSessionId;
     const file = files.find((entry) => entry.file_id === fileId);
-    if (!file) {
+    if (!file || !requestSessionId) {
       return;
     }
     error = null;
@@ -208,10 +253,14 @@
       link.click();
       link.remove();
       URL.revokeObjectURL(url);
-      feedback = successFeedback(`Produced file ${file.file_name} download started.`);
+      if (isCurrentSession(requestSessionId)) {
+        feedback = successFeedback(`Produced file ${file.file_name} download started.`);
+      }
     } catch (downloadError) {
-      error = errorMessage(downloadError);
-      feedback = null;
+      if (isCurrentSession(requestSessionId)) {
+        error = errorMessage(downloadError);
+        feedback = null;
+      }
     }
   }
 
@@ -236,6 +285,14 @@
     return { variant: 'success', title: 'Workflow updated', message, testId: 'workflow-message' };
   }
 
+  function isCurrentSession(sessionId: string): boolean {
+    return currentSessionId === sessionId;
+  }
+
+  function isCurrentWorkflowSelection(workflowId: string, version: string): boolean {
+    return selectedWorkflowId === workflowId && selectedVersion === version;
+  }
+
   function shortId(value: string): string {
     return value.length > 13 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
   }
@@ -252,8 +309,8 @@
   onConnectSession={onConnectSession}
   onInvokeRun={() => void invokeRun()}
   onRefreshRun={() => void refreshRunResources()}
-  onCancelRun={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} was cancelled.`, () => workflowService.cancelRun(currentRun!.id))}
-  onReleaseHold={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} hold was released.`, () => workflowService.releaseHold(currentRun!.id))}
-  onSubmitInput={() => currentRun && void mutateRun((run) => `Operator input was submitted for workflow run ${shortId(run.id)}.`, () => workflowService.submitInput(currentRun!.id, parseJson(interventionInputText)))}
+  onCancelRun={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} was cancelled.`, (run) => workflowService.cancelRun(run.id))}
+  onReleaseHold={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} hold was released.`, (run) => workflowService.releaseHold(run.id))}
+  onSubmitInput={() => currentRun && void mutateRun((run) => `Operator input was submitted for workflow run ${shortId(run.id)}.`, (run) => workflowService.submitInput(run.id, parseJson(interventionInputText)))}
   onDownloadProducedFile={(fileId) => void downloadProducedFile(fileId)}
 />

--- a/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/WorkflowOperationsSurface.svelte
@@ -3,6 +3,7 @@
   import type { SessionResource } from '../api/control-types';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { WorkflowDefinitionResource, WorkflowDefinitionVersionResource, WorkflowRunEventResource, WorkflowRunLogResource, WorkflowRunProducedFileResource, WorkflowRunResource } from '../api/workflow-types';
+  import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import WorkflowOperationsPanel from '../presentation/WorkflowOperationsPanel.svelte';
   import { WorkflowOperationsViewModelBuilder } from '../presentation/workflow-operations-view-model';
   import { WorkflowOperationsService } from './workflow-operations-service';
@@ -36,6 +37,7 @@
   let loading = $state(false);
   let actionInFlight = $state(false);
   let error = $state<string | null>(null);
+  let feedback = $state<AdminMessageFeedback | null>(null);
   let currentSessionId = $state<string | null>(null);
 
   const inputValid = $derived(isJson(inputText));
@@ -47,7 +49,7 @@
   }));
 
   onMount(() => {
-    void loadDefinitions();
+    void loadDefinitions(false);
   });
 
   $effect(() => {
@@ -61,28 +63,44 @@
     logs = [];
     files = [];
     error = null;
+    feedback = null;
   });
 
-  async function loadDefinitions(): Promise<void> {
+  async function loadDefinitions(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
+    feedback = null;
     try {
       const selection = await workflowService.loadDefinitions(selectedWorkflowId, selectedVersion);
       definitions = selection.definitions;
       selectedWorkflowId = selection.selectedWorkflowId;
       selectedVersion = selection.selectedVersion;
       selectedVersionResource = selection.selectedVersionResource;
+      if (showFeedback) {
+        feedback = successFeedback(`${selection.definitions.length} workflow template${selection.definitions.length === 1 ? '' : 's'} refreshed.`);
+      }
     } catch (loadError) {
       error = errorMessage(loadError);
+      feedback = null;
     } finally {
       loading = false;
     }
   }
 
   async function selectWorkflow(workflowId: string): Promise<void> {
+    error = null;
+    feedback = null;
     selectedWorkflowId = workflowId;
     selectedVersion = definitions.find((entry) => entry.id === workflowId)?.latest_version ?? '';
+    selectedVersionResource = null;
     await loadSelectedVersion();
+  }
+
+  function updateSelectedVersion(version: string): void {
+    selectedVersion = version.trim();
+    selectedVersionResource = null;
+    error = null;
+    feedback = null;
   }
 
   async function loadSelectedVersion(): Promise<void> {
@@ -101,10 +119,12 @@
   async function invokeRun(): Promise<void> {
     if (viewModel.invokeBlockedReason) {
       error = viewModel.invokeBlockedReason;
+      feedback = null;
       return;
     }
     if (!selectedSession) {
       error = 'Select or create a session before invoking a workflow. The selected session is the workflow baseline.';
+      feedback = null;
       return;
     }
     await runAction(async () => {
@@ -121,7 +141,7 @@
         runInput: parseJson(inputText),
       });
       await refreshRunResources(false);
-    });
+    }, () => currentRun ? `Workflow run ${shortId(currentRun.id)} was invoked.` : 'Workflow run was invoked.');
   }
 
   async function refreshRunResources(withBusy = true): Promise<void> {
@@ -136,26 +156,37 @@
       files = snapshot.files;
     };
     if (withBusy) {
-      await runAction(refresh);
+      await runAction(refresh, () => currentRun ? `Workflow run ${shortId(currentRun.id)} refreshed.` : 'Workflow run refreshed.');
     } else {
       await refresh();
     }
   }
 
-  async function mutateRun(action: () => Promise<WorkflowRunResource>): Promise<void> {
+  async function mutateRun(
+    successMessage: (run: WorkflowRunResource) => string,
+    action: () => Promise<WorkflowRunResource>,
+  ): Promise<void> {
     await runAction(async () => {
       currentRun = await action();
       await refreshRunResources(false);
-    });
+    }, () => currentRun ? successMessage(currentRun) : 'Workflow run updated.');
   }
 
-  async function runAction(action: () => Promise<void>): Promise<void> {
+  async function runAction(
+    action: () => Promise<void>,
+    successMessage?: () => string,
+  ): Promise<void> {
     actionInFlight = true;
     error = null;
+    feedback = null;
     try {
       await action();
+      if (successMessage) {
+        feedback = successFeedback(successMessage());
+      }
     } catch (actionError) {
       error = errorMessage(actionError);
+      feedback = null;
     } finally {
       actionInFlight = false;
     }
@@ -166,6 +197,8 @@
     if (!file) {
       return;
     }
+    error = null;
+    feedback = null;
     try {
       const url = URL.createObjectURL(await workflowService.downloadFile(file));
       const link = document.createElement('a');
@@ -175,8 +208,10 @@
       link.click();
       link.remove();
       URL.revokeObjectURL(url);
+      feedback = successFeedback(`Produced file ${file.file_name} download started.`);
     } catch (downloadError) {
       error = errorMessage(downloadError);
+      feedback = null;
     }
   }
 
@@ -196,21 +231,29 @@
   function errorMessage(value: unknown): string {
     return value instanceof Error ? value.message : 'Unexpected workflow operation error';
   }
+
+  function successFeedback(message: string): AdminMessageFeedback {
+    return { variant: 'success', title: 'Workflow updated', message, testId: 'workflow-message' };
+  }
+
+  function shortId(value: string): string {
+    return value.length > 13 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+  }
 </script>
 
 <WorkflowOperationsPanel
-  {viewModel} {inputText} {interventionInputText}
+  {viewModel} {inputText} {interventionInputText} {feedback}
   onRefreshDefinitions={() => void loadDefinitions()}
   onWorkflowChange={(workflowId) => void selectWorkflow(workflowId)}
-  onVersionChange={(version) => { selectedVersion = version.trim(); selectedVersionResource = null; }}
+  onVersionChange={updateSelectedVersion}
   onInputTextChange={(next) => { inputText = next; }}
   onInterventionInputChange={(next) => { interventionInputText = next; }}
   onCreateSession={onCreateSession}
   onConnectSession={onConnectSession}
   onInvokeRun={() => void invokeRun()}
   onRefreshRun={() => void refreshRunResources()}
-  onCancelRun={() => currentRun && void mutateRun(() => workflowService.cancelRun(currentRun!.id))}
-  onReleaseHold={() => currentRun && void mutateRun(() => workflowService.releaseHold(currentRun!.id))}
-  onSubmitInput={() => currentRun && void mutateRun(() => workflowService.submitInput(currentRun!.id, parseJson(interventionInputText)))}
+  onCancelRun={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} was cancelled.`, () => workflowService.cancelRun(currentRun!.id))}
+  onReleaseHold={() => currentRun && void mutateRun((run) => `Workflow run ${shortId(run.id)} hold was released.`, () => workflowService.releaseHold(currentRun!.id))}
+  onSubmitInput={() => currentRun && void mutateRun((run) => `Operator input was submitted for workflow run ${shortId(run.id)}.`, () => workflowService.submitInput(currentRun!.id, parseJson(interventionInputText)))}
   onDownloadProducedFile={(fileId) => void downloadProducedFile(fileId)}
 />

--- a/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AdminMcpDelegationSnapshot,
+  AdminRecordingsSnapshot,
+  AdminWorkflowRunSnapshot,
+} from '../api/admin-event-snapshots';
+import type { SessionResource } from '../api/control-types';
+import {
+  eventStreamStatusMessage,
+  mcpDelegationSnapshotMessage,
+  recordingsSnapshotMessage,
+  selectedSessionDiffMessage,
+  sessionFilesSnapshotMessage,
+  workflowFollowMessage,
+  workflowRunsSnapshotMessage,
+} from './admin-feedback-notifications';
+
+const SESSION_ID = '019df4d2-f4f7-7b00-9e0c-79683b1c82f6';
+
+describe('admin feedback notifications', () => {
+  it('does not notify selected-session diffs before the first event snapshot', () => {
+    expect(selectedSessionDiffMessage(session(), session({ state: 'stopped' }), false)).toBeNull();
+  });
+
+  it('notifies selected-session state and presence transitions', () => {
+    expect(selectedSessionDiffMessage(session(), session({ state: 'stopped' }), true)).toMatchObject({
+      variant: 'warning',
+      title: 'Session state changed',
+      message: 'Selected session 019df4d2...82f6 changed from active to stopped.',
+    });
+
+    expect(selectedSessionDiffMessage(
+      session({ totalClients: 0 }),
+      session({ totalClients: 2 }),
+      true,
+    )).toMatchObject({
+      variant: 'info',
+      title: 'Session clients connected',
+      message: '2 live clients attached to the selected session.',
+    });
+  });
+
+  it('notifies selected-session file count increases only after baseline', () => {
+    const first = sessionFilesSnapshotMessage(SESSION_ID, [
+      { sessionId: SESSION_ID, fileCount: 1, latestUpdatedAt: null },
+    ], new Map());
+    expect(first.message).toBeNull();
+
+    const second = sessionFilesSnapshotMessage(SESSION_ID, [
+      { sessionId: SESSION_ID, fileCount: 3, latestUpdatedAt: null },
+    ], first.counts);
+    expect(second.message).toMatchObject({
+      variant: 'info',
+      title: 'Session files updated',
+      message: '2 new runtime files recorded for the selected session.',
+    });
+  });
+
+  it('notifies recording start, ready, and ended-without-ready transitions', () => {
+    const baseline = new Map([[SESSION_ID, recording({ activeCount: 0, readyCount: 0, recordingCount: 0 })]]);
+    expect(recordingsSnapshotMessage(SESSION_ID, [
+      recording({ activeCount: 1, readyCount: 0, recordingCount: 1 }),
+    ], baseline).message).toMatchObject({
+      variant: 'info',
+      title: 'Recording updated',
+    });
+
+    expect(recordingsSnapshotMessage(SESSION_ID, [
+      recording({ activeCount: 0, readyCount: 1, recordingCount: 1 }),
+    ], new Map([[SESSION_ID, recording({ activeCount: 1, readyCount: 0, recordingCount: 1 })]])).message).toMatchObject({
+      variant: 'success',
+      title: 'Recording ready',
+    });
+
+    expect(recordingsSnapshotMessage(SESSION_ID, [
+      recording({ activeCount: 0, readyCount: 0, recordingCount: 1 }),
+    ], new Map([[SESSION_ID, recording({ activeCount: 1, readyCount: 0, recordingCount: 1 })]])).message).toMatchObject({
+      variant: 'warning',
+      title: 'Recording changed',
+    });
+  });
+
+  it('notifies MCP delegation and owner changes', () => {
+    const previous = new Map([[SESSION_ID, mcp({ delegatedClientId: null, mcpOwner: false })]]);
+    expect(mcpDelegationSnapshotMessage(SESSION_ID, [
+      mcp({ delegatedClientId: 'bpane-mcp-bridge', mcpOwner: false }),
+    ], previous).message).toMatchObject({
+      variant: 'success',
+      title: 'MCP delegation changed',
+    });
+
+    expect(mcpDelegationSnapshotMessage(SESSION_ID, [
+      mcp({ delegatedClientId: null, mcpOwner: true }),
+    ], previous).message).toMatchObject({
+      variant: 'info',
+      title: 'MCP ownership changed',
+    });
+  });
+
+  it('notifies workflow run transitions and follow events', () => {
+    const run: AdminWorkflowRunSnapshot = {
+      id: 'run-1234567890',
+      sessionId: SESSION_ID,
+      state: 'awaiting_input',
+      updatedAt: '2026-05-04T19:02:00Z',
+    };
+    expect(workflowRunsSnapshotMessage(SESSION_ID, [run], new Map([[run.id, 'running']])).message).toMatchObject({
+      variant: 'warning',
+      title: 'Workflow needs input',
+    });
+
+    expect(workflowFollowMessage(run)).toMatchObject({
+      variant: 'info',
+      title: 'Following workflow run',
+    });
+  });
+
+  it('notifies event stream reconnect and recovery', () => {
+    expect(eventStreamStatusMessage('open', 'reconnecting')).toMatchObject({
+      variant: 'warning',
+      title: 'Admin event stream',
+    });
+    expect(eventStreamStatusMessage('reconnecting', 'open')).toMatchObject({
+      variant: 'success',
+      title: 'Admin event stream',
+    });
+  });
+});
+
+function session(overrides: { readonly state?: string; readonly totalClients?: number } = {}): SessionResource {
+  const totalClients = overrides.totalClients ?? 1;
+  return {
+    id: SESSION_ID,
+    state: overrides.state ?? 'active',
+    owner_mode: 'shared',
+    idle_timeout_sec: 1800,
+    labels: {},
+    connect: {
+      gateway_url: 'https://localhost:4433',
+      transport_path: '/session',
+      auth_type: 'session_connect_ticket',
+      compatibility_mode: 'session_runtime_pool',
+    },
+    runtime: {
+      binding: 'docker_runtime_pool',
+      compatibility_mode: 'session_runtime_pool',
+    },
+    status: {
+      runtime_state: 'running',
+      presence_state: totalClients > 0 ? 'connected' : 'idle',
+      connection_counts: {
+        interactive_clients: totalClients,
+        owner_clients: totalClients,
+        viewer_clients: 0,
+        recorder_clients: 0,
+        automation_clients: 0,
+        total_clients: totalClients,
+      },
+      stop_eligibility: { allowed: totalClients === 0, blockers: [] },
+    },
+    created_at: '2026-05-04T19:00:00Z',
+    updated_at: '2026-05-04T19:01:00Z',
+  };
+}
+
+function recording(overrides: Partial<AdminRecordingsSnapshot>): AdminRecordingsSnapshot {
+  return {
+    sessionId: SESSION_ID,
+    recordingCount: overrides.recordingCount ?? 0,
+    activeCount: overrides.activeCount ?? 0,
+    readyCount: overrides.readyCount ?? 0,
+    latestUpdatedAt: null,
+  };
+}
+
+function mcp(overrides: Partial<AdminMcpDelegationSnapshot>): AdminMcpDelegationSnapshot {
+  return {
+    sessionId: SESSION_ID,
+    delegatedClientId: overrides.delegatedClientId ?? null,
+    delegatedIssuer: overrides.delegatedIssuer ?? null,
+    mcpOwner: overrides.mcpOwner ?? false,
+    updatedAt: '2026-05-04T19:01:00Z',
+  };
+}

--- a/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.ts
@@ -1,0 +1,223 @@
+import type { AdminEventConnectionStatus } from '../api/admin-event-client';
+import type {
+  AdminMcpDelegationSnapshot,
+  AdminRecordingsSnapshot,
+  AdminSessionFilesSnapshot,
+  AdminWorkflowRunSnapshot,
+} from '../api/admin-event-snapshots';
+import type { SessionResource } from '../api/control-types';
+import type { AdminMessageFeedback, AdminMessageVariant } from '../presentation/admin-message-types';
+
+const GLOBAL_MESSAGE_TEST_ID = 'admin-global-message';
+
+export type SessionFilesNotificationResult = {
+  readonly counts: ReadonlyMap<string, number>;
+  readonly message: AdminMessageFeedback | null;
+};
+
+export type RecordingsNotificationResult = {
+  readonly snapshots: ReadonlyMap<string, AdminRecordingsSnapshot>;
+  readonly message: AdminMessageFeedback | null;
+};
+
+export type McpDelegationNotificationResult = {
+  readonly snapshots: ReadonlyMap<string, AdminMcpDelegationSnapshot>;
+  readonly message: AdminMessageFeedback | null;
+};
+
+export type WorkflowRunsNotificationResult = {
+  readonly states: ReadonlyMap<string, string>;
+  readonly message: AdminMessageFeedback | null;
+};
+
+export function globalAdminMessage(
+  variant: AdminMessageVariant,
+  title: string,
+  message: string,
+): AdminMessageFeedback {
+  return { variant, title, message, testId: GLOBAL_MESSAGE_TEST_ID };
+}
+
+export function eventStreamStatusMessage(
+  previous: AdminEventConnectionStatus | null,
+  current: AdminEventConnectionStatus,
+): AdminMessageFeedback | null {
+  if (current === 'reconnecting') {
+    return globalAdminMessage('warning', 'Admin event stream', 'Reconnecting to the gateway event stream.');
+  }
+  if (current === 'open' && previous && previous !== 'open' && previous !== 'connecting') {
+    return globalAdminMessage('success', 'Admin event stream', 'Gateway event stream reconnected.');
+  }
+  return null;
+}
+
+export function selectedSessionDiffMessage(
+  previous: SessionResource | null,
+  current: SessionResource | null,
+  sessionSnapshotSeen: boolean,
+): AdminMessageFeedback | null {
+  if (!sessionSnapshotSeen || !previous) {
+    return null;
+  }
+  if (!current) {
+    return globalAdminMessage('warning', 'Selected session unavailable', `Session ${shortAdminId(previous.id)} is no longer visible.`);
+  }
+  if (previous.id !== current.id) {
+    return null;
+  }
+  if (previous.state !== current.state) {
+    return globalAdminMessage(
+      current.state === 'active' ? 'success' : 'warning',
+      'Session state changed',
+      `Selected session ${shortAdminId(current.id)} changed from ${previous.state} to ${current.state}.`,
+    );
+  }
+  const previousClients = previous.status.connection_counts.total_clients;
+  const currentClients = current.status.connection_counts.total_clients;
+  if (previousClients === 0 && currentClients > 0) {
+    return globalAdminMessage('info', 'Session clients connected', `${currentClients} live client${currentClients === 1 ? '' : 's'} attached to the selected session.`);
+  }
+  if (previousClients > 0 && currentClients === 0) {
+    return globalAdminMessage('info', 'Session clients disconnected', 'No live clients remain attached to the selected session.');
+  }
+  return null;
+}
+
+export function sessionFilesSnapshotMessage(
+  selectedSessionId: string | null,
+  snapshot: readonly AdminSessionFilesSnapshot[],
+  previousCounts: ReadonlyMap<string, number>,
+): SessionFilesNotificationResult {
+  const counts = new Map(snapshot.map((entry) => [entry.sessionId, entry.fileCount]));
+  const selectedSnapshot = selectedSessionId ? snapshot.find((entry) => entry.sessionId === selectedSessionId) : null;
+  const previousCount = selectedSessionId ? previousCounts.get(selectedSessionId) : undefined;
+  if (!selectedSessionId || !selectedSnapshot || previousCount === undefined || selectedSnapshot.fileCount <= previousCount) {
+    return { counts, message: null };
+  }
+  const delta = selectedSnapshot.fileCount - previousCount;
+  return {
+    counts,
+    message: globalAdminMessage(
+      'info',
+      'Session files updated',
+      `${delta} new runtime file${delta === 1 ? '' : 's'} recorded for the selected session.`,
+    ),
+  };
+}
+
+export function recordingsSnapshotMessage(
+  selectedSessionId: string | null,
+  snapshot: readonly AdminRecordingsSnapshot[],
+  previousSnapshots: ReadonlyMap<string, AdminRecordingsSnapshot>,
+): RecordingsNotificationResult {
+  const snapshots = new Map(snapshot.map((entry) => [entry.sessionId, entry]));
+  const selectedSnapshot = selectedSessionId ? snapshot.find((entry) => entry.sessionId === selectedSessionId) : null;
+  const previous = selectedSessionId ? previousSnapshots.get(selectedSessionId) : undefined;
+  if (!selectedSessionId || !selectedSnapshot || !previous) {
+    return { snapshots, message: null };
+  }
+  if (selectedSnapshot.activeCount > previous.activeCount) {
+    return {
+      snapshots,
+      message: globalAdminMessage('info', 'Recording updated', 'Recording activity started for the selected session.'),
+    };
+  }
+  if (selectedSnapshot.readyCount > previous.readyCount) {
+    return {
+      snapshots,
+      message: globalAdminMessage('success', 'Recording ready', 'A recording segment is ready for the selected session.'),
+    };
+  }
+  if (
+    selectedSnapshot.activeCount < previous.activeCount
+    || (selectedSnapshot.recordingCount > previous.recordingCount && selectedSnapshot.readyCount <= previous.readyCount)
+  ) {
+    return {
+      snapshots,
+      message: globalAdminMessage('warning', 'Recording changed', 'Recording activity ended without a new ready segment for the selected session.'),
+    };
+  }
+  return { snapshots, message: null };
+}
+
+export function mcpDelegationSnapshotMessage(
+  selectedSessionId: string | null,
+  snapshot: readonly AdminMcpDelegationSnapshot[],
+  previousSnapshots: ReadonlyMap<string, AdminMcpDelegationSnapshot>,
+): McpDelegationNotificationResult {
+  const snapshots = new Map(snapshot.map((entry) => [entry.sessionId, entry]));
+  const selectedSnapshot = selectedSessionId ? snapshot.find((entry) => entry.sessionId === selectedSessionId) : null;
+  const previous = selectedSessionId ? previousSnapshots.get(selectedSessionId) : undefined;
+  if (!selectedSessionId || !selectedSnapshot || !previous) {
+    return { snapshots, message: null };
+  }
+  if (selectedSnapshot.delegatedClientId !== previous.delegatedClientId) {
+    return {
+      snapshots,
+      message: globalAdminMessage(
+        selectedSnapshot.delegatedClientId ? 'success' : 'warning',
+        'MCP delegation changed',
+        selectedSnapshot.delegatedClientId
+          ? 'MCP was delegated to the selected session.'
+          : 'MCP delegation was removed from the selected session.',
+      ),
+    };
+  }
+  if (selectedSnapshot.mcpOwner !== previous.mcpOwner) {
+    return {
+      snapshots,
+      message: globalAdminMessage(
+        selectedSnapshot.mcpOwner ? 'info' : 'warning',
+        'MCP ownership changed',
+        selectedSnapshot.mcpOwner ? 'MCP now owns the selected session.' : 'MCP no longer owns the selected session.',
+      ),
+    };
+  }
+  return { snapshots, message: null };
+}
+
+export function workflowRunsSnapshotMessage(
+  selectedSessionId: string | null,
+  runs: readonly AdminWorkflowRunSnapshot[],
+  previousStates: ReadonlyMap<string, string>,
+): WorkflowRunsNotificationResult {
+  const states = new Map(runs.map((run) => [run.id, run.state]));
+  if (!selectedSessionId) {
+    return { states, message: null };
+  }
+  let message: AdminMessageFeedback | null = null;
+  for (const run of runs.filter((entry) => entry.sessionId === selectedSessionId)) {
+    const previousState = previousStates.get(run.id);
+    if (!previousState || previousState === run.state) {
+      continue;
+    }
+    if (run.state === 'awaiting_input') {
+      message = globalAdminMessage('warning', 'Workflow needs input', `Workflow run ${shortAdminId(run.id)} is waiting for operator input.`);
+    } else if (isTerminalWorkflowState(run.state)) {
+      message = globalAdminMessage(
+        run.state === 'succeeded' ? 'success' : 'error',
+        'Workflow finished',
+        `Workflow run ${shortAdminId(run.id)} ${run.state}.`,
+      );
+    } else if (run.state === 'running') {
+      message = globalAdminMessage('info', 'Workflow running', `Workflow run ${shortAdminId(run.id)} is running.`);
+    }
+  }
+  return { states, message };
+}
+
+export function workflowFollowMessage(run: AdminWorkflowRunSnapshot): AdminMessageFeedback {
+  return globalAdminMessage(
+    'info',
+    'Following workflow run',
+    `Connecting to workflow run ${shortAdminId(run.id)} on session ${shortAdminId(run.sessionId)}.`,
+  );
+}
+
+export function shortAdminId(value: string): string {
+  return value.length > 13 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}
+
+function isTerminalWorkflowState(state: string): boolean {
+  return state === 'succeeded' || state === 'failed' || state === 'cancelled' || state === 'timed_out';
+}

--- a/code/web/bpane-admin/src/lib/application/admin-session-event-sync.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-session-event-sync.test.ts
@@ -52,14 +52,14 @@ describe('subscribeAdminSessionEvents', () => {
 
   it('notifies panel refresh boundaries when session files change', () => {
     const client = new FakeAdminEventClient();
-    let refreshes = 0;
+    const snapshots: Array<readonly { readonly sessionId: string; readonly fileCount: number }[]> = [];
 
     subscribeAdminSessionEvents(client as never, {
       onSessions: () => undefined,
       onLoadingChange: () => undefined,
       onError: () => undefined,
       onLog: () => undefined,
-      onSessionFilesSnapshot: () => { refreshes += 1; },
+      onSessionFilesSnapshot: (next) => snapshots.push(next),
     });
     client.handlers.onEvent({
       type: 'session_files.snapshot',
@@ -68,7 +68,7 @@ describe('subscribeAdminSessionEvents', () => {
       sessionFiles: [{ sessionId: 'session-a', fileCount: 1, latestUpdatedAt: null }],
     });
 
-    expect(refreshes).toBe(1);
+    expect(snapshots).toEqual([[{ sessionId: 'session-a', fileCount: 1, latestUpdatedAt: null }]]);
   });
 
   it('passes workflow run snapshots to the follow handler', () => {
@@ -94,14 +94,14 @@ describe('subscribeAdminSessionEvents', () => {
 
   it('notifies panel refresh boundaries when recordings change', () => {
     const client = new FakeAdminEventClient();
-    let refreshes = 0;
+    const snapshots: Array<readonly { readonly sessionId: string; readonly readyCount: number }[]> = [];
 
     subscribeAdminSessionEvents(client as never, {
       onSessions: () => undefined,
       onLoadingChange: () => undefined,
       onError: () => undefined,
       onLog: () => undefined,
-      onRecordingsSnapshot: () => { refreshes += 1; },
+      onRecordingsSnapshot: (next) => snapshots.push(next),
     });
     client.handlers.onEvent({
       type: 'recordings.snapshot',
@@ -116,19 +116,27 @@ describe('subscribeAdminSessionEvents', () => {
       }],
     });
 
-    expect(refreshes).toBe(1);
+    expect(snapshots).toEqual([[
+      {
+        sessionId: 'session-a',
+        recordingCount: 1,
+        activeCount: 0,
+        readyCount: 1,
+        latestUpdatedAt: null,
+      },
+    ]]);
   });
 
   it('notifies panel refresh boundaries when MCP delegation changes', () => {
     const client = new FakeAdminEventClient();
-    let refreshes = 0;
+    const snapshots: Array<readonly { readonly sessionId: string; readonly delegatedClientId: string | null }[]> = [];
 
     subscribeAdminSessionEvents(client as never, {
       onSessions: () => undefined,
       onLoadingChange: () => undefined,
       onError: () => undefined,
       onLog: () => undefined,
-      onMcpDelegationSnapshot: () => { refreshes += 1; },
+      onMcpDelegationSnapshot: (next) => snapshots.push(next),
     });
     client.handlers.onEvent({
       type: 'mcp_delegation.snapshot',
@@ -143,7 +151,15 @@ describe('subscribeAdminSessionEvents', () => {
       }],
     });
 
-    expect(refreshes).toBe(1);
+    expect(snapshots).toEqual([[
+      {
+        sessionId: 'session-a',
+        delegatedClientId: 'bpane-mcp-bridge',
+        delegatedIssuer: 'local-compose',
+        mcpOwner: false,
+        updatedAt: '2026-05-04T19:01:00Z',
+      },
+    ]]);
   });
 });
 

--- a/code/web/bpane-admin/src/lib/application/admin-session-event-sync.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-session-event-sync.ts
@@ -1,5 +1,14 @@
-import type { AdminEventClient, AdminEventSubscription } from '../api/admin-event-client';
-import type { AdminWorkflowRunSnapshot } from '../api/admin-event-snapshots';
+import type {
+  AdminEventClient,
+  AdminEventConnectionStatus,
+  AdminEventSubscription,
+} from '../api/admin-event-client';
+import type {
+  AdminMcpDelegationSnapshot,
+  AdminRecordingsSnapshot,
+  AdminSessionFilesSnapshot,
+  AdminWorkflowRunSnapshot,
+} from '../api/admin-event-snapshots';
 import type { SessionResource } from '../api/control-types';
 import type { AdminLogEntry } from '../presentation/logs-view-model';
 import { AdminLogEntryFactory } from './admin-log-entries';
@@ -9,9 +18,10 @@ type AdminSessionEventSyncHandlers = {
   readonly onLoadingChange: (loading: boolean) => void;
   readonly onError: (error: string | null) => void;
   readonly onLog: (entry: AdminLogEntry) => void;
-  readonly onSessionFilesSnapshot?: () => void;
-  readonly onRecordingsSnapshot?: () => void;
-  readonly onMcpDelegationSnapshot?: () => void;
+  readonly onConnectionStatus?: (status: AdminEventConnectionStatus) => void;
+  readonly onSessionFilesSnapshot?: (sessionFiles: readonly AdminSessionFilesSnapshot[]) => void;
+  readonly onRecordingsSnapshot?: (recordings: readonly AdminRecordingsSnapshot[]) => void;
+  readonly onMcpDelegationSnapshot?: (delegations: readonly AdminMcpDelegationSnapshot[]) => void;
   readonly onWorkflowRunsSnapshot?: (runs: readonly AdminWorkflowRunSnapshot[]) => void;
 };
 
@@ -31,14 +41,17 @@ export function subscribeAdminSessionEvents(
       } else if (event.type === 'workflow_runs.snapshot') {
         handlers.onWorkflowRunsSnapshot?.(event.workflowRuns);
       } else if (event.type === 'session_files.snapshot') {
-        handlers.onSessionFilesSnapshot?.();
+        handlers.onSessionFilesSnapshot?.(event.sessionFiles);
       } else if (event.type === 'recordings.snapshot') {
-        handlers.onRecordingsSnapshot?.();
+        handlers.onRecordingsSnapshot?.(event.recordings);
       } else if (event.type === 'mcp_delegation.snapshot') {
-        handlers.onMcpDelegationSnapshot?.();
+        handlers.onMcpDelegationSnapshot?.(event.delegations);
       }
     },
-    onStatus: (status) => handlers.onLog(AdminLogEntryFactory.fromConnectionStatus(status)),
+    onStatus: (status) => {
+      handlers.onLog(AdminLogEntryFactory.fromConnectionStatus(status));
+      handlers.onConnectionStatus?.(status);
+    },
     onError: (error) => {
       handlers.onError(error.message);
       handlers.onLog(AdminLogEntryFactory.fromStreamError(error));

--- a/code/web/bpane-admin/src/lib/application/admin-workflow-follow.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-workflow-follow.ts
@@ -8,6 +8,7 @@ export type AdminWorkflowSessionFollowerOptions = {
   readonly getConnectedSessionId: () => string | null;
   readonly upsertSession: (session: SessionResource) => void;
   readonly requestBrowserConnect: () => void;
+  readonly onFollow?: (run: AdminWorkflowRunSnapshot) => void;
   readonly onError: (message: string) => void;
 };
 
@@ -40,6 +41,7 @@ export class AdminWorkflowSessionFollower {
         ?? await this.options.controlClient.getSession(run.sessionId);
       this.options.upsertSession(session);
       this.followSignature = signature;
+      this.options.onFollow?.(run);
       this.options.requestBrowserConnect();
     } catch (error) {
       this.options.onError(AdminWorkflowSessionFollower.errorMessage(error));

--- a/code/web/bpane-admin/src/lib/presentation/AdminMessage.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/AdminMessage.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { AlertCircle, CheckCircle2, Info, LoaderCircle, TriangleAlert, X } from 'lucide-svelte';
+  import { resolveAdminMessageAccessibility, type AdminMessageRole } from './admin-message-accessibility';
+  import type { AdminMessageVariant } from './admin-message-types';
+
+  type AdminMessageProps = {
+    readonly variant?: AdminMessageVariant;
+    readonly title?: string;
+    readonly message: string;
+    readonly testId?: string;
+    readonly compact?: boolean;
+    readonly role?: AdminMessageRole;
+    readonly onDismiss?: () => void;
+    readonly dismissLabel?: string;
+    readonly dismissTestId?: string;
+  };
+
+  type MessageTone = {
+    readonly icon: typeof Info;
+    readonly rootClass: string;
+    readonly iconClass: string;
+    readonly titleClass: string;
+    readonly messageClass: string;
+  };
+
+  const MESSAGE_TONES = {
+    info: {
+      icon: Info,
+      rootClass: 'border-[#90a6cc]/34 bg-[#172946] text-admin-ink shadow-[0_14px_34px_rgb(0_0_0_/_28%)]',
+      iconClass: 'text-[#9fb1cf]',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#d9e5fa]',
+    },
+    success: {
+      icon: CheckCircle2,
+      rootClass: 'border-admin-leaf/52 bg-[#102f2c] text-admin-ink shadow-[0_14px_34px_rgb(0_0_0_/_28%)]',
+      iconClass: 'text-admin-leaf',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#d7fff4]',
+    },
+    warning: {
+      icon: TriangleAlert,
+      rootClass: 'border-admin-warm/56 bg-[#332a13] text-admin-ink shadow-[0_14px_34px_rgb(0_0_0_/_28%)]',
+      iconClass: 'text-admin-warm',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#fff3c2]',
+    },
+    error: {
+      icon: AlertCircle,
+      rootClass: 'border-admin-danger/60 bg-[#351b24] text-admin-ink shadow-[0_14px_34px_rgb(0_0_0_/_28%)]',
+      iconClass: 'text-admin-danger',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#ffc3b7]',
+    },
+    loading: {
+      icon: LoaderCircle,
+      rootClass: 'border-admin-leaf/44 bg-[#142d3a] text-admin-ink shadow-[0_14px_34px_rgb(0_0_0_/_28%)]',
+      iconClass: 'text-admin-leaf',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#d9e5fa]',
+    },
+    empty: {
+      icon: Info,
+      rootClass: 'border-[#90a6cc]/26 bg-[#111f35] text-admin-ink shadow-[0_10px_24px_rgb(0_0_0_/_20%)]',
+      iconClass: 'text-[#9fb1cf]',
+      titleClass: 'text-admin-ink',
+      messageClass: 'text-[#c1d0e8]',
+    },
+  } satisfies Record<AdminMessageVariant, MessageTone>;
+
+  let {
+    variant = 'info',
+    title,
+    message,
+    testId,
+    compact = false,
+    role,
+    onDismiss,
+    dismissLabel = 'Dismiss message',
+    dismissTestId,
+  }: AdminMessageProps = $props();
+
+  const tone = $derived(MESSAGE_TONES[variant]);
+  const MessageIcon = $derived(tone.icon);
+  const accessibility = $derived(resolveAdminMessageAccessibility(variant, role));
+  const rootClass = $derived([
+    'grid w-full min-w-0 items-start gap-3 rounded-xl border border-l-[5px]',
+    onDismiss ? 'grid-cols-[auto_minmax(0,1fr)_auto]' : 'grid-cols-[auto_minmax(0,1fr)]',
+    compact ? 'min-h-[52px] p-3' : 'min-h-[68px] p-4',
+    tone.rootClass,
+  ].join(' '));
+  const iconClass = $derived([
+    'mt-0.5 shrink-0',
+    tone.iconClass,
+    variant === 'loading' ? 'animate-spin' : '',
+  ].filter(Boolean).join(' '));
+</script>
+
+<section
+  class={rootClass}
+  role={accessibility.role}
+  aria-live={accessibility.ariaLive}
+  aria-atomic={accessibility.ariaAtomic}
+  data-testid={testId}
+>
+  <MessageIcon class={iconClass} size={compact ? 16 : 18} aria-hidden="true" />
+  <div class="grid min-w-0 gap-1">
+    {#if title}
+      <strong class={`text-sm font-extrabold leading-snug ${tone.titleClass}`}>{title}</strong>
+    {/if}
+    <p class={`m-0 min-w-0 text-sm font-semibold leading-normal [overflow-wrap:anywhere] ${tone.messageClass}`}>
+      {message}
+    </p>
+  </div>
+  {#if onDismiss}
+    <button
+      class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-current/14 text-current/70 transition hover:bg-white/8 hover:text-current"
+      type="button"
+      aria-label={dismissLabel}
+      title={dismissLabel}
+      data-testid={dismissTestId}
+      onclick={onDismiss}
+    >
+      <X size={15} aria-hidden="true" />
+    </button>
+  {/if}
+</section>

--- a/code/web/bpane-admin/src/lib/presentation/BrowserEmbedPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/BrowserEmbedPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { SessionResource } from '../api/control-types';
+  import AdminMessage from './AdminMessage.svelte';
   import type { BrowserStageViewModel } from './admin-workspace-view-model';
 
   type BrowserEmbedPanelProps = {
@@ -93,7 +94,9 @@
   </div>
 
   {#if error}
-    <p class="mt-4 mb-0 text-[#f49a7d] leading-normal" data-testid="browser-error">{error}</p>
+    <div class="mt-4">
+      <AdminMessage variant="error" message={error} testId="browser-error" compact={true} />
+    </div>
   {/if}
   <p class="sr-only" data-testid="browser-status">{viewModel.status}</p>
 </section>

--- a/code/web/bpane-admin/src/lib/presentation/BrowserPolicyPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/BrowserPolicyPanel.svelte
@@ -1,14 +1,23 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { BrowserPolicySignal, BrowserPolicyViewModel } from './browser-policy-view-model';
 
   type BrowserPolicyPanelProps = {
     readonly viewModel: BrowserPolicyViewModel;
     readonly copied: boolean;
+    readonly feedback?: AdminMessageFeedback | null;
     readonly onRefresh: () => void;
     readonly onCopyProbeCommand: () => void;
   };
 
-  let { viewModel, copied, onRefresh, onCopyProbeCommand }: BrowserPolicyPanelProps = $props();
+  let {
+    viewModel,
+    copied,
+    feedback = null,
+    onRefresh,
+    onCopyProbeCommand,
+  }: BrowserPolicyPanelProps = $props();
 
   function signalClass(signal: BrowserPolicySignal): string {
     if (signal.tone === 'ok') {
@@ -33,6 +42,15 @@
   </div>
 
   <p class="m-0 text-sm leading-normal text-admin-ink/68" data-testid="policy-note">{viewModel.note}</p>
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
+  {/if}
 
   <div class="grid grid-cols-3 gap-2 max-[760px]:grid-cols-1">
     {#each viewModel.signals as signal}

--- a/code/web/bpane-admin/src/lib/presentation/DisplayControlsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/DisplayControlsPanel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import type { BrowserSessionRenderBackend } from '../session/browser-session-types';
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import {
     DISPLAY_BACKEND_OPTIONS,
     type DisplaySettingsViewModel,
@@ -7,6 +9,7 @@
 
   type DisplayControlsPanelProps = {
     readonly viewModel: DisplaySettingsViewModel;
+    readonly feedback?: AdminMessageFeedback | null;
     readonly onRenderBackendChange: (value: BrowserSessionRenderBackend) => void;
     readonly onHiDpiChange: (value: boolean) => void;
     readonly onScrollCopyChange: (value: boolean) => void;
@@ -14,6 +17,7 @@
 
   let {
     viewModel,
+    feedback = null,
     onRenderBackendChange,
     onHiDpiChange,
     onScrollCopyChange,
@@ -32,6 +36,15 @@
   <p class="m-0 text-sm font-bold text-admin-ink/68" data-testid="display-connection-label">
     {viewModel.connectionLabel}
   </p>
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
+  {/if}
 
   <div class="grid gap-3">
     <label class="grid gap-1.5 text-sm font-bold text-admin-ink">

--- a/code/web/bpane-admin/src/lib/presentation/LiveSessionActionsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/LiveSessionActionsPanel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { Mic, Upload, Video } from 'lucide-svelte';
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { LiveSessionActionsViewModel } from './live-session-actions-view-model';
 
   type LiveSessionActionsPanelProps = {
@@ -7,6 +9,7 @@
     readonly onCameraToggle: () => void;
     readonly onMicrophoneToggle: () => void;
     readonly onUploadFiles: (files: FileList) => void;
+    readonly feedback?: AdminMessageFeedback | null;
   };
 
   let {
@@ -14,6 +17,7 @@
     onCameraToggle,
     onMicrophoneToggle,
     onUploadFiles,
+    feedback = null,
   }: LiveSessionActionsPanelProps = $props();
   let fileInput: HTMLInputElement | null = null;
 
@@ -66,10 +70,25 @@
 
   <input class="sr-only" type="file" multiple data-testid="display-upload-input" bind:this={fileInput} onchange={handleUploadChange} />
 
+  {#if feedback}
+    <div class="mt-3">
+      <AdminMessage
+        variant={feedback.variant}
+        title={feedback.title}
+        message={feedback.message}
+        testId={feedback.testId}
+        compact={true}
+      />
+    </div>
+  {/if}
   {#if viewModel.busy}
-    <p class="admin-empty mt-3" data-testid="display-busy">Applying live action...</p>
+    <div class="mt-3">
+      <AdminMessage variant="loading" message="Applying live action..." testId="display-busy" compact={true} />
+    </div>
   {/if}
   {#if viewModel.error}
-    <p class="admin-error mt-3" data-testid="display-error">{viewModel.error}</p>
+    <div class="mt-3">
+      <AdminMessage variant="error" message={viewModel.error} testId="display-error" compact={true} />
+    </div>
   {/if}
 </section>

--- a/code/web/bpane-admin/src/lib/presentation/LogsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/LogsPanel.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { AdminLogEntry, AdminLogsViewModel } from './logs-view-model';
 
   type LogsPanelProps = {
     readonly viewModel: AdminLogsViewModel;
     readonly copied: boolean;
+    readonly feedback?: AdminMessageFeedback | null;
     readonly onClear: () => void;
     readonly onCopy: () => void;
   };
 
-  let { viewModel, copied, onClear, onCopy }: LogsPanelProps = $props();
+  let { viewModel, copied, feedback = null, onClear, onCopy }: LogsPanelProps = $props();
 
   function levelClass(entry: AdminLogEntry): string {
     return entry.level === 'warn' ? 'text-admin-warm' : 'text-admin-leaf';
@@ -39,8 +42,18 @@
     </button>
   </div>
 
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if viewModel.entries.length === 0}
-    <p class="admin-empty mt-0">{viewModel.emptyLabel}</p>
+    <AdminMessage variant="empty" message={viewModel.emptyLabel} compact={true} />
   {:else}
     <ol class="grid max-h-64 gap-2 overflow-auto p-0">
       {#each viewModel.entries as entry}

--- a/code/web/bpane-admin/src/lib/presentation/McpDelegationPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/McpDelegationPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { McpDelegationTone, McpDelegationViewModel } from './mcp-delegation-view-model';
 
   type McpDelegationPanelProps = {
@@ -9,6 +11,7 @@
     readonly onSetDefault: () => void;
     readonly onClearDefault: () => void;
     readonly onCopyEndpoint: () => void;
+    readonly feedback?: AdminMessageFeedback | null;
   };
 
   let {
@@ -19,6 +22,7 @@
     onSetDefault,
     onClearDefault,
     onCopyEndpoint,
+    feedback = null,
   }: McpDelegationPanelProps = $props();
 
   function toneClass(tone: McpDelegationTone): string {
@@ -122,9 +126,18 @@
   </div>
 
   {#if viewModel.busy}
-    <p class="admin-empty mt-0" data-testid="mcp-busy">Updating MCP delegation...</p>
+    <AdminMessage variant="loading" message="Updating MCP delegation..." testId="mcp-busy" compact={true} />
+  {/if}
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
   {/if}
   {#if viewModel.error}
-    <p class="admin-error mt-0" data-testid="mcp-error">{viewModel.error}</p>
+    <AdminMessage variant="error" message={viewModel.error} testId="mcp-error" compact={true} />
   {/if}
 </section>

--- a/code/web/bpane-admin/src/lib/presentation/MetricsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/MetricsPanel.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { MetricsViewModel } from './metrics-view-model';
 
   type MetricsPanelProps = {
     readonly viewModel: MetricsViewModel;
     readonly copied: boolean;
+    readonly feedback?: AdminMessageFeedback | null;
     readonly onStart: () => void;
     readonly onStop: () => void;
     readonly onCopy: () => void;
     readonly onReset: () => void;
   };
 
-  let { viewModel, copied, onStart, onStop, onCopy, onReset }: MetricsPanelProps = $props();
+  let {
+    viewModel,
+    copied,
+    feedback = null,
+    onStart,
+    onStop,
+    onCopy,
+    onReset,
+  }: MetricsPanelProps = $props();
   const rows = $derived([
     ['sample', viewModel.sample],
     ['render', viewModel.render],
@@ -23,6 +34,15 @@
 
 <section class="grid gap-4" aria-label="Metrics controls">
   <p class="m-0 text-sm leading-normal text-admin-ink/68">{viewModel.note}</p>
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
+  {/if}
 
   <div class="grid grid-cols-2 gap-2 max-[760px]:grid-cols-1">
     {#each rows as row}

--- a/code/web/bpane-admin/src/lib/presentation/RecordingPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/RecordingPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { RecordingViewModel } from './recording-view-model';
   import RecordingSegmentCard from './RecordingSegmentCard.svelte';
 
@@ -12,6 +14,7 @@
     readonly onRefreshLibrary: () => void;
     readonly onDownloadSegment: (recordingId: string) => void;
     readonly onDownloadPlayback: () => void;
+    readonly feedback?: AdminMessageFeedback | null;
   };
 
   let {
@@ -24,6 +27,7 @@
     onRefreshLibrary,
     onDownloadSegment,
     onDownloadPlayback,
+    feedback = null,
   }: RecordingPanelProps = $props();
 </script>
 
@@ -72,10 +76,19 @@
   </div>
 
   {#if viewModel.busy}
-    <p class="admin-empty mt-0">Recording operation in progress...</p>
+    <AdminMessage variant="loading" message="Recording operation in progress..." compact={true} />
+  {/if}
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
   {/if}
   {#if viewModel.error}
-    <p class="admin-error mt-0" data-testid="recording-error">{viewModel.error}</p>
+    <AdminMessage variant="error" message={viewModel.error} testId="recording-error" compact={true} />
   {/if}
 
   <div class="border-t border-[#90a6cc]/18 pt-4">
@@ -110,10 +123,15 @@
       </div>
     </div>
 
-    <p class="admin-empty mt-0" data-testid="recording-library-note">{viewModel.libraryNote}</p>
+    <AdminMessage variant="info" role="note" message={viewModel.libraryNote} testId="recording-library-note" compact={true} />
 
     {#if viewModel.segments.length === 0}
-      <p class="admin-empty" data-testid="recording-library-empty">{viewModel.emptyLibraryLabel}</p>
+      <AdminMessage
+        variant="empty"
+        message={viewModel.emptyLibraryLabel}
+        testId="recording-library-empty"
+        compact={true}
+      />
     {:else}
       <div class="grid gap-3">
         {#each viewModel.segments as segment (segment.id)}

--- a/code/web/bpane-admin/src/lib/presentation/RecordingSegmentCard.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/RecordingSegmentCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
   import type { RecordingSegmentCardViewModel } from './recording-view-model';
 
   type RecordingSegmentCardProps = {
@@ -37,6 +38,8 @@
     {/each}
   </div>
   {#if viewModel.error}
-    <p class="admin-error col-span-full m-0">{viewModel.error}</p>
+    <div class="col-span-full">
+      <AdminMessage variant="error" message={viewModel.error} compact={true} />
+    </div>
   {/if}
 </article>

--- a/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import type { CreateSessionCommand } from '../api/control-types';
+  import {
+    SESSION_CREATE_OWNER_MODES,
+    defaultSessionCreateFormState,
+    validateSessionCreateForm,
+  } from './session-create-configurator';
+  import AdminMessage from './AdminMessage.svelte';
+
+  type SessionCreateConfiguratorProps = {
+    readonly onCreateSession: (command: CreateSessionCommand) => void;
+    readonly loading?: boolean;
+    readonly disabled?: boolean;
+    readonly submitTestId?: string;
+    readonly submitLabel?: string;
+    readonly variant?: 'panel' | 'inline';
+    readonly showFileWorkspaceLink?: boolean;
+    readonly payloadInitiallyOpen?: boolean;
+    readonly payloadOpen?: boolean;
+    readonly onPayloadOpenChange?: (open: boolean) => void;
+  };
+
+  let {
+    onCreateSession,
+    loading = false,
+    disabled = false,
+    submitTestId = 'session-new',
+    submitLabel = 'Create session',
+    variant = 'inline',
+    showFileWorkspaceLink = true,
+    payloadInitiallyOpen = false,
+    payloadOpen: controlledPayloadOpen,
+    onPayloadOpenChange,
+  }: SessionCreateConfiguratorProps = $props();
+
+  const defaults = defaultSessionCreateFormState();
+  let ownerMode = $state(defaults.ownerMode);
+  let idleTimeoutSec = $state(defaults.idleTimeoutSec);
+  let labels = $state(defaults.labels);
+  let payloadOpenInternal = $state(false);
+  const validation = $derived(validateSessionCreateForm({ ownerMode, idleTimeoutSec, labels }));
+  const rootClass = $derived(variant === 'panel'
+    ? 'admin-panel mt-0 grid gap-4'
+    : 'grid gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3');
+  const payloadOpen = $derived(controlledPayloadOpen ?? payloadOpenInternal);
+
+  $effect(() => {
+    if (payloadInitiallyOpen) {
+      payloadOpenInternal = true;
+    }
+  });
+
+  function submit(): void {
+    if (!validation.command) {
+      return;
+    }
+    onCreateSession(validation.command);
+  }
+
+  function setPayloadOpen(open: boolean): void {
+    payloadOpenInternal = open;
+    onPayloadOpenChange?.(open);
+  }
+</script>
+
+<section class={rootClass} aria-label="Create session" data-testid="session-create-configurator">
+  <div class="flex min-w-0 flex-wrap items-start justify-between gap-3">
+    <div class="min-w-0">
+      <p class="admin-eyebrow mb-1">Create session</p>
+      <h3 class="m-0 text-base font-bold text-admin-ink">Session configuration</h3>
+    </div>
+    {#if showFileWorkspaceLink}
+      <a class="admin-button-ghost min-h-9 px-3 text-sm" href={`${base}/files/workspaces`}>
+        File workspaces
+      </a>
+    {/if}
+  </div>
+
+  <form
+    class="grid gap-3"
+    onsubmit={(event) => {
+      event.preventDefault();
+      submit();
+    }}
+  >
+    <div class="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)]">
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Owner mode
+        <select
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="session-create-owner-mode"
+          bind:value={ownerMode}
+          disabled={loading || disabled}
+        >
+          {#each SESSION_CREATE_OWNER_MODES as mode}
+            <option value={mode.value}>{mode.label}</option>
+          {/each}
+        </select>
+      </label>
+
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Idle timeout
+        <input
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="session-create-idle-timeout"
+          inputmode="numeric"
+          placeholder="Backend default"
+          type="text"
+          bind:value={idleTimeoutSec}
+          disabled={loading || disabled}
+        />
+      </label>
+    </div>
+
+    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      Labels
+      <textarea
+        class="min-h-20 resize-y rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 py-2 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="session-create-labels"
+        placeholder="case=1234, purpose=import-repro"
+        rows={variant === 'panel' ? 3 : 2}
+        bind:value={labels}
+        disabled={loading || disabled}
+      ></textarea>
+    </label>
+
+    <section class="rounded-xl border border-admin-ink/10 bg-admin-field/68 p-3" aria-label="API payload preview">
+      <button
+        class="flex w-full cursor-pointer items-center justify-between gap-3 border-0 bg-transparent p-0 text-left text-xs font-bold uppercase text-[#c1d0e8]"
+        type="button"
+        aria-expanded={payloadOpen}
+        data-testid="session-create-preview-toggle"
+        onclick={() => setPayloadOpen(!payloadOpen)}
+      >
+        <span>API payload</span>
+        <span aria-hidden="true">{payloadOpen ? 'Hide' : 'Show'}</span>
+      </button>
+      {#if payloadOpen}
+        <pre class="mt-3 max-h-44 overflow-auto whitespace-pre-wrap text-xs text-admin-ink" data-testid="session-create-preview">{validation.preview}</pre>
+      {/if}
+    </section>
+
+    {#if validation.errors.length > 0}
+      <AdminMessage
+        variant="error"
+        title="Invalid session configuration"
+        message={validation.errors.join(' ')}
+        testId="session-create-error"
+        compact={true}
+      />
+    {/if}
+
+    <button
+      class="admin-button-primary w-fit"
+      type="submit"
+      data-testid={submitTestId}
+      disabled={loading || disabled || validation.errors.length > 0}
+    >
+      {loading ? 'Creating...' : submitLabel}
+    </button>
+  </form>
+</section>

--- a/code/web/bpane-admin/src/lib/presentation/SessionDetailPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionDetailPanel.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { SessionDetailPanelViewModel } from './session-view-model';
 
   type SessionDetailPanelProps = {
@@ -8,6 +10,7 @@
     readonly onKill: () => void;
     readonly onDisconnectConnection: (connectionId: number) => void;
     readonly onDisconnectAll: () => void;
+    readonly feedback?: AdminMessageFeedback | null;
   };
 
   let {
@@ -17,6 +20,7 @@
     onKill,
     onDisconnectConnection,
     onDisconnectAll,
+    feedback = null,
   }: SessionDetailPanelProps = $props();
 </script>
 
@@ -66,8 +70,18 @@
     </button>
   </div>
 
+  {#if feedback}
+    <AdminMessage
+      variant={feedback.variant}
+      title={feedback.title}
+      message={feedback.message}
+      testId={feedback.testId}
+      compact={true}
+    />
+  {/if}
+
   {#if viewModel.facts.length === 0}
-    <p class="admin-empty">{viewModel.hint}</p>
+    <AdminMessage variant="empty" message={viewModel.hint} compact={true} />
   {:else}
     <div class="grid grid-cols-2 gap-2.5 max-[860px]:grid-cols-1">
       {#each viewModel.facts as fact}
@@ -80,7 +94,7 @@
       {/each}
     </div>
     {#if viewModel.hint}
-      <p class="admin-empty">{viewModel.hint}</p>
+      <AdminMessage variant="info" role="note" message={viewModel.hint} compact={true} />
     {/if}
   {/if}
 
@@ -92,9 +106,12 @@
       {/if}
     </div>
     {#if viewModel.connections.length === 0}
-      <p class="admin-empty" data-testid="session-connection-empty">
-        {viewModel.statusHint ?? 'No live connections reported.'}
-      </p>
+      <AdminMessage
+        variant="empty"
+        message={viewModel.statusHint ?? 'No live connections reported.'}
+        testId="session-connection-empty"
+        compact={true}
+      />
     {:else}
       <div class="grid gap-2">
         {#each viewModel.connections as connection}
@@ -125,6 +142,6 @@
   </div>
 
   {#if viewModel.error}
-    <p class="admin-error">{viewModel.error}</p>
+    <AdminMessage variant="error" message={viewModel.error} compact={true} />
   {/if}
 </div>

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { base } from '$app/paths';
+  import type { CreateSessionCommand } from '../api/control-types';
+  import AdminMessage from './AdminMessage.svelte';
+  import SessionCreateConfigurator from './SessionCreateConfigurator.svelte';
   import SessionTable from './SessionTable.svelte';
   import type { SessionListPanelViewModel } from './session-view-model';
 
   type SessionListPanelProps = {
     readonly viewModel: SessionListPanelViewModel;
     readonly onRefresh: () => void;
-    readonly onCreateSession: () => void;
+    readonly onCreateSession: (command: CreateSessionCommand) => void;
     readonly onJoinSession: () => void;
     readonly onSelectSessionId: (sessionId: string) => void;
   };
@@ -18,6 +21,7 @@
     onJoinSession,
     onSelectSessionId,
   }: SessionListPanelProps = $props();
+  let createPayloadOpen = $state(false);
 
   function detailHref(sessionId: string): string {
     return `${base}/sessions/${encodeURIComponent(sessionId)}`;
@@ -46,7 +50,7 @@
         {@render Fact('MCP', viewModel.selectedSession.mcpDelegation, 'session-selected-mcp')}
       </div>
       <p class="m-0 truncate text-xs text-admin-ink/58">
-        {viewModel.selectedSession.ownerMode} | {viewModel.selectedSession.runtimeBinding} | updated {viewModel.selectedSession.updatedAt}
+        {viewModel.selectedSession.ownerMode} | {viewModel.selectedSession.runtimeBinding} | {viewModel.selectedSession.labels} | updated {viewModel.selectedSession.updatedAt}
       </p>
     {:else}
       <p class="m-0 text-sm leading-normal text-admin-ink/68">
@@ -72,6 +76,16 @@
     </div>
   </section>
 
+  <SessionCreateConfigurator
+    loading={viewModel.loading}
+    disabled={!viewModel.authenticated}
+    submitTestId="session-new"
+    variant="inline"
+    payloadOpen={createPayloadOpen}
+    onPayloadOpenChange={(open) => { createPayloadOpen = open; }}
+    {onCreateSession}
+  />
+
   <section class="grid gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Session switcher">
     <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
       <div>
@@ -79,15 +93,6 @@
         <p class="m-0 text-sm font-bold text-admin-ink/72">{viewModel.sessions.length} visible sessions</p>
       </div>
       <div class="flex flex-wrap gap-2">
-        <button
-          class="admin-button-primary"
-          type="button"
-          data-testid="session-new"
-          disabled={!viewModel.authenticated || viewModel.loading}
-          onclick={onCreateSession}
-        >
-          New session
-        </button>
         <button
           class="admin-button-primary"
           type="button"
@@ -101,15 +106,22 @@
     </div>
 
     {#if !viewModel.authenticated}
-      <p class="admin-empty mt-0">
-        Sign in to inspect sessions from <code class="admin-code-pill">/api/v1/sessions</code>.
-      </p>
+      <AdminMessage
+        variant="warning"
+        title="Sign in required"
+        message="Sign in to inspect sessions from /api/v1/sessions."
+        compact={true}
+      />
     {:else if viewModel.loading}
-      <p class="admin-empty mt-0">Loading sessions...</p>
+      <AdminMessage variant="loading" message="Loading sessions..." compact={true} />
     {:else if viewModel.error}
-      <p class="admin-error mt-0">{viewModel.error}</p>
+      <AdminMessage variant="error" message={viewModel.error} compact={true} />
     {:else if viewModel.sessions.length === 0}
-      <p class="admin-empty mt-0">No owner-scoped sessions are visible for this operator.</p>
+      <AdminMessage
+        variant="empty"
+        message="No owner-scoped sessions are visible for this operator."
+        compact={true}
+      />
     {:else}
       <SessionTable
         sessions={viewModel.sessions}

--- a/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
@@ -37,7 +37,7 @@
           {/if}
         </span>
         <span class="min-w-0 truncate text-xs text-admin-ink/52">
-          {session.mcpDelegation} | updated {session.updatedAt}
+          {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
         </span>
       </span>
       <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/WorkflowOperationsPanel.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import { Download, Play, Plug, RefreshCw, Send, Unlock, XCircle } from 'lucide-svelte';
+  import AdminMessage from './AdminMessage.svelte';
+  import type { AdminMessageFeedback } from './admin-message-types';
   import type { WorkflowOperationsViewModel } from './workflow-operations-view-model';
 
   type WorkflowOperationsPanelProps = {
     readonly viewModel: WorkflowOperationsViewModel;
     readonly inputText: string;
     readonly interventionInputText: string;
+    readonly feedback?: AdminMessageFeedback | null;
     readonly onRefreshDefinitions: () => void;
     readonly onWorkflowChange: (workflowId: string) => void;
     readonly onVersionChange: (version: string) => void;
@@ -45,8 +48,17 @@
   </div>
 
   <p class="m-0 text-sm leading-normal text-admin-ink/68">{props.viewModel.note}</p>
+  {#if props.feedback}
+    <AdminMessage
+      variant={props.feedback.variant}
+      title={props.feedback.title}
+      message={props.feedback.message}
+      testId={props.feedback.testId}
+      compact={true}
+    />
+  {/if}
   {#if props.viewModel.error}
-    <p class="admin-error" data-testid="workflow-error">{props.viewModel.error}</p>
+    <AdminMessage variant="error" message={props.viewModel.error} testId="workflow-error" compact={true} />
   {/if}
 
   <div class="grid min-w-0 gap-3 rounded-[16px] bg-admin-cream/70 p-3">
@@ -138,13 +150,12 @@
       {/if}
     </div>
     {#if props.viewModel.invokeBlockedReason}
-      <p
-        class="m-0 rounded-xl border border-admin-warm/20 bg-admin-warm/10 px-3 py-2 text-sm font-bold text-admin-ink"
+      <div
         id="workflow-invoke-disabled-reason"
         data-testid="workflow-invoke-disabled-reason"
       >
-        {props.viewModel.invokeBlockedReason}
-      </p>
+        <AdminMessage variant="warning" message={props.viewModel.invokeBlockedReason} compact={true} />
+      </div>
     {/if}
   </div>
 
@@ -193,7 +204,7 @@
   <div class="grid min-w-0 gap-2">
     <h3 class="m-0 text-sm font-extrabold text-admin-ink">Produced files</h3>
     {#if props.viewModel.producedFiles.length === 0}
-      <p class="admin-empty">No produced artifacts loaded.</p>
+      <AdminMessage variant="empty" message="No produced artifacts loaded." compact={true} />
     {:else}
       <div class="grid min-w-0 gap-2">
         {#each props.viewModel.producedFiles as file}
@@ -218,7 +229,7 @@
   <div class="grid min-w-0 gap-2 rounded-[16px] bg-admin-cream/55 p-3">
     <h3 class="m-0 text-sm font-extrabold text-admin-ink">{title}</h3>
     {#if rows.length === 0}
-      <p class="admin-empty">{empty}</p>
+      <AdminMessage variant="empty" message={empty} compact={true} />
     {:else}
       {#each rows as row}
         <p class="m-0 min-w-0 rounded-xl bg-admin-night/5 p-2 text-xs text-admin-ink/70">

--- a/code/web/bpane-admin/src/lib/presentation/admin-message-accessibility.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-message-accessibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAdminMessageAccessibility } from './admin-message-accessibility';
+
+describe('resolveAdminMessageAccessibility', () => {
+  it('announces error and warning feedback assertively', () => {
+    expect(resolveAdminMessageAccessibility('error')).toEqual({
+      role: 'alert',
+      ariaLive: 'assertive',
+      ariaAtomic: 'true',
+    });
+    expect(resolveAdminMessageAccessibility('warning')).toEqual({
+      role: 'alert',
+      ariaLive: 'assertive',
+      ariaAtomic: 'true',
+    });
+  });
+
+  it('announces normal feedback politely', () => {
+    expect(resolveAdminMessageAccessibility('success')).toEqual({
+      role: 'status',
+      ariaLive: 'polite',
+      ariaAtomic: 'true',
+    });
+  });
+
+  it('keeps empty states out of live regions by default', () => {
+    expect(resolveAdminMessageAccessibility('empty')).toEqual({
+      role: 'note',
+      ariaLive: undefined,
+      ariaAtomic: undefined,
+    });
+  });
+
+  it('keeps explicit notes out of live regions', () => {
+    expect(resolveAdminMessageAccessibility('info', 'note')).toEqual({
+      role: 'note',
+      ariaLive: undefined,
+      ariaAtomic: undefined,
+    });
+  });
+});

--- a/code/web/bpane-admin/src/lib/presentation/admin-message-accessibility.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-message-accessibility.ts
@@ -1,0 +1,36 @@
+import type { AdminMessageVariant } from './admin-message-types';
+
+export type AdminMessageRole = 'alert' | 'status' | 'note';
+
+export type AdminMessageAccessibility = {
+  readonly role: AdminMessageRole;
+  readonly ariaLive: 'assertive' | 'polite' | undefined;
+  readonly ariaAtomic: 'true' | undefined;
+};
+
+export function resolveAdminMessageAccessibility(
+  variant: AdminMessageVariant,
+  role?: AdminMessageRole,
+): AdminMessageAccessibility {
+  const resolvedRole = role ?? defaultRole(variant);
+  const ariaLive = resolvedRole === 'note'
+    ? undefined
+    : resolvedRole === 'alert'
+      ? 'assertive'
+      : 'polite';
+  return {
+    role: resolvedRole,
+    ariaLive,
+    ariaAtomic: ariaLive ? 'true' : undefined,
+  };
+}
+
+function defaultRole(variant: AdminMessageVariant): AdminMessageRole {
+  if (variant === 'error' || variant === 'warning') {
+    return 'alert';
+  }
+  if (variant === 'empty') {
+    return 'note';
+  }
+  return 'status';
+}

--- a/code/web/bpane-admin/src/lib/presentation/admin-message-types.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-message-types.ts
@@ -1,0 +1,8 @@
+export type AdminMessageVariant = 'info' | 'success' | 'warning' | 'error' | 'loading' | 'empty';
+
+export type AdminMessageFeedback = {
+  readonly variant: AdminMessageVariant;
+  readonly message: string;
+  readonly title?: string;
+  readonly testId?: string;
+};

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultSessionCreateFormState,
+  parseSessionCreateLabels,
+  validateSessionCreateForm,
+} from './session-create-configurator';
+
+describe('session create configurator', () => {
+  it('builds the backend-default collaborative command', () => {
+    const validation = validateSessionCreateForm(defaultSessionCreateFormState());
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.command).toEqual({ owner_mode: 'collaborative' });
+    expect(validation.preview).toBe(JSON.stringify({ owner_mode: 'collaborative' }, null, 2));
+  });
+
+  it('normalizes idle timeout and labels into a create-session payload', () => {
+    const validation = validateSessionCreateForm({
+      ownerMode: 'exclusive_browser_owner',
+      idleTimeoutSec: '1800',
+      labels: 'case=1234\npurpose=import-repro, suite=admin',
+    });
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.command).toEqual({
+      owner_mode: 'exclusive_browser_owner',
+      idle_timeout_sec: 1800,
+      labels: {
+        case: '1234',
+        purpose: 'import-repro',
+        suite: 'admin',
+      },
+    });
+  });
+
+  it('rejects unsupported owner modes and invalid idle timeout values', () => {
+    const validation = validateSessionCreateForm({
+      ownerMode: 'shared',
+      idleTimeoutSec: '0',
+      labels: '',
+    });
+
+    expect(validation.command).toBeNull();
+    expect(validation.errors).toEqual([
+      'Owner mode "shared" is not supported.',
+      'Idle timeout must be a positive whole number of seconds.',
+    ]);
+    expect(validation.preview).toBe('Fix validation errors to preview the API payload.');
+  });
+
+  it('rejects malformed and duplicate labels', () => {
+    const errors: string[] = [];
+
+    const labels = parseSessionCreateLabels(
+      'case=1234\nmalformed\npurpose=\ncase=5678',
+      errors,
+    );
+
+    expect(labels).toEqual({ case: '1234' });
+    expect(errors).toEqual([
+      'Label "malformed" must use key=value.',
+      'Label "purpose=" must use non-empty key and value.',
+      'Label "case" is duplicated.',
+    ]);
+  });
+});

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
@@ -1,0 +1,124 @@
+import type { CreateSessionCommand } from '../api/control-types';
+
+export const SESSION_CREATE_OWNER_MODES = [
+  {
+    value: 'collaborative',
+    label: 'Collaborative',
+  },
+  {
+    value: 'exclusive_browser_owner',
+    label: 'Exclusive browser owner',
+  },
+] as const;
+
+export const DEFAULT_SESSION_CREATE_OWNER_MODE = 'collaborative';
+
+const OWNER_MODE_VALUES = new Set<string>(
+  SESSION_CREATE_OWNER_MODES.map((mode) => mode.value),
+);
+
+export type SessionCreateFormState = {
+  readonly ownerMode: string;
+  readonly idleTimeoutSec: string;
+  readonly labels: string;
+};
+
+export type SessionCreateValidation = {
+  readonly command: CreateSessionCommand | null;
+  readonly errors: readonly string[];
+  readonly preview: string;
+};
+
+type MutableCreateSessionCommand = {
+  owner_mode?: string;
+  idle_timeout_sec?: number;
+  labels?: Readonly<Record<string, string>>;
+};
+
+export function defaultSessionCreateFormState(): SessionCreateFormState {
+  return {
+    ownerMode: DEFAULT_SESSION_CREATE_OWNER_MODE,
+    idleTimeoutSec: '',
+    labels: '',
+  };
+}
+
+export function validateSessionCreateForm(
+  state: SessionCreateFormState,
+): SessionCreateValidation {
+  const errors: string[] = [];
+  const command: MutableCreateSessionCommand = {};
+  const ownerMode = state.ownerMode.trim() || DEFAULT_SESSION_CREATE_OWNER_MODE;
+  if (OWNER_MODE_VALUES.has(ownerMode)) {
+    command.owner_mode = ownerMode;
+  } else {
+    errors.push(`Owner mode "${ownerMode}" is not supported.`);
+  }
+
+  const idleTimeoutSec = parseIdleTimeoutSec(state.idleTimeoutSec, errors);
+  if (idleTimeoutSec !== undefined) {
+    command.idle_timeout_sec = idleTimeoutSec;
+  }
+
+  const labels = parseSessionCreateLabels(state.labels, errors);
+  if (Object.keys(labels).length > 0) {
+    command.labels = labels;
+  }
+
+  return {
+    command: errors.length === 0 ? command : null,
+    errors,
+    preview: errors.length === 0
+      ? JSON.stringify(command, null, 2)
+      : 'Fix validation errors to preview the API payload.',
+  };
+}
+
+export function parseSessionCreateLabels(
+  value: string,
+  errors: string[] = [],
+): Readonly<Record<string, string>> {
+  const labels: Record<string, string> = {};
+  const seen = new Set<string>();
+  for (const rawPart of value.split(/[\n,]/u)) {
+    const part = rawPart.trim();
+    if (!part) {
+      continue;
+    }
+    const separator = part.indexOf('=');
+    if (separator <= 0) {
+      errors.push(`Label "${part}" must use key=value.`);
+      continue;
+    }
+    const key = part.slice(0, separator).trim();
+    const labelValue = part.slice(separator + 1).trim();
+    if (!key || !labelValue) {
+      errors.push(`Label "${part}" must use non-empty key and value.`);
+      continue;
+    }
+    if (seen.has(key)) {
+      errors.push(`Label "${key}" is duplicated.`);
+      continue;
+    }
+    seen.add(key);
+    labels[key] = labelValue;
+  }
+  return labels;
+}
+
+function parseIdleTimeoutSec(value: string, errors: string[]): number | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    errors.push('Idle timeout must be a positive whole number of seconds.');
+    return undefined;
+  }
+  if (!Number.isSafeInteger(parsed)) {
+    errors.push('Idle timeout is too large to send safely.');
+    return undefined;
+  }
+  return parsed;
+}

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -7,6 +7,8 @@ const SESSION: SessionResource = {
   id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
   state: 'active',
   owner_mode: 'shared',
+  idle_timeout_sec: 1800,
+  labels: { case: '1234', purpose: 'import-repro' },
   connect: {
     gateway_url: 'https://localhost:4433',
     transport_path: '/session',
@@ -115,6 +117,7 @@ describe('SessionViewModelBuilder', () => {
       presence: 'connected',
       clients: 1,
       mcpDelegation: 'MCP not delegated',
+      labels: 'case=1234, purpose=import-repro',
     });
     expect(viewModel.selectedSession).toMatchObject({
       id: SESSION.id,
@@ -149,6 +152,11 @@ describe('SessionViewModelBuilder', () => {
       label: 'mcp owner',
       value: 'yes',
       testId: 'session-mcp-owner',
+    });
+    expect(viewModel.facts).toContainEqual({
+      label: 'labels',
+      value: 'case=1234, purpose=import-repro',
+      testId: 'session-labels',
     });
     expect(viewModel.connections).toEqual([{
       id: 7,

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -10,6 +10,7 @@ export type SessionListItemViewModel = {
   readonly clients: number;
   readonly updatedAt: string;
   readonly mcpDelegation: string;
+  readonly labels: string;
 };
 
 export type SelectedSessionViewModel = SessionListItemViewModel & {
@@ -103,7 +104,9 @@ export class SessionViewModelBuilder {
       title: session.id,
       facts: [
         { label: 'state', value: session.state, testId: 'session-state' },
-        { label: 'owner', value: session.owner_mode },
+        { label: 'owner', value: session.owner_mode, testId: 'session-owner-mode' },
+        { label: 'idle override', value: session.idle_timeout_sec?.toString() ?? 'default', testId: 'session-idle-timeout' },
+        { label: 'labels', value: labelSummary(session.labels ?? {}), testId: 'session-labels' },
         { label: 'runtime', value: session.status.runtime_state, testId: 'session-runtime-state' },
         { label: 'presence', value: session.status.presence_state, testId: 'session-presence-state' },
         { label: 'clients', value: String(connectionCount), testId: 'session-total-clients' },
@@ -142,6 +145,7 @@ function toListItem(session: SessionResource): SessionListItemViewModel {
     clients: session.status.connection_counts.total_clients,
     updatedAt: session.updated_at,
     mcpDelegation: mcpDelegationLabel(session),
+    labels: labelSummary(session.labels ?? {}),
   };
 }
 
@@ -189,6 +193,14 @@ function yesNo(value: boolean): string {
 
 function mcpDelegationLabel(session: SessionResource): string {
   return session.automation_delegate ? 'MCP delegated' : 'MCP not delegated';
+}
+
+function labelSummary(labels: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(labels).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) {
+    return 'No labels';
+  }
+  return entries.map(([key, value]) => `${key}=${value}`).join(', ');
 }
 
 function shortId(value: string): string {

--- a/code/web/bpane-client/package.json
+++ b/code/web/bpane-client/package.json
@@ -14,6 +14,7 @@
     "smoke:session-files": "node scripts/run-session-files-smoke.mjs",
     "smoke:browser-policy": "node scripts/run-browser-policy-smoke.mjs",
     "smoke:admin-session": "node scripts/run-admin-session-smoke.mjs",
+    "smoke:admin-session-configurator": "node scripts/run-admin-session-configurator-smoke.mjs",
     "smoke:admin-realtime": "node scripts/run-admin-realtime-smoke.mjs",
     "smoke:admin-event-reconnect": "node scripts/run-admin-event-reconnect-smoke.mjs",
     "smoke:admin-session-files": "node scripts/run-admin-session-files-smoke.mjs",

--- a/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
@@ -1,0 +1,198 @@
+import fs from 'node:fs/promises';
+import process from 'node:process';
+import { chromium } from 'playwright-core';
+import {
+  cleanupAdminBeforeRun,
+  ensureAdminLoggedIn,
+  getAdminAccessToken,
+  openAdminTab,
+} from './admin-smoke-lib.mjs';
+import {
+  DEFAULTS,
+  apiOrigin,
+  createLogger,
+  deleteSession,
+  fetchJson,
+  launchChrome,
+  parseSmokeArgs,
+} from './workflow-smoke-lib.mjs';
+
+async function run() {
+  const options = parseSmokeArgs(process.argv.slice(2), 'run-admin-session-configurator-smoke.mjs');
+  if (options.pageUrl === DEFAULTS.pageUrl) {
+    options.pageUrl = `${DEFAULTS.pageUrl}/admin/`;
+  }
+  const log = createLogger('admin-session-configurator-smoke');
+  const browser = await launchChrome(chromium, options);
+  const context = await browser.newContext({ viewport: { width: 1440, height: 980 } });
+  const page = await context.newPage();
+  let sessionId = '';
+
+  try {
+    log(`Opening ${options.pageUrl}`);
+    await ensureAdminLoggedIn(page, options);
+    await cleanupAdminBeforeRun(page, options, log);
+
+    await verifyCompactPayloadToggle(page, options);
+
+    await page.goto(adminRouteUrl(options, 'sessions'), { waitUntil: 'domcontentloaded' });
+    await page.getByTestId('session-create-configurator').waitFor({
+      state: 'visible',
+      timeout: options.connectTimeoutMs,
+    });
+
+    await verifyClientValidation(page);
+    await configureCollaborativeSession(page);
+    await verifyPayloadPreview(page);
+    await page.getByTestId('session-inspector-new').click();
+    sessionId = await waitForSessionDetailUrl(page, options);
+
+    const session = await fetchSession(page, options, sessionId);
+    verifyCreatedSession(session, sessionId);
+    await verifyDetailUi(page, options, sessionId);
+    await emitSummary(page, options, session, log);
+  } finally {
+    await cleanupCreatedSession(page, options, sessionId, log);
+    await context.close();
+    await browser.close();
+  }
+}
+
+async function verifyCompactPayloadToggle(page, options) {
+  await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
+  await openAdminTab(page, 'sessions');
+  const toggle = page.getByTestId('session-create-preview-toggle');
+  await toggle.click();
+  await page.getByTestId('session-create-preview').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  await page.waitForTimeout(1500);
+  const stillVisible = await page.getByTestId('session-create-preview').isVisible().catch(() => false);
+  if (!stillVisible) {
+    throw new Error('Expected compact API payload preview to stay expanded after opening.');
+  }
+  await toggle.click();
+}
+
+async function verifyClientValidation(page) {
+  await page.getByTestId('session-create-idle-timeout').fill('0');
+  await page.getByTestId('session-create-labels').fill('case=1234\ncase=5678');
+  const disabled = await page.getByTestId('session-inspector-new').isDisabled();
+  if (!disabled) {
+    throw new Error('Expected configured session create to be disabled for invalid idle timeout and duplicate labels.');
+  }
+  const errorText = await page.getByTestId('session-create-error').textContent();
+  if (!errorText?.includes('Idle timeout') || !errorText.includes('duplicated')) {
+    throw new Error(`Expected validation errors for idle timeout and duplicate labels, got ${errorText}`);
+  }
+}
+
+async function configureCollaborativeSession(page) {
+  await page.getByTestId('session-create-owner-mode').selectOption('collaborative');
+  await page.getByTestId('session-create-idle-timeout').fill('1800');
+  await page.getByTestId('session-create-labels').fill('case=1234\npurpose=import-repro');
+}
+
+async function verifyPayloadPreview(page) {
+  const previewText = await page.getByTestId('session-create-preview').textContent();
+  const preview = JSON.parse(previewText ?? '{}');
+  const expectedLabels = { case: '1234', purpose: 'import-repro' };
+  if (
+    preview.owner_mode !== 'collaborative'
+    || preview.idle_timeout_sec !== 1800
+    || JSON.stringify(preview.labels) !== JSON.stringify(expectedLabels)
+  ) {
+    throw new Error(`Unexpected session create payload preview: ${previewText}`);
+  }
+}
+
+async function verifyDetailUi(page, options, sessionId) {
+  await page.getByTestId('session-inspector-detail').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  const title = await page.getByTestId('session-inspector-title').textContent();
+  if (!title?.includes(sessionId)) {
+    throw new Error(`Expected session detail title to include ${sessionId}, got ${title}`);
+  }
+  await page.getByTestId('session-owner-mode').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  const ownerMode = await page.getByTestId('session-owner-mode').textContent();
+  const idleTimeout = await page.getByTestId('session-idle-timeout').textContent();
+  const labels = await page.getByTestId('session-labels').textContent();
+  if (ownerMode !== 'collaborative' || idleTimeout !== '1800' || !labels?.includes('purpose=import-repro')) {
+    throw new Error(`Unexpected configured session detail facts: ${ownerMode} / ${idleTimeout} / ${labels}`);
+  }
+  await page.getByTestId('session-file-bindings').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+}
+
+function verifyCreatedSession(session, sessionId) {
+  if (session.id !== sessionId) {
+    throw new Error(`Expected API session ${sessionId}, got ${session.id}`);
+  }
+  if (session.owner_mode !== 'collaborative') {
+    throw new Error(`Expected collaborative owner mode, got ${session.owner_mode}`);
+  }
+  if (session.idle_timeout_sec !== 1800) {
+    throw new Error(`Expected idle timeout 1800, got ${session.idle_timeout_sec}`);
+  }
+  if (session.labels?.case !== '1234' || session.labels?.purpose !== 'import-repro') {
+    throw new Error(`Expected configured labels, got ${JSON.stringify(session.labels)}`);
+  }
+}
+
+async function fetchSession(page, options, sessionId) {
+  const accessToken = await getAdminAccessToken(page);
+  return await fetchJson(`${apiOrigin(options)}/api/v1/sessions/${sessionId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+}
+
+async function cleanupCreatedSession(page, options, sessionId, log) {
+  if (!sessionId) {
+    return;
+  }
+  const accessToken = await getAdminAccessToken(page).catch(() => '');
+  if (!accessToken) {
+    log(`Skipped cleanup for ${sessionId}; no admin access token is available.`);
+    return;
+  }
+  await deleteSession(accessToken, options, sessionId);
+}
+
+async function waitForSessionDetailUrl(page, options) {
+  await page.waitForURL(/\/sessions\/[^/]+$/, { timeout: options.connectTimeoutMs });
+  const sessionId = decodeURIComponent(new URL(page.url()).pathname.split('/').filter(Boolean).at(-1) ?? '');
+  if (!sessionId) {
+    throw new Error(`Could not resolve session id from ${page.url()}`);
+  }
+  return sessionId;
+}
+
+async function emitSummary(page, options, session, log) {
+  const summary = {
+    pageUrl: options.pageUrl,
+    sessionId: session.id,
+    ownerMode: session.owner_mode,
+    idleTimeoutSec: session.idle_timeout_sec,
+    labels: session.labels ?? {},
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (options.outputPath) {
+    await fs.writeFile(options.outputPath, JSON.stringify(summary, null, 2));
+    log(`Wrote summary to ${options.outputPath}`);
+  }
+}
+
+function adminRouteUrl(options, routePath) {
+  const baseUrl = new URL(options.pageUrl);
+  if (!baseUrl.pathname.endsWith('/')) {
+    baseUrl.pathname = `${baseUrl.pathname}/`;
+  }
+  return new URL(routePath, baseUrl).toString();
+}
+
+run().catch((error) => {
+  console.error(`[admin-session-configurator-smoke] ${error.stack || error.message}`);
+  process.exitCode = 1;
+});

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -39,6 +39,8 @@ async function run() {
     sessionId = await resolveSelectedSessionId(page, options);
     await waitForMcpDelegationReady(page, options);
     await waitForBrowserConnected(page, options);
+    await expectGlobalMessage(page, options, (message) => message.trim().length > 0);
+    await dismissGlobalMessage(page, options);
     await verifyBrowserPolicyPanel(page);
     await verifyRemainingPanels(page);
     await openAdminTab(page, 'display');
@@ -59,6 +61,7 @@ async function run() {
     await waitForStopEnabled(page, options, sessionId);
     await page.getByTestId('session-stop').click();
     await waitForSessionState(page, options, sessionId, 'stopped');
+    await expectLifecycleMessage(page, options, 'Selected session stopped.');
 
     log(`Reconnecting stopped session ${sessionId}.`);
     await openAdminTab(page, 'sessions');
@@ -70,6 +73,7 @@ async function run() {
     await waitForKillEnabled(page, options, sessionId);
     await page.getByTestId('session-kill').click();
     await waitForSessionState(page, options, sessionId, 'stopped');
+    await expectLifecycleMessage(page, options, 'Selected session was force killed.');
     await emitSummary(page, options, sessionId, stopDisabled, log);
   } finally {
     await cleanupAdminSmoke(page, options, log);
@@ -125,6 +129,33 @@ async function disconnectThroughSessionInspector(page, options) {
     (status) => status === 'Disconnected',
     options.connectTimeoutMs,
   );
+  await expectLifecycleMessage(page, options, 'Disconnected all live clients.');
+}
+
+async function expectLifecycleMessage(page, options, expectedText) {
+  await poll(
+    `admin lifecycle message ${expectedText}`,
+    async () => await page.getByTestId('session-lifecycle-message').textContent().catch(() => ''),
+    (message) => message.includes(expectedText),
+    options.connectTimeoutMs,
+    100,
+  );
+}
+
+async function expectGlobalMessage(page, options, matches) {
+  await page.getByTestId('admin-global-message-region').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await poll(
+    'admin global message',
+    async () => await page.getByTestId('admin-global-message').textContent().catch(() => ''),
+    matches,
+    options.connectTimeoutMs,
+    100,
+  );
+}
+
+async function dismissGlobalMessage(page, options) {
+  await page.getByTestId('admin-global-message-dismiss').click();
+  await page.getByTestId('admin-global-message-region').waitFor({ state: 'hidden', timeout: options.connectTimeoutMs });
 }
 
 async function waitForMcpDelegationReady(page, options) {


### PR DESCRIPTION
## Summary

- Add the admin session creation configurator with payload preview, validation, configured create flow, and smoke coverage.
- Introduce shared admin message rendering across the admin app for action feedback, inline errors, loading states, and empty states.
- Add global operations-overlay notifications for browser connection, event-stream health, selected-session state diffs, workflow follow/run transitions, files, recordings, and MCP delegation changes.
- Tighten stale async feedback handling across workflow operations, lifecycle operations, live browser actions, recording, policy, MCP, session files, and inspector detail views.

## Validation

- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `node --check scripts/run-admin-session-smoke.mjs`
- `node --check scripts/run-admin-session-configurator-smoke.mjs`
- `git diff --check main...HEAD`

Closes #93
Closes #95