### PR TITLE
Fix MCP bridge health URL path prefix

### DIFF
--- a/code/web/bpane-admin/src/lib/api/mcp-bridge-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/mcp-bridge-client.test.ts
@@ -42,6 +42,29 @@ describe('McpBridgeClient', () => {
     );
   });
 
+  it('preserves path prefixes when loading bridge health', async () => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({
+      status: 'ok',
+      clients: 0,
+      control_session_id: null,
+      control_session_state: null,
+      control_session_backend_delegated: false,
+      bridge_alignment: null,
+      managed_sessions: [],
+    }));
+    const client = new McpBridgeClient({
+      controlUrl: 'https://example.test/mcp-control/control-session',
+      fetchImpl,
+    });
+
+    await client.getHealth();
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('https://example.test/mcp-control/health'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
   it('sets and clears the bridge control session', async () => {
     const fetchImpl = vi.fn<typeof fetch>(async () => jsonResponse({
       session: { id: 'session-b' },

--- a/code/web/bpane-admin/src/lib/api/mcp-bridge-client.ts
+++ b/code/web/bpane-admin/src/lib/api/mcp-bridge-client.ts
@@ -78,7 +78,11 @@ export class McpBridgeClient {
 
   #healthUrl(): URL {
     const healthUrl = new URL(this.#controlUrl);
-    healthUrl.pathname = '/health';
+    const controlPath = healthUrl.pathname.endsWith('/')
+      ? healthUrl.pathname.slice(0, -1)
+      : healthUrl.pathname;
+    const lastSeparator = controlPath.lastIndexOf('/');
+    healthUrl.pathname = `${controlPath.slice(0, lastSeparator + 1)}health`;
     healthUrl.search = '';
     return healthUrl;
   }


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- preserve the reverse-proxy path prefix when deriving the MCP bridge health URL from the configured control-session URL
- keep existing origin-level `/control-session -> /health` behavior unchanged
- add a regression test for a path-prefixed `/mcp-control/control-session` deployment

Closes #110

## Tests
- `npm test -- src/lib/api/mcp-bridge-client.test.ts -t 'preserves path prefixes when loading bridge health'`
- `npm test -- src/lib/api/mcp-bridge-client.test.ts`
- `npx tsc --noEmit --ignoreConfig --moduleResolution bundler --module esnext --target es2022 src/lib/api/mcp-bridge-client.ts src/lib/api/mcp-bridge-client.test.ts`

Note: these focused checks ran in an API-only temporary workspace using the admin package files needed for this change.