### PR TITLE
BPANE-00120 session runtime lifecycle hardening

### DIFF
--- a/code/apps/bpane-gateway/migrations/20260518000100_session_runtime_release.sql
+++ b/code/apps/bpane-gateway/migrations/20260518000100_session_runtime_release.sql
@@ -1,0 +1,2 @@
+ALTER TABLE control_sessions
+    ADD COLUMN IF NOT EXISTS runtime_released_at TIMESTAMPTZ NULL;

--- a/code/apps/bpane-gateway/src/api/admin_events/snapshots.rs
+++ b/code/apps/bpane-gateway/src/api/admin_events/snapshots.rs
@@ -19,6 +19,33 @@ pub(super) struct AdminSessionsSnapshotEvent {
 }
 
 #[derive(Debug, Serialize)]
+struct AdminSessionSnapshotChangeSummary {
+    id: Uuid,
+    state: crate::session_control::SessionLifecycleState,
+    template_id: Option<String>,
+    owner_mode: crate::session_control::SessionOwnerMode,
+    viewport: crate::session_control::SessionViewport,
+    automation_delegate: Option<crate::session_control::SessionAutomationDelegate>,
+    idle_timeout_sec: Option<u32>,
+    labels: Vec<(String, String)>,
+    extensions: Vec<AdminAppliedExtensionSummary>,
+    recording: crate::session_control::SessionRecordingPolicy,
+    runtime: crate::session_control::SessionRuntimeInfo,
+    status: crate::session_control::SessionStatusSummary,
+    created_at: chrono::DateTime<Utc>,
+    runtime_released_at: Option<chrono::DateTime<Utc>>,
+    stopped_at: Option<chrono::DateTime<Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminAppliedExtensionSummary {
+    extension_id: Uuid,
+    extension_version_id: Uuid,
+    name: String,
+    version: String,
+}
+
+#[derive(Debug, Serialize)]
 pub(super) struct AdminWorkflowRunsSnapshotEvent {
     event_type: &'static str,
     sequence: u64,
@@ -103,7 +130,11 @@ pub(super) async fn build_sessions_snapshot(
         resources.push(session_resource(state, &session, None).await?);
     }
     resources.sort_by_key(|session| session.id);
-    let change_key = serialized_change_key(&resources)?;
+    let change_summaries = resources
+        .iter()
+        .map(session_snapshot_change_summary)
+        .collect::<Vec<_>>();
+    let change_key = serialized_change_key(&change_summaries)?;
     Ok(AdminChangedEvent {
         event: AdminSessionsSnapshotEvent {
             event_type: SESSIONS_SNAPSHOT_EVENT_TYPE,
@@ -113,6 +144,51 @@ pub(super) async fn build_sessions_snapshot(
         },
         change_key,
     })
+}
+
+fn session_snapshot_change_summary(session: &SessionResource) -> AdminSessionSnapshotChangeSummary {
+    let mut labels = session
+        .labels
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<Vec<_>>();
+    labels.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+
+    let mut extensions = session
+        .extensions
+        .iter()
+        .map(|extension| AdminAppliedExtensionSummary {
+            extension_id: extension.extension_id,
+            extension_version_id: extension.extension_version_id,
+            name: extension.name.clone(),
+            version: extension.version.clone(),
+        })
+        .collect::<Vec<_>>();
+    extensions.sort_by(|left, right| {
+        left.extension_id
+            .cmp(&right.extension_id)
+            .then_with(|| left.extension_version_id.cmp(&right.extension_version_id))
+            .then_with(|| left.name.cmp(&right.name))
+            .then_with(|| left.version.cmp(&right.version))
+    });
+
+    AdminSessionSnapshotChangeSummary {
+        id: session.id,
+        state: session.state,
+        template_id: session.template_id.clone(),
+        owner_mode: session.owner_mode,
+        viewport: session.viewport.clone(),
+        automation_delegate: session.automation_delegate.clone(),
+        idle_timeout_sec: session.idle_timeout_sec,
+        labels,
+        extensions,
+        recording: session.recording.clone(),
+        runtime: session.runtime.clone(),
+        status: session.status.clone(),
+        created_at: session.created_at,
+        runtime_released_at: session.runtime_released_at,
+        stopped_at: session.stopped_at,
+    }
 }
 
 pub(super) async fn build_workflow_runs_snapshot(
@@ -290,14 +366,44 @@ fn serialized_change_key<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session_control::{
+        SessionCapabilities, SessionConnectInfo, SessionConnectionCounts, SessionIdleStatus,
+        SessionOwner, SessionPresenceState, SessionRuntimeInfo, SessionRuntimeResumeMode,
+        SessionRuntimeState, SessionStatusSummary, SessionStopEligibility, SessionViewport,
+    };
+    use std::collections::HashMap;
 
     #[test]
-    fn session_snapshot_change_key_ignores_event_metadata() {
-        let payload = vec!["session-a".to_string(), "session-b".to_string()];
-        let first_key = serialized_change_key(&payload).unwrap();
-        let second_key = serialized_change_key(&payload).unwrap();
+    fn session_snapshot_change_key_uses_stable_summary_for_unchanged_resources() {
+        let first = session_resource_fixture(HashMap::from([
+            ("b".to_string(), "2".to_string()),
+            ("a".to_string(), "1".to_string()),
+        ]));
+        let mut second = session_resource_fixture(HashMap::from([
+            ("a".to_string(), "1".to_string()),
+            ("b".to_string(), "2".to_string()),
+        ]));
+        second.created_at = first.created_at;
+        second.updated_at = second.updated_at + chrono::Duration::seconds(1);
+        let first_key =
+            serialized_change_key(&vec![session_snapshot_change_summary(&first)]).unwrap();
+        let second_key =
+            serialized_change_key(&vec![session_snapshot_change_summary(&second)]).unwrap();
 
         assert_eq!(first_key, second_key);
+    }
+
+    #[test]
+    fn session_snapshot_change_key_tracks_session_state() {
+        let ready = session_resource_fixture(HashMap::new());
+        let mut active = ready.clone();
+        active.state = SessionLifecycleState::Active;
+        let ready_key =
+            serialized_change_key(&vec![session_snapshot_change_summary(&ready)]).unwrap();
+        let active_key =
+            serialized_change_key(&vec![session_snapshot_change_summary(&active)]).unwrap();
+
+        assert_ne!(ready_key, active_key);
     }
 
     #[test]
@@ -387,5 +493,59 @@ mod tests {
         .unwrap();
 
         assert_ne!(empty_key, delegated_key);
+    }
+
+    fn session_resource_fixture(labels: HashMap<String, String>) -> SessionResource {
+        let now = Utc::now();
+        SessionResource {
+            id: Uuid::nil(),
+            state: SessionLifecycleState::Ready,
+            template_id: None,
+            owner_mode: SessionOwnerMode::Collaborative,
+            viewport: SessionViewport {
+                width: 1600,
+                height: 900,
+            },
+            capabilities: SessionCapabilities::default(),
+            owner: SessionOwner {
+                subject: "owner".to_string(),
+                issuer: "issuer".to_string(),
+                display_name: None,
+            },
+            automation_delegate: None,
+            idle_timeout_sec: Some(300),
+            labels,
+            integration_context: None,
+            extensions: Vec::new(),
+            recording: SessionRecordingPolicy::default(),
+            connect: SessionConnectInfo {
+                gateway_url: "https://gateway.example".to_string(),
+                transport_path: "/session".to_string(),
+                auth_type: "session_connect_ticket".to_string(),
+                ticket_path: Some("/api/v1/sessions/000/access-tokens".to_string()),
+                compatibility_mode: "session_runtime_pool".to_string(),
+            },
+            runtime: SessionRuntimeInfo {
+                binding: "docker_pool".to_string(),
+                compatibility_mode: "session_runtime_pool".to_string(),
+                cdp_endpoint: None,
+            },
+            status: SessionStatusSummary {
+                runtime_state: SessionRuntimeState::NotStarted,
+                runtime_resume_mode: SessionRuntimeResumeMode::FreshStart,
+                presence_state: SessionPresenceState::Empty,
+                connection_counts: SessionConnectionCounts::default(),
+                stop_eligibility: SessionStopEligibility::default(),
+                idle: SessionIdleStatus {
+                    idle_timeout_sec: Some(300),
+                    idle_since: None,
+                    idle_deadline: None,
+                },
+            },
+            created_at: now,
+            updated_at: now,
+            runtime_released_at: None,
+            stopped_at: None,
+        }
     }
 }

--- a/code/apps/bpane-gateway/src/api/authz/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/authz/sessions.rs
@@ -95,8 +95,9 @@ pub(in crate::api) async fn prepare_runtime_access_session(
             )
         })?;
     let was_stopped = stored.state == SessionLifecycleState::Stopped;
+    let was_released = stored.state == SessionLifecycleState::Released;
 
-    let connectable = if was_stopped {
+    let connectable = if was_stopped || was_released {
         let prepared = state
             .session_store
             .prepare_session_for_connect(session_id)
@@ -128,7 +129,12 @@ pub(in crate::api) async fn prepare_runtime_access_session(
         .ensure_auto_recording(&connectable)
         .await
     {
-        if was_stopped {
+        if was_released {
+            let _ = state
+                .session_store
+                .release_session_runtime_for_owner(principal, session_id)
+                .await;
+        } else if was_stopped {
             let _ = state.session_store.stop_session_if_idle(session_id).await;
             state.session_manager.release(session_id).await;
             state.registry.remove_session(session_id).await;

--- a/code/apps/bpane-gateway/src/api/resources.rs
+++ b/code/apps/bpane-gateway/src/api/resources.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 
 use crate::auth::AuthenticatedPrincipal;
 use crate::session_control::{
-    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
-    SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
-    SessionStoreError, StoredSession,
+    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeResumeMode,
+    SessionRuntimeState, SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind,
+    SessionStopEligibility, SessionStoreError, StoredSession,
 };
 use crate::session_manager::SessionRuntimeAssignmentStatus;
 
@@ -23,6 +23,8 @@ pub(super) async fn session_status_summary(
         .describe_session_runtime_assignment_status(stored.id)
         .await;
     let runtime_state = derive_session_runtime_state(stored.state, runtime_assignment);
+    let runtime_resume_mode =
+        derive_session_runtime_resume_mode(stored, runtime_assignment, runtime_state);
     let connection_counts = session_connection_counts_from_snapshot(snapshot);
     let presence_state = derive_session_presence_state(stored.state, &connection_counts);
     let owner = session_owner_principal(stored);
@@ -67,6 +69,7 @@ pub(super) async fn session_status_summary(
 
     Ok(SessionStatusSummary {
         runtime_state,
+        runtime_resume_mode,
         presence_state,
         connection_counts,
         stop_eligibility,
@@ -138,6 +141,7 @@ fn derive_session_runtime_state(
         SessionLifecycleState::Stopped
         | SessionLifecycleState::Failed
         | SessionLifecycleState::Expired => SessionRuntimeState::Stopped,
+        SessionLifecycleState::Released => SessionRuntimeState::Released,
         SessionLifecycleState::Stopping => SessionRuntimeState::Stopping,
         SessionLifecycleState::Starting => SessionRuntimeState::Starting,
         SessionLifecycleState::Pending => match runtime_assignment {
@@ -151,6 +155,33 @@ fn derive_session_runtime_state(
             Some(SessionRuntimeAssignmentStatus::Starting) => SessionRuntimeState::Starting,
             Some(SessionRuntimeAssignmentStatus::Ready) => SessionRuntimeState::Running,
             None => SessionRuntimeState::NotStarted,
+        },
+    }
+}
+
+fn derive_session_runtime_resume_mode(
+    stored: &StoredSession,
+    runtime_assignment: Option<SessionRuntimeAssignmentStatus>,
+    runtime_state: SessionRuntimeState,
+) -> SessionRuntimeResumeMode {
+    match runtime_state {
+        SessionRuntimeState::Stopped | SessionRuntimeState::Stopping => {
+            SessionRuntimeResumeMode::Stopped
+        }
+        SessionRuntimeState::Released => SessionRuntimeResumeMode::Released,
+        SessionRuntimeState::Running | SessionRuntimeState::Starting => {
+            if stored.runtime_released_at.is_some() {
+                SessionRuntimeResumeMode::ProfileRestart
+            } else {
+                SessionRuntimeResumeMode::ExactLive
+            }
+        }
+        SessionRuntimeState::NotStarted => match runtime_assignment {
+            Some(_) => SessionRuntimeResumeMode::ExactLive,
+            None if stored.runtime_released_at.is_some() => {
+                SessionRuntimeResumeMode::ProfileRestart
+            }
+            None => SessionRuntimeResumeMode::FreshStart,
         },
     }
 }

--- a/code/apps/bpane-gateway/src/api/sessions.rs
+++ b/code/apps/bpane-gateway/src/api/sessions.rs
@@ -8,6 +8,7 @@ mod disconnect;
 mod kill;
 mod mcp;
 mod ownership;
+mod release;
 mod status;
 mod stop;
 
@@ -52,6 +53,10 @@ pub(super) fn session_operation_routes() -> Router<Arc<ApiState>> {
         .route(
             "/api/v1/sessions/{session_id}/kill",
             post(kill::kill_session),
+        )
+        .route(
+            "/api/v1/sessions/{session_id}/release",
+            post(release::release_session_runtime),
         )
         .route(
             "/api/v1/sessions/{session_id}/stop",

--- a/code/apps/bpane-gateway/src/api/sessions/release.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/release.rs
@@ -1,0 +1,102 @@
+use axum::response::{IntoResponse, Response};
+use tracing::info;
+
+use super::super::*;
+use crate::session_control::{SessionStopBlockerKind, SessionStopEligibility};
+
+pub(super) async fn release_session_runtime(
+    headers: HeaderMap,
+    Path(session_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+
+    let stored = state
+        .session_store
+        .get_session_for_owner(&principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    let status = session_status_summary(&state, &stored)
+        .await
+        .map_err(map_session_store_error)?;
+    if !status.stop_eligibility.allowed {
+        let session = session_resource(&state, &stored, None)
+            .await
+            .map_err(map_session_store_error)?;
+        return Ok((
+            StatusCode::CONFLICT,
+            Json(SessionStopConflictResponse {
+                error: session_release_conflict_message(&status.stop_eligibility),
+                session,
+            }),
+        )
+            .into_response());
+    }
+
+    let released = state
+        .session_store
+        .release_session_runtime_for_owner(&principal, session_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session {session_id} not found"),
+                }),
+            )
+        })?;
+
+    state.session_manager.release(session_id).await;
+    state.registry.remove_session(session_id).await;
+    info!(%session_id, "released session runtime and preserved session resource");
+
+    let resource = session_resource(&state, &released, None)
+        .await
+        .map_err(map_session_store_error)?;
+    Ok((StatusCode::OK, Json(resource)).into_response())
+}
+
+fn session_release_conflict_message(stop_eligibility: &SessionStopEligibility) -> String {
+    let blockers = stop_eligibility
+        .blockers
+        .iter()
+        .map(|blocker| match blocker.kind {
+            SessionStopBlockerKind::OwnerClients => {
+                format!("{} owner client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::ViewerClients => {
+                format!("{} viewer client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::RecorderClients => {
+                format!("{} recorder client(s)", blocker.count)
+            }
+            SessionStopBlockerKind::AutomationOwner => {
+                format!("{} automation owner(s)", blocker.count)
+            }
+            SessionStopBlockerKind::RecordingActivity => {
+                format!("{} active recording operation(s)", blocker.count)
+            }
+            SessionStopBlockerKind::AutomationTasks => {
+                format!("{} active automation task(s)", blocker.count)
+            }
+            SessionStopBlockerKind::WorkflowRuns => {
+                format!("{} active workflow run(s)", blocker.count)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!("session runtime cannot be released while blockers remain: {blockers}")
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -362,7 +362,7 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
 }
 
 #[tokio::test]
-async fn stopped_session_cannot_issue_a_new_connect_ticket() {
+async fn stopped_session_can_issue_a_new_connect_ticket_for_profile_restart() {
     let (app, token) = test_router();
 
     let created = response_json(
@@ -408,7 +408,10 @@ async fn stopped_session_cannot_issue_a_new_connect_ticket() {
         )
         .await
         .unwrap();
-    assert_eq!(issue_response.status(), StatusCode::CONFLICT);
+    assert_eq!(issue_response.status(), StatusCode::OK);
+    let issued = response_json(issue_response).await;
+    assert_eq!(issued["session_id"], session_id);
+    assert_eq!(issued["token_type"], "session_connect_ticket");
 
     let get_response = app
         .clone()
@@ -423,8 +426,11 @@ async fn stopped_session_cannot_issue_a_new_connect_ticket() {
         .unwrap();
     assert_eq!(get_response.status(), StatusCode::OK);
     let fetched = response_json(get_response).await;
-    assert_eq!(fetched["state"], "stopped");
-    assert!(fetched["stopped_at"].is_string());
+    assert_eq!(fetched["state"], "ready");
+    assert_eq!(fetched["status"]["runtime_state"], "not_started");
+    assert_eq!(fetched["status"]["runtime_resume_mode"], "profile_restart");
+    assert!(fetched["runtime_released_at"].is_string());
+    assert!(fetched["stopped_at"].is_null());
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::session_control::{
-    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeState,
-    SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind, SessionStopEligibility,
+    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeResumeMode,
+    SessionRuntimeState, SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind,
+    SessionStopEligibility,
 };
 use crate::session_hub::{SessionConnectionTelemetry, SessionConnectionTelemetryRole};
 
@@ -46,6 +47,7 @@ fn session_status_maps_recorder_clients() {
         SessionLifecycleState::Active,
         SessionStatusSummary {
             runtime_state: SessionRuntimeState::Running,
+            runtime_resume_mode: SessionRuntimeResumeMode::ExactLive,
             presence_state: SessionPresenceState::Connected,
             connection_counts: SessionConnectionCounts {
                 interactive_clients: 2,
@@ -360,7 +362,7 @@ async fn creates_lists_gets_and_stops_a_session_resource() {
 }
 
 #[tokio::test]
-async fn stopped_session_can_issue_a_new_connect_ticket_and_resume() {
+async fn stopped_session_cannot_issue_a_new_connect_ticket() {
     let (app, token) = test_router();
 
     let created = response_json(
@@ -406,6 +408,78 @@ async fn stopped_session_can_issue_a_new_connect_ticket_and_resume() {
         )
         .await
         .unwrap();
+    assert_eq!(issue_response.status(), StatusCode::CONFLICT);
+
+    let get_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{session_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(get_response.status(), StatusCode::OK);
+    let fetched = response_json(get_response).await;
+    assert_eq!(fetched["state"], "stopped");
+    assert!(fetched["stopped_at"].is_string());
+}
+
+#[tokio::test]
+async fn released_session_can_issue_a_new_connect_ticket_for_profile_restart() {
+    let (app, token) = test_router();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({ "idle_timeout_sec": 300 }).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = created["id"].as_str().unwrap().to_string();
+
+    let release_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/release"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(release_response.status(), StatusCode::OK);
+    let released = response_json(release_response).await;
+    assert_eq!(released["state"], "released");
+    assert_eq!(released["status"]["runtime_state"], "released");
+    assert_eq!(released["status"]["runtime_resume_mode"], "released");
+    assert!(released["runtime_released_at"].is_string());
+    assert!(released["stopped_at"].is_null());
+
+    let issue_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/access-tokens"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_eq!(issue_response.status(), StatusCode::OK);
     let issued = response_json(issue_response).await;
     assert_eq!(issued["session_id"], session_id);
@@ -425,5 +499,7 @@ async fn stopped_session_can_issue_a_new_connect_ticket_and_resume() {
     assert_eq!(get_response.status(), StatusCode::OK);
     let fetched = response_json(get_response).await;
     assert_eq!(fetched["state"], "ready");
-    assert!(fetched["stopped_at"].is_null());
+    assert_eq!(fetched["status"]["runtime_state"], "not_started");
+    assert_eq!(fetched["status"]["runtime_resume_mode"], "profile_restart");
+    assert!(fetched["runtime_released_at"].is_string());
 }

--- a/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
@@ -241,12 +241,6 @@ impl InMemorySessionStore {
         if state != SessionLifecycleState::Released && state != SessionLifecycleState::Stopped {
             return Ok(Some(sessions[index].clone()));
         }
-        if state == SessionLifecycleState::Stopped {
-            return Err(SessionStoreError::Conflict(format!(
-                "session {id} is stopped; create a new session before connecting"
-            )));
-        }
-
         let active_runtime_candidates = active_runtime_candidate_count(&sessions);
         if active_runtime_candidates >= self.config.max_runtime_candidates {
             return Err(SessionStoreError::ActiveSessionConflict {
@@ -255,6 +249,12 @@ impl InMemorySessionStore {
         }
 
         let session = &mut sessions[index];
+        if state == SessionLifecycleState::Stopped {
+            session.runtime_released_at = session
+                .stopped_at
+                .or(session.runtime_released_at)
+                .or_else(|| Some(Utc::now()));
+        }
         session.state = SessionLifecycleState::Ready;
         session.updated_at = Utc::now();
         session.stopped_at = None;

--- a/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
@@ -56,6 +56,7 @@ impl InMemorySessionStore {
             recording: request.recording,
             created_at: now,
             updated_at: now,
+            runtime_released_at: None,
             stopped_at: None,
         };
         sessions.push(session.clone());
@@ -152,6 +153,40 @@ impl InMemorySessionStore {
         Ok(Some(session.clone()))
     }
 
+    pub(in crate::session_control) async fn release_session_runtime_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSession>, SessionStoreError> {
+        let mut sessions = self.sessions.lock().await;
+        let Some(session) = sessions.iter_mut().find(|session| {
+            session.id == id
+                && session.owner.subject == principal.subject
+                && session.owner.issuer == principal.issuer
+        }) else {
+            return Ok(None);
+        };
+
+        if session.state == SessionLifecycleState::Stopped {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} is stopped; create a new session instead of releasing it"
+            )));
+        }
+        if !session.state.is_runtime_candidate() && session.state != SessionLifecycleState::Released
+        {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} cannot release a runtime from state {}",
+                session.state.as_str()
+            )));
+        }
+
+        session.state = SessionLifecycleState::Released;
+        session.updated_at = Utc::now();
+        session.runtime_released_at = Some(session.updated_at);
+        session.stopped_at = None;
+        Ok(Some(session.clone()))
+    }
+
     pub(in crate::session_control) async fn mark_session_state(
         &self,
         id: Uuid,
@@ -203,8 +238,13 @@ impl InMemorySessionStore {
         };
 
         let state = sessions[index].state;
-        if state != SessionLifecycleState::Stopped {
+        if state != SessionLifecycleState::Released && state != SessionLifecycleState::Stopped {
             return Ok(Some(sessions[index].clone()));
+        }
+        if state == SessionLifecycleState::Stopped {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} is stopped; create a new session before connecting"
+            )));
         }
 
         let active_runtime_candidates = active_runtime_candidate_count(&sessions);

--- a/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
@@ -200,6 +200,9 @@ impl InMemorySessionStore {
         if !session.state.is_runtime_candidate() {
             return Ok(Some(session.clone()));
         }
+        if session.state == state {
+            return Ok(Some(session.clone()));
+        }
 
         session.state = state;
         session.updated_at = Utc::now();

--- a/code/apps/bpane-gateway/src/session_control/postgres/runtime_assignments.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/runtime_assignments.rs
@@ -49,6 +49,7 @@ const SESSION_RECOVERY_COLUMNS: &str = r#"
     recording,
     created_at,
     updated_at,
+    runtime_released_at,
     stopped_at
 "#;
 

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions.rs
@@ -24,6 +24,7 @@ const SESSION_COLUMNS: &str = r#"
     recording,
     created_at,
     updated_at,
+    runtime_released_at,
     stopped_at
 "#;
 
@@ -98,6 +99,16 @@ impl PostgresSessionStore {
     ) -> Result<Option<StoredSession>, SessionStoreError> {
         self.session_repository()
             .stop_session_for_owner(principal, id)
+            .await
+    }
+
+    pub(in crate::session_control) async fn release_session_runtime_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSession>, SessionStoreError> {
+        self.session_repository()
+            .release_session_runtime_for_owner(principal, id)
             .await
     }
 

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
@@ -278,12 +278,6 @@ impl SessionRepository<'_> {
             })?;
             return Ok(Some(current));
         }
-        if current.state == SessionLifecycleState::Stopped {
-            return Err(SessionStoreError::Conflict(format!(
-                "session {id} is stopped; create a new session before connecting"
-            )));
-        }
-
         let active_runtime_candidates = self
             .count_active_runtime_candidates_in_transaction(&transaction)
             .await?;
@@ -299,6 +293,7 @@ impl SessionRepository<'_> {
             SET
                 state = 'ready',
                 updated_at = NOW(),
+                runtime_released_at = COALESCE(stopped_at, runtime_released_at, NOW()),
                 stopped_at = NULL
             WHERE id = $1
             RETURNING

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
@@ -123,6 +123,57 @@ impl SessionRepository<'_> {
         row.as_ref().map(row_to_stored_session).transpose()
     }
 
+    pub(in crate::session_control) async fn release_session_runtime_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSession>, SessionStoreError> {
+        let current = self
+            .get_session_for_owner(principal, id)
+            .await?
+            .ok_or_else(|| SessionStoreError::NotFound(format!("session {id} not found")))?;
+        if current.state == SessionLifecycleState::Stopped {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} is stopped; create a new session instead of releasing it"
+            )));
+        }
+        if !current.state.is_runtime_candidate() && current.state != SessionLifecycleState::Released
+        {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} cannot release a runtime from state {}",
+                current.state.as_str()
+            )));
+        }
+
+        let update_query = format!(
+            r#"
+            UPDATE control_sessions
+            SET
+                state = 'released',
+                updated_at = NOW(),
+                runtime_released_at = NOW(),
+                stopped_at = NULL
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            RETURNING
+                {SESSION_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(&update_query, &[&id, &principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to release session runtime: {error}"))
+            })?;
+
+        row.as_ref().map(row_to_stored_session).transpose()
+    }
+
     pub(in crate::session_control) async fn mark_session_state(
         &self,
         id: Uuid,
@@ -219,11 +270,18 @@ impl SessionRepository<'_> {
         };
 
         let current = row_to_stored_session(&current_row)?;
-        if current.state != SessionLifecycleState::Stopped {
+        if current.state != SessionLifecycleState::Released
+            && current.state != SessionLifecycleState::Stopped
+        {
             transaction.commit().await.map_err(|error| {
                 SessionStoreError::Backend(format!("failed to commit transaction: {error}"))
             })?;
             return Ok(Some(current));
+        }
+        if current.state == SessionLifecycleState::Stopped {
+            return Err(SessionStoreError::Conflict(format!(
+                "session {id} is stopped; create a new session before connecting"
+            )));
         }
 
         let active_runtime_candidates = self

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
@@ -184,7 +184,7 @@ impl SessionRepository<'_> {
             UPDATE control_sessions
             SET
                 state = $2,
-                updated_at = NOW()
+                updated_at = CASE WHEN state = $2 THEN updated_at ELSE NOW() END
             WHERE id = $1
               AND state IN ('pending', 'starting', 'ready', 'active', 'idle')
             RETURNING

--- a/code/apps/bpane-gateway/src/session_control/rows/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/sessions.rs
@@ -73,6 +73,7 @@ pub(in crate::session_control) fn row_to_stored_session(
         recording,
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
+        runtime_released_at: row.get("runtime_released_at"),
         stopped_at: row.get("stopped_at"),
     })
 }

--- a/code/apps/bpane-gateway/src/session_control/store/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/store/sessions.rs
@@ -58,6 +58,21 @@ impl SessionStore {
         }
     }
 
+    pub async fn release_session_runtime_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSession>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.release_session_runtime_for_owner(principal, id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.release_session_runtime_for_owner(principal, id).await
+            }
+        }
+    }
+
     pub async fn get_session_for_principal(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
@@ -172,5 +172,10 @@ async fn reconnect_prep_respects_runtime_pool_capacity() {
         .prepare_session_for_connect(stopped.id)
         .await
         .unwrap_err();
-    assert!(matches!(error, SessionStoreError::Conflict(_)));
+    assert!(matches!(
+        error,
+        SessionStoreError::ActiveSessionConflict {
+            max_runtime_sessions: 1
+        }
+    ));
 }

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
@@ -172,10 +172,5 @@ async fn reconnect_prep_respects_runtime_pool_capacity() {
         .prepare_session_for_connect(stopped.id)
         .await
         .unwrap_err();
-    assert!(matches!(
-        error,
-        SessionStoreError::ActiveSessionConflict {
-            max_runtime_sessions: 1
-        }
-    ));
+    assert!(matches!(error, SessionStoreError::Conflict(_)));
 }

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
@@ -75,7 +75,7 @@ async fn in_memory_store_stops_unused_ready_sessions_and_idle_sessions() {
 }
 
 #[tokio::test]
-async fn in_memory_store_can_prepare_a_stopped_session_for_reconnect() {
+async fn in_memory_store_rejects_stopped_session_reconnect_prep() {
     let store = SessionStore::in_memory();
     let owner = principal("owner");
     let created = store
@@ -104,6 +104,44 @@ async fn in_memory_store_can_prepare_a_stopped_session_for_reconnect() {
         .unwrap();
     assert_eq!(stopped.state, SessionLifecycleState::Stopped);
 
+    let error = store
+        .prepare_session_for_connect(created.id)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, SessionStoreError::Conflict(_)));
+}
+
+#[tokio::test]
+async fn in_memory_store_can_prepare_a_released_session_for_reconnect() {
+    let store = SessionStore::in_memory();
+    let owner = principal("owner");
+    let created = store
+        .create_session(
+            &owner,
+            CreateSessionRequest {
+                template_id: None,
+                owner_mode: None,
+                viewport: None,
+                idle_timeout_sec: Some(300),
+                labels: HashMap::new(),
+                integration_context: None,
+                extension_ids: Vec::new(),
+                extensions: Vec::new(),
+                recording: SessionRecordingPolicy::default(),
+            },
+            SessionOwnerMode::Collaborative,
+        )
+        .await
+        .unwrap();
+
+    let released = store
+        .release_session_runtime_for_owner(&owner, created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(released.state, SessionLifecycleState::Released);
+    assert!(released.runtime_released_at.is_some());
+
     let resumed = store
         .prepare_session_for_connect(created.id)
         .await
@@ -111,6 +149,7 @@ async fn in_memory_store_can_prepare_a_stopped_session_for_reconnect() {
         .unwrap();
     assert_eq!(resumed.state, SessionLifecycleState::Ready);
     assert!(resumed.stopped_at.is_none());
+    assert!(resumed.runtime_released_at.is_some());
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
@@ -75,7 +75,7 @@ async fn in_memory_store_stops_unused_ready_sessions_and_idle_sessions() {
 }
 
 #[tokio::test]
-async fn in_memory_store_rejects_stopped_session_reconnect_prep() {
+async fn in_memory_store_can_prepare_a_stopped_session_for_reconnect() {
     let store = SessionStore::in_memory();
     let owner = principal("owner");
     let created = store
@@ -104,11 +104,14 @@ async fn in_memory_store_rejects_stopped_session_reconnect_prep() {
         .unwrap();
     assert_eq!(stopped.state, SessionLifecycleState::Stopped);
 
-    let error = store
+    let resumed = store
         .prepare_session_for_connect(created.id)
         .await
-        .unwrap_err();
-    assert!(matches!(error, SessionStoreError::Conflict(_)));
+        .unwrap()
+        .unwrap();
+    assert_eq!(resumed.state, SessionLifecycleState::Ready);
+    assert!(resumed.stopped_at.is_none());
+    assert!(resumed.runtime_released_at.is_some());
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
@@ -55,9 +55,17 @@ async fn in_memory_store_stops_unused_ready_sessions_and_idle_sessions() {
         .unwrap()
         .unwrap();
     assert_eq!(active.state, SessionLifecycleState::Active);
+    let active_again = store
+        .mark_session_active(created.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(active_again.updated_at, active.updated_at);
 
     let idle = store.mark_session_idle(created.id).await.unwrap().unwrap();
     assert_eq!(idle.state, SessionLifecycleState::Idle);
+    let idle_again = store.mark_session_idle(created.id).await.unwrap().unwrap();
+    assert_eq!(idle_again.updated_at, idle.updated_at);
 
     let stopped = store
         .stop_session_if_idle(created.id)

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -20,6 +20,7 @@ pub enum SessionLifecycleState {
     Ready,
     Active,
     Idle,
+    Released,
     Stopping,
     Stopped,
     Failed,
@@ -34,6 +35,7 @@ impl SessionLifecycleState {
             Self::Ready => "ready",
             Self::Active => "active",
             Self::Idle => "idle",
+            Self::Released => "released",
             Self::Stopping => "stopping",
             Self::Stopped => "stopped",
             Self::Failed => "failed",
@@ -59,6 +61,7 @@ impl FromStr for SessionLifecycleState {
             "ready" => Ok(Self::Ready),
             "active" => Ok(Self::Active),
             "idle" => Ok(Self::Idle),
+            "released" => Ok(Self::Released),
             "stopping" => Ok(Self::Stopping),
             "stopped" => Ok(Self::Stopped),
             "failed" => Ok(Self::Failed),
@@ -182,7 +185,18 @@ pub enum SessionRuntimeState {
     NotStarted,
     Starting,
     Running,
+    Released,
     Stopping,
+    Stopped,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRuntimeResumeMode {
+    FreshStart,
+    ExactLive,
+    ProfileRestart,
+    Released,
     Stopped,
 }
 
@@ -240,6 +254,7 @@ pub struct SessionIdleStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct SessionStatusSummary {
     pub runtime_state: SessionRuntimeState,
+    pub runtime_resume_mode: SessionRuntimeResumeMode,
     pub presence_state: SessionPresenceState,
     pub connection_counts: SessionConnectionCounts,
     pub stop_eligibility: SessionStopEligibility,
@@ -266,6 +281,7 @@ pub struct SessionResource {
     pub status: SessionStatusSummary,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub runtime_released_at: Option<DateTime<Utc>>,
     pub stopped_at: Option<DateTime<Utc>>,
 }
 
@@ -321,6 +337,7 @@ pub struct StoredSession {
     pub recording: crate::session_control::SessionRecordingPolicy,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub runtime_released_at: Option<DateTime<Utc>>,
     pub stopped_at: Option<DateTime<Utc>>,
 }
 
@@ -361,6 +378,7 @@ impl StoredSession {
             status,
             created_at: self.created_at,
             updated_at: self.updated_at,
+            runtime_released_at: self.runtime_released_at,
             stopped_at: self.stopped_at,
         }
     }

--- a/code/apps/bpane-gateway/src/session_hub/membership.rs
+++ b/code/apps/bpane-gateway/src/session_hub/membership.rs
@@ -83,7 +83,7 @@ pub(super) async fn subscribe(
     let initial_frames = gather_initial_frames(hub).await;
     let initial_access_state = super::policy::initial_access_state(hub, client_id).await;
 
-    if prev_count > 0 || should_request_automation_repaint(hub, client_role) {
+    if should_request_join_repaint(hub, client_role, prev_count).await {
         let tiles_requested = hub.request_full_refresh().await;
         if tiles_requested > 0 {
             hub.record_refresh_burst(tiles_requested);
@@ -106,8 +106,18 @@ pub(super) async fn subscribe(
     })
 }
 
-fn should_request_automation_repaint(hub: &SessionHub, client_role: BrowserClientRole) -> bool {
-    client_role == BrowserClientRole::Interactive && hub.mcp_is_owner.load(Ordering::Relaxed)
+async fn should_request_join_repaint(
+    hub: &SessionHub,
+    client_role: BrowserClientRole,
+    prev_count: u32,
+) -> bool {
+    if client_role != BrowserClientRole::Interactive {
+        return false;
+    }
+    if prev_count > 0 || hub.mcp_is_owner.load(Ordering::Relaxed) {
+        return true;
+    }
+    hub.cached_grid_config.lock().await.is_some()
 }
 
 pub(super) async fn unsubscribe(hub: &SessionHub, client_id: u64) {

--- a/code/apps/bpane-gateway/src/session_hub/tests/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_hub/tests/lifecycle.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use bpane_protocol::frame::Frame;
+
 use super::*;
 
 #[tokio::test]
@@ -47,6 +49,43 @@ async fn late_joiner_gets_cached_session_ready() {
 }
 
 #[tokio::test]
+async fn reconnect_after_last_client_requests_full_tile_refresh() {
+    let dir = tempfile::tempdir().unwrap();
+    let sock = dir.path().join("test.sock");
+    let sock_str = sock.to_str().unwrap();
+
+    let _agent = mock_agent(sock_str).await;
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let hub = SessionHub::new(sock_str, 10, false).await.unwrap();
+    let first = hub.subscribe().await.unwrap();
+    *hub.cached_grid_config.lock().await = Some(Arc::new(
+        TileMessage::GridConfig {
+            tile_size: 64,
+            cols: 2,
+            rows: 1,
+            screen_w: 128,
+            screen_h: 64,
+        }
+        .to_frame(),
+    ));
+
+    hub.unsubscribe(first.client_id).await;
+
+    let mut reconnect = hub.subscribe().await.unwrap();
+    let repaint = next_tile_frame(&mut reconnect).await;
+    assert_eq!(repaint.channel, ChannelId::Tiles);
+    assert!(matches!(
+        TileMessage::decode(&repaint.payload).unwrap(),
+        TileMessage::Fill { .. }
+    ));
+
+    let snapshot = hub.telemetry_snapshot().await;
+    assert_eq!(snapshot.full_refresh_requests, 1);
+    assert_eq!(snapshot.full_refresh_tiles_requested, 2);
+}
+
+#[tokio::test]
 async fn hub_reports_active_while_agent_connected() {
     let dir = tempfile::tempdir().unwrap();
     let sock = dir.path().join("test.sock");
@@ -57,6 +96,21 @@ async fn hub_reports_active_while_agent_connected() {
 
     let hub = SessionHub::new(sock_str, 10, false).await.unwrap();
     assert!(hub.is_active());
+}
+
+async fn next_tile_frame(handle: &mut crate::session_hub::ClientHandle) -> Arc<Frame> {
+    for _ in 0..4 {
+        let frame =
+            tokio::time::timeout(std::time::Duration::from_secs(1), handle.from_host.recv())
+                .await
+                .unwrap()
+                .unwrap();
+        if frame.channel == ChannelId::Tiles {
+            return frame;
+        }
+    }
+
+    panic!("did not receive a tile repaint frame");
 }
 
 #[tokio::test]

--- a/code/web/bpane-admin/src/lib/api/admin-event-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/admin-event-client.test.ts
@@ -23,6 +23,7 @@ const SESSION = {
   },
   status: {
     runtime_state: 'not_started',
+    runtime_resume_mode: 'fresh_start',
     presence_state: 'empty',
     connection_counts: {
       interactive_clients: 0,

--- a/code/web/bpane-admin/src/lib/api/control-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.test.ts
@@ -19,6 +19,7 @@ const SESSION = {
   },
   status: {
     runtime_state: 'running',
+    runtime_resume_mode: 'exact_live',
     presence_state: 'connected',
     connection_counts: {
       interactive_clients: 1,
@@ -94,9 +95,14 @@ describe('ControlClient', () => {
     });
 
     await client.stopSession('session/with/slash');
+    await client.releaseSessionRuntime('session/with/slash');
 
     expect(fetchImpl).toHaveBeenCalledWith(
       new URL('http://localhost:8932/api/v1/sessions/session%2Fwith%2Fslash/stop'),
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('http://localhost:8932/api/v1/sessions/session%2Fwith%2Fslash/release'),
       expect.objectContaining({ method: 'POST' }),
     );
   });

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -91,6 +91,11 @@ export class ControlClient {
     return ControlSessionMapper.toSessionResource(payload);
   }
 
+  async releaseSessionRuntime(sessionId: string): Promise<SessionResource> {
+    const payload = await this.#request('POST', `/api/v1/sessions/${encodeURIComponent(sessionId)}/release`);
+    return ControlSessionMapper.toSessionResource(payload);
+  }
+
   async disconnectSessionConnection(sessionId: string, connectionId: number): Promise<SessionStatus> {
     const payload = await this.#request(
       'POST',

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -34,6 +34,10 @@ export class ControlSessionMapper {
   static toSessionResource(payload: unknown): SessionResource {
     const object = expectRecord(payload, 'session resource');
     const stoppedAt = optionalString(object.stopped_at, 'session resource stopped_at');
+    const runtimeReleasedAt = optionalString(
+      object.runtime_released_at,
+      'session resource runtime_released_at',
+    );
     const automationDelegate = toAutomationDelegate(object.automation_delegate);
     return {
       id: expectString(object.id, 'session resource id'),
@@ -47,6 +51,7 @@ export class ControlSessionMapper {
       status: toStatusSummary(object.status),
       created_at: expectString(object.created_at, 'session resource created_at'),
       updated_at: expectString(object.updated_at, 'session resource updated_at'),
+      ...(runtimeReleasedAt !== undefined ? { runtime_released_at: runtimeReleasedAt } : {}),
       ...(stoppedAt !== undefined ? { stopped_at: stoppedAt } : {}),
     };
   }
@@ -112,6 +117,7 @@ function toStatusSummary(value: unknown): SessionStatusSummary {
   const object = expectRecord(value, 'session resource status');
   return {
     runtime_state: expectString(object.runtime_state, 'session status runtime_state'),
+    runtime_resume_mode: expectString(object.runtime_resume_mode, 'session status runtime_resume_mode'),
     presence_state: expectString(object.presence_state, 'session status presence_state'),
     connection_counts: toConnectionCounts(object.connection_counts),
     stop_eligibility: toStopEligibility(object.stop_eligibility),

--- a/code/web/bpane-admin/src/lib/api/control-session-status-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-status-client.test.ts
@@ -69,6 +69,7 @@ function sessionStatusPayload(overrides: {
   return {
     state: overrides.state ?? 'active',
     runtime_state: 'running',
+    runtime_resume_mode: 'exact_live',
     presence_state: 'connected',
     connection_counts: counts(overrides.connections?.length ?? 1),
     stop_eligibility: { allowed: false, blockers: [{ kind: 'owner_clients', count: 1 }] },

--- a/code/web/bpane-admin/src/lib/api/control-session-status-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-status-mapper.ts
@@ -21,6 +21,7 @@ export class ControlSessionStatusMapper {
     return {
       state: expectString(object.state, 'session status state'),
       runtime_state: expectString(object.runtime_state, 'session status runtime_state'),
+      runtime_resume_mode: expectString(object.runtime_resume_mode, 'session status runtime_resume_mode'),
       presence_state: expectString(object.presence_state, 'session status presence_state'),
       connection_counts: toConnectionCounts(object.connection_counts),
       stop_eligibility: toStopEligibility(object.stop_eligibility),

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -39,6 +39,7 @@ export type SessionConnectionCounts = {
 
 export type SessionStatusSummary = {
   readonly runtime_state: string;
+  readonly runtime_resume_mode: string;
   readonly presence_state: string;
   readonly connection_counts: SessionConnectionCounts;
   readonly stop_eligibility: SessionStopEligibility;
@@ -56,6 +57,7 @@ export type SessionResource = {
   readonly status: SessionStatusSummary;
   readonly created_at: string;
   readonly updated_at: string;
+  readonly runtime_released_at?: string | null;
   readonly stopped_at?: string | null;
 };
 

--- a/code/web/bpane-admin/src/lib/api/session-status-types.ts
+++ b/code/web/bpane-admin/src/lib/api/session-status-types.ts
@@ -45,6 +45,7 @@ export type SessionTelemetry = {
 export type SessionStatus = {
   readonly state: string;
   readonly runtime_state: string;
+  readonly runtime_resume_mode: string;
   readonly presence_state: string;
   readonly connection_counts: SessionConnectionCounts;
   readonly stop_eligibility: SessionStopEligibility;

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -120,6 +120,14 @@
     );
   }
 
+  async function releaseSessionRuntime(): Promise<void> {
+    await mutateSession(
+      'Releasing selected session runtime...',
+      'Selected session runtime was released.',
+      () => controlClient.releaseSessionRuntime(sessionId),
+    );
+  }
+
   async function killSession(): Promise<void> {
     await mutateSession(
       'Killing selected session...',
@@ -268,6 +276,7 @@
         {viewModel}
         feedback={actionFeedback}
         onRefresh={() => void refreshInspector()}
+        onRelease={() => void releaseSessionRuntime()}
         onStop={() => void stopSession()}
         onKill={() => void killSession()}
         onDisconnectConnection={(connectionId) => void disconnectConnection(connectionId)}

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -32,11 +32,14 @@
   let relatedError = $state<string | null>(null);
   let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let lastRefreshedAt = $state<string | null>(null);
+  const connected = $derived(
+    (status?.connection_counts.total_clients ?? session?.status.connection_counts.total_clients ?? 0) > 0,
+  );
 
   const viewModel = $derived(SessionViewModelBuilder.detail({
     session,
     status,
-    connected: false,
+    connected,
     loading,
     error,
   }));

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -172,14 +172,16 @@
       // turning a follow-up refresh failure into a failed action.
     }
   }
-  async function runLifecycle(action: 'stop' | 'kill'): Promise<void> {
+  async function runLifecycle(action: 'release' | 'stop' | 'kill'): Promise<void> {
     if (!selectedSession) return;
     sessionsLoading = true;
     sessionsError = null;
     try {
-      const updated = action === 'stop'
-        ? await controlClient.stopSession(selectedSession.id)
-        : await controlClient.killSession(selectedSession.id);
+      const updated = action === 'release'
+        ? await controlClient.releaseSessionRuntime(selectedSession.id)
+        : action === 'stop'
+          ? await controlClient.stopSession(selectedSession.id)
+          : await controlClient.killSession(selectedSession.id);
       upsertSession(updated);
     } catch (error) {
       sessionsError = errorMessage(error);
@@ -317,6 +319,7 @@
       {sessionFilesRefreshVersion} {recordingsRefreshVersion} {mcpDelegationRefreshVersion} onRefreshSessions={loadSessions}
       onCreateSession={(command) => void createSession(command)} onJoinSelectedSession={requestBrowserConnect}
       onSelectSessionId={selectSession} onRefreshSelectedSession={refreshSelectedSession}
+      onReleaseSessionRuntime={() => runLifecycle('release')}
       onStopSession={() => runLifecycle('stop')} onKillSession={() => runLifecycle('kill')} onDisconnectEmbeddedBrowser={() => disconnectBrowser(false)}
       onFileCountChange={(count) => { sessionFileCount = count; }}
       onClearLogs={() => { logEntries = []; }}

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -191,16 +191,23 @@
     }
   }
   async function connectBrowser(container: HTMLElement): Promise<void> {
-    if (!selectedSession) return;
+    const session = selectedSession;
+    if (!session) return;
     disconnectBrowser(false);
     browserConnecting = true;
     browserError = null;
-    browserStatus = `Connecting to ${selectedSession.id}`;
-    showGlobalMessage('loading', 'Browser connection', `Connecting to session ${shortAdminId(selectedSession.id)}...`);
+    browserStatus = `Connecting to ${session.id}`;
+    showGlobalMessage('loading', 'Browser connection', `Connecting to session ${shortAdminId(session.id)}...`);
     try {
-      liveConnection = await browserConnector.connect(selectedSession, container, browserPreferences);
-      browserStatus = `Connected to ${selectedSession.id}`;
-      showGlobalMessage('success', 'Browser connected', `Connected to session ${shortAdminId(selectedSession.id)}.`);
+      const connection = await browserConnector.connect(session, container, browserPreferences);
+      if (selectedSession?.id !== session.id) {
+        connection.handle.disconnect();
+        browserStatus = 'Disconnected';
+        return;
+      }
+      liveConnection = connection;
+      browserStatus = `Connected to ${session.id}`;
+      showGlobalMessage('success', 'Browser connected', `Connected to session ${shortAdminId(session.id)}.`);
       void refreshSelectedSessionInBackground();
     } catch (error) {
       browserError = errorMessage(error);
@@ -245,8 +252,29 @@
       : [session, ...sessions];
   }
   function selectSession(sessionId: string): void {
+    const nextSession = sessions.find((session) => session.id === sessionId) ?? null;
     pendingSelectedSessionId = null;
-    selectedSession = sessions.find((session) => session.id === sessionId) ?? selectedSession;
+    if (!nextSession) {
+      showGlobalMessage('warning', 'Session selection failed', `Session ${shortAdminId(sessionId)} is not visible.`);
+      return;
+    }
+    const previousLiveSessionId = liveConnection?.sessionId ?? null;
+    const disconnectForSwitch = Boolean(previousLiveSessionId && previousLiveSessionId !== nextSession.id);
+    if (disconnectForSwitch) {
+      liveConnection?.handle.disconnect();
+      liveConnection = null;
+      browserError = null;
+      browserStatus = 'Disconnected';
+    }
+    selectedSession = nextSession;
+    if (disconnectForSwitch && previousLiveSessionId) {
+      showGlobalMessage(
+        'info',
+        'Session switched',
+        `Disconnected from session ${shortAdminId(previousLiveSessionId)} and selected session ${shortAdminId(nextSession.id)}.`,
+      );
+      return;
+    }
     showGlobalMessage('info', 'Session selected', `Selected session ${shortAdminId(selectedSession?.id ?? sessionId)}.`);
   }
   function requestBrowserConnect(): void { browserConnectRequestVersion += 1; }

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -57,6 +57,7 @@
     readonly onJoinSelectedSession: () => void;
     readonly onSelectSessionId: (sessionId: string) => void;
     readonly onRefreshSelectedSession: () => Promise<void>;
+    readonly onReleaseSessionRuntime: () => Promise<void>;
     readonly onStopSession: () => Promise<void>;
     readonly onKillSession: () => Promise<void>;
     readonly onDisconnectEmbeddedBrowser: () => void;
@@ -166,6 +167,7 @@
           connected={props.browserConnected}
           resourceLoading={props.sessionListViewModel.loading}
           onRefreshSelectedSession={props.onRefreshSelectedSession}
+          onReleaseSessionRuntime={props.onReleaseSessionRuntime}
           onStopSession={props.onStopSession}
           onKillSession={props.onKillSession}
           onDisconnectEmbeddedBrowser={props.onDisconnectEmbeddedBrowser}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -147,9 +147,11 @@
         {#if activePanel.id === 'sessions'}
         <SessionListPanel
           viewModel={props.sessionListViewModel}
+          connected={props.browserConnected}
           onRefresh={() => void props.onRefreshSessions(true)}
           onCreateSession={props.onCreateSession}
           onJoinSession={props.onJoinSelectedSession}
+          onDisconnectSession={props.onDisconnectEmbeddedBrowser}
           onSelectSessionId={props.onSelectSessionId}
         />
         <McpDelegationSurface

--- a/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/SessionLifecycleSurface.svelte
@@ -12,6 +12,7 @@
     readonly connected: boolean;
     readonly resourceLoading: boolean;
     readonly onRefreshSelectedSession: () => Promise<void>;
+    readonly onReleaseSessionRuntime: () => Promise<void>;
     readonly onStopSession: () => Promise<void>;
     readonly onKillSession: () => Promise<void>;
     readonly onDisconnectEmbeddedBrowser: () => void;
@@ -23,6 +24,7 @@
     connected,
     resourceLoading,
     onRefreshSelectedSession,
+    onReleaseSessionRuntime,
     onStopSession,
     onKillSession,
     onDisconnectEmbeddedBrowser,
@@ -236,6 +238,7 @@
   {viewModel}
   {feedback}
   onRefresh={() => void refreshPanel()}
+  onRelease={() => void runLifecycleAction('Releasing selected session runtime...', 'Selected session runtime was released.', onReleaseSessionRuntime)}
   onStop={() => void runLifecycleAction('Stopping selected session...', 'Selected session stopped.', onStopSession)}
   onKill={() => void runLifecycleAction('Killing selected session...', 'Selected session was force killed.', onKillSession)}
   onDisconnectConnection={(connectionId) => void disconnectConnection(connectionId)}

--- a/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-feedback-notifications.test.ts
@@ -147,6 +147,7 @@ function session(overrides: { readonly state?: string; readonly totalClients?: n
     },
     status: {
       runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
       presence_state: totalClients > 0 ? 'connected' : 'idle',
       connection_counts: {
         interactive_clients: totalClients,

--- a/code/web/bpane-admin/src/lib/application/admin-log-entries.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-log-entries.ts
@@ -17,6 +17,87 @@ type UiStateLogInput = {
 };
 
 export class AdminLogEntryFactory {
+  static eventLogSignature(event: AdminEvent): string | null {
+    if (event.type === 'sessions.snapshot') {
+      return stableSignature([
+        event.type,
+        event.sessions
+          .map((session) => [
+            session.id,
+            session.state ?? null,
+            session.owner_mode ?? null,
+            sortedRecordEntries(session.labels),
+            session.automation_delegate?.client_id ?? null,
+            session.automation_delegate?.issuer ?? null,
+            session.automation_delegate?.display_name ?? null,
+            session.runtime?.binding ?? null,
+            session.runtime?.compatibility_mode ?? null,
+            session.runtime?.cdp_endpoint ?? null,
+            session.status?.runtime_state ?? null,
+            session.status?.runtime_resume_mode ?? null,
+            session.status?.presence_state ?? null,
+            session.status?.connection_counts?.interactive_clients ?? null,
+            session.status?.connection_counts?.owner_clients ?? null,
+            session.status?.connection_counts?.viewer_clients ?? null,
+            session.status?.connection_counts?.recorder_clients ?? null,
+            session.status?.connection_counts?.automation_clients ?? null,
+            session.status?.connection_counts?.total_clients ?? null,
+            session.status?.stop_eligibility?.allowed ?? null,
+            session.status?.stop_eligibility?.blockers
+              ?.map((blocker) => [blocker.kind, blocker.count])
+              .sort(compareSignatureParts) ?? [],
+            session.runtime_released_at ?? null,
+            session.stopped_at ?? null,
+          ])
+          .sort(compareSignatureParts),
+      ]);
+    }
+    if (event.type === 'workflow_runs.snapshot') {
+      return stableSignature([
+        event.type,
+        event.workflowRuns
+          .map((run) => [run.id, run.sessionId, run.state, run.updatedAt])
+          .sort(compareSignatureParts),
+      ]);
+    }
+    if (event.type === 'session_files.snapshot') {
+      return stableSignature([
+        event.type,
+        event.sessionFiles
+          .map((session) => [session.sessionId, session.fileCount, session.latestUpdatedAt])
+          .sort(compareSignatureParts),
+      ]);
+    }
+    if (event.type === 'recordings.snapshot') {
+      return stableSignature([
+        event.type,
+        event.recordings
+          .map((session) => [
+            session.sessionId,
+            session.recordingCount,
+            session.activeCount,
+            session.readyCount,
+            session.latestUpdatedAt,
+          ])
+          .sort(compareSignatureParts),
+      ]);
+    }
+    if (event.type === 'mcp_delegation.snapshot') {
+      return stableSignature([
+        event.type,
+        event.delegations
+          .map((delegation) => [
+            delegation.sessionId,
+            delegation.delegatedClientId,
+            delegation.delegatedIssuer,
+            delegation.mcpOwner,
+          ])
+          .sort(compareSignatureParts),
+      ]);
+    }
+    return null;
+  }
+
   static fromAdminEvent(event: AdminEvent): AdminLogEntry {
     if (event.type === 'sessions.snapshot') {
       return entry({
@@ -118,6 +199,18 @@ export class AdminLogEntryFactory {
 }
 
 const TERMINAL_WORKFLOW_STATES = new Set(['succeeded', 'failed', 'cancelled', 'timed_out']);
+
+function sortedRecordEntries(record: Readonly<Record<string, string>> | undefined): readonly [string, string][] {
+  return Object.entries(record ?? {}).sort(([left], [right]) => left.localeCompare(right));
+}
+
+function stableSignature(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function compareSignatureParts(left: readonly unknown[], right: readonly unknown[]): number {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}
 
 function entry(input: {
   readonly timestamp?: string;

--- a/code/web/bpane-admin/src/lib/application/admin-session-event-sync.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-session-event-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AdminEventClient, AdminEventHandlers } from '../api/admin-event-client';
+import type { SessionResource } from '../api/control-types';
 import type { AdminLogEntry } from '../presentation/logs-view-model';
 import { subscribeAdminSessionEvents } from './admin-session-event-sync';
 
@@ -30,6 +31,44 @@ describe('subscribeAdminSessionEvents', () => {
     expect(errors).toEqual([null]);
     expect(sessions).toEqual([[{ id: 'session-a' }]]);
     expect(logs.map((entry) => entry.source)).toEqual(['ui', 'gateway']);
+  });
+
+  it('deduplicates unchanged snapshot log entries while keeping panels in sync', () => {
+    const client = new FakeAdminEventClient();
+    const logs: AdminLogEntry[] = [];
+    const sessions: Array<readonly SessionResource[]> = [];
+    const activeSession = sessionResource({ state: 'active', updated_at: '2026-05-04T19:02:00Z' });
+
+    subscribeAdminSessionEvents(client as never, {
+      onSessions: (next) => sessions.push(next),
+      onLoadingChange: () => undefined,
+      onError: () => undefined,
+      onLog: (entry) => logs.push(entry),
+    });
+    client.handlers.onEvent({
+      type: 'sessions.snapshot',
+      sequence: 3,
+      createdAt: '2026-05-04T19:02:00Z',
+      sessions: [activeSession],
+    });
+    client.handlers.onEvent({
+      type: 'sessions.snapshot',
+      sequence: 4,
+      createdAt: '2026-05-04T19:02:01Z',
+      sessions: [sessionResource({ state: 'active', updated_at: '2026-05-04T19:02:01Z' })],
+    });
+    client.handlers.onEvent({
+      type: 'sessions.snapshot',
+      sequence: 5,
+      createdAt: '2026-05-04T19:02:02Z',
+      sessions: [sessionResource({ state: 'idle', updated_at: '2026-05-04T19:02:02Z' })],
+    });
+
+    expect(sessions).toHaveLength(3);
+    expect(logs.map((entry) => entry.message)).toEqual([
+      'Gateway session snapshot #3: 1 visible sessions.',
+      'Gateway session snapshot #5: 1 visible sessions.',
+    ]);
   });
 
   it('surfaces stream errors as UI diagnostics', () => {
@@ -170,4 +209,48 @@ class FakeAdminEventClient implements Pick<AdminEventClient, 'subscribe'> {
     this.handlers = handlers;
     return { close: () => undefined };
   }
+}
+
+function sessionResource(overrides: Partial<SessionResource> = {}): SessionResource {
+  return {
+    id: 'session-a',
+    state: 'active',
+    owner_mode: 'collaborative',
+    idle_timeout_sec: null,
+    labels: {},
+    connect: {
+      gateway_url: 'https://gateway.example',
+      transport_path: '/session',
+      auth_type: 'session_connect_ticket',
+      ticket_path: '/api/v1/sessions/session-a/access-tokens',
+      compatibility_mode: 'session_runtime_pool',
+    },
+    runtime: {
+      binding: 'docker_pool',
+      compatibility_mode: 'session_runtime_pool',
+      cdp_endpoint: null,
+    },
+    status: {
+      runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
+      presence_state: 'connected',
+      connection_counts: {
+        interactive_clients: 1,
+        owner_clients: 1,
+        viewer_clients: 0,
+        recorder_clients: 0,
+        automation_clients: 0,
+        total_clients: 1,
+      },
+      stop_eligibility: {
+        allowed: false,
+        blockers: [{ kind: 'owner_clients', count: 1 }],
+      },
+    },
+    created_at: '2026-05-04T19:01:00Z',
+    updated_at: '2026-05-04T19:02:00Z',
+    runtime_released_at: null,
+    stopped_at: null,
+    ...overrides,
+  };
 }

--- a/code/web/bpane-admin/src/lib/application/admin-session-event-sync.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-session-event-sync.ts
@@ -9,6 +9,7 @@ import type {
   AdminSessionFilesSnapshot,
   AdminWorkflowRunSnapshot,
 } from '../api/admin-event-snapshots';
+import type { AdminEvent } from '../api/admin-event-mapper';
 import type { SessionResource } from '../api/control-types';
 import type { AdminLogEntry } from '../presentation/logs-view-model';
 import { AdminLogEntryFactory } from './admin-log-entries';
@@ -29,9 +30,13 @@ export function subscribeAdminSessionEvents(
   adminEventClient: AdminEventClient,
   handlers: AdminSessionEventSyncHandlers,
 ): AdminEventSubscription {
+  const lastLogSignatures = new Map<string, string>();
+
   return adminEventClient.subscribe({
     onEvent: (event) => {
-      handlers.onLog(AdminLogEntryFactory.fromAdminEvent(event));
+      if (shouldLogAdminEvent(event, lastLogSignatures)) {
+        handlers.onLog(AdminLogEntryFactory.fromAdminEvent(event));
+      }
       if (event.type === 'sessions.snapshot') {
         handlers.onLoadingChange(false);
         handlers.onError(null);
@@ -57,4 +62,16 @@ export function subscribeAdminSessionEvents(
       handlers.onLog(AdminLogEntryFactory.fromStreamError(error));
     },
   });
+}
+
+function shouldLogAdminEvent(event: AdminEvent, lastLogSignatures: Map<string, string>): boolean {
+  const signature = AdminLogEntryFactory.eventLogSignature(event);
+  if (!signature) {
+    return true;
+  }
+  if (lastLogSignatures.get(event.type) === signature) {
+    return false;
+  }
+  lastLogSignatures.set(event.type, signature);
+  return true;
 }

--- a/code/web/bpane-admin/src/lib/application/admin-session-selection.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-session-selection.test.ts
@@ -46,6 +46,7 @@ function session(id: string): SessionResource {
     },
     status: {
       runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
       presence_state: 'empty',
       connection_counts: {
         interactive_clients: 0,

--- a/code/web/bpane-admin/src/lib/application/admin-workflow-follow.test.ts
+++ b/code/web/bpane-admin/src/lib/application/admin-workflow-follow.test.ts
@@ -73,6 +73,7 @@ function createSession(id: string): SessionResource {
     runtime: { binding: 'docker', compatibility_mode: 'direct' },
     status: {
       runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
       presence_state: 'connected',
       connection_counts: {
         interactive_clients: 0, owner_clients: 0, viewer_clients: 0,

--- a/code/web/bpane-admin/src/lib/presentation/BrowserEmbedPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/BrowserEmbedPanel.svelte
@@ -24,9 +24,17 @@
     onConnect,
     onDisconnect,
   }: BrowserEmbedPanelProps = $props();
-  let container: HTMLElement;
+  let container: HTMLElement | null = null;
   let lastAutoConnectVersion = $state(0);
   const isConnected = $derived(Boolean(session && connectedSessionId === session.id));
+
+  $effect(() => {
+    if (!container || isConnected || connecting) {
+      return;
+    }
+    container.replaceChildren();
+    container.removeAttribute('style');
+  });
 
   $effect(() => {
     if (autoConnectVersion === 0 || autoConnectVersion === lastAutoConnectVersion || !session || !container) {
@@ -80,8 +88,12 @@
   <div
     class="relative mt-3 min-h-0 flex-1 overflow-hidden rounded-xl border border-[#c4d5f4]/10 bg-[#050806]"
     data-testid="browser-viewport"
-    bind:this={container}
   >
+    <div
+      class="h-full min-h-0 w-full"
+      data-testid="browser-viewport-mount"
+      bind:this={container}
+    ></div>
     {#if !isConnected}
       <div class="absolute inset-0 grid place-content-center gap-2 bg-[radial-gradient(circle_at_top,rgba(79,209,168,0.08),transparent_34%),linear-gradient(180deg,rgba(14,24,41,0.24),rgba(7,12,21,0.56))] p-6 text-center text-[#9fb1cf]">
         <strong class="text-[1.3rem] text-admin-ink">{session ? 'Ready to connect' : 'No session selected'}</strong>

--- a/code/web/bpane-admin/src/lib/presentation/SessionDetailPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionDetailPanel.svelte
@@ -6,6 +6,7 @@
   type SessionDetailPanelProps = {
     readonly viewModel: SessionDetailPanelViewModel;
     readonly onRefresh: () => void;
+    readonly onRelease: () => void;
     readonly onStop: () => void;
     readonly onKill: () => void;
     readonly onDisconnectConnection: (connectionId: number) => void;
@@ -16,6 +17,7 @@
   let {
     viewModel,
     onRefresh,
+    onRelease,
     onStop,
     onKill,
     onDisconnectConnection,
@@ -40,6 +42,15 @@
       onclick={onRefresh}
     >
       Refresh
+    </button>
+    <button
+      class="admin-button-primary"
+      type="button"
+      data-testid="session-release-runtime"
+      disabled={!viewModel.canRelease}
+      onclick={onRelease}
+    >
+      Release runtime
     </button>
     <button
       class="admin-button-primary"

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -63,7 +63,7 @@
         class="admin-button-primary"
         type="button"
         data-testid="session-join"
-        disabled={!viewModel.authenticated || viewModel.loading || !viewModel.selectedSessionId}
+        disabled={!viewModel.authenticated || viewModel.loading || !viewModel.selectedSessionId || !viewModel.selectedSession?.canJoin}
         onclick={onJoinSession}
       >
         Join / reconnect

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -8,17 +8,21 @@
 
   type SessionListPanelProps = {
     readonly viewModel: SessionListPanelViewModel;
+    readonly connected: boolean;
     readonly onRefresh: () => void;
     readonly onCreateSession: (command: CreateSessionCommand) => void;
     readonly onJoinSession: () => void;
+    readonly onDisconnectSession: () => void;
     readonly onSelectSessionId: (sessionId: string) => void;
   };
 
   let {
     viewModel,
+    connected,
     onRefresh,
     onCreateSession,
     onJoinSession,
+    onDisconnectSession,
     onSelectSessionId,
   }: SessionListPanelProps = $props();
   let createPayloadOpen = $state(false);
@@ -67,6 +71,15 @@
         onclick={onJoinSession}
       >
         Start / reconnect
+      </button>
+      <button
+        class="admin-button-ghost"
+        type="button"
+        data-testid="session-disconnect"
+        disabled={!viewModel.authenticated || viewModel.loading || !viewModel.selectedSessionId || !connected}
+        onclick={onDisconnectSession}
+      >
+        Disconnect
       </button>
       {#if viewModel.selectedSessionId}
         <a class="admin-button-ghost" data-testid="session-detail-link" href={detailHref(viewModel.selectedSessionId)}>

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -66,7 +66,7 @@
         disabled={!viewModel.authenticated || viewModel.loading || !viewModel.selectedSessionId || !viewModel.selectedSession?.canJoin}
         onclick={onJoinSession}
       >
-        Join / reconnect
+        Start / reconnect
       </button>
       {#if viewModel.selectedSessionId}
         <a class="admin-button-ghost" data-testid="session-detail-link" href={detailHref(viewModel.selectedSessionId)}>

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
@@ -49,6 +49,7 @@ export class AdminWorkspaceViewModelBuilder {
         panel('sessions', 'Sessions', 'Login, start, reconnect, share', 'Owner-scoped session entrypoint.', `${input.sessionCount} visible`, true, [
           'New session',
           'Start / reconnect',
+          'Disconnect',
           'MCP authorization',
         ], ['visible sessions', 'selected session']),
         panel('lifecycle', 'Lifecycle', 'Runtime state, stop blockers, live clients', 'Inspect lifecycle safety before mutating a runtime.', input.connected ? 'busy' : 'ready', true, [

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
@@ -48,7 +48,7 @@ export class AdminWorkspaceViewModelBuilder {
       panels: [
         panel('sessions', 'Sessions', 'Login, start, reconnect, share', 'Owner-scoped session entrypoint.', `${input.sessionCount} visible`, true, [
           'New session',
-          'Join / reconnect',
+          'Start / reconnect',
           'MCP authorization',
         ], ['visible sessions', 'selected session']),
         panel('lifecycle', 'Lifecycle', 'Runtime state, stop blockers, live clients', 'Inspect lifecycle safety before mutating a runtime.', input.connected ? 'busy' : 'ready', true, [

--- a/code/web/bpane-admin/src/lib/presentation/browser-policy-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/browser-policy-view-model.test.ts
@@ -64,6 +64,7 @@ function sessionResource(input: {
     },
     status: {
       runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
       presence_state: 'connected',
       connection_counts: {
         interactive_clients: 0,

--- a/code/web/bpane-admin/src/lib/presentation/mcp-delegation-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/mcp-delegation-view-model.test.ts
@@ -140,6 +140,7 @@ function sessionResource(id: string, delegated = false): SessionResource {
     runtime: { binding: 'docker_runtime_pool', compatibility_mode: 'session_runtime_pool' },
     status: {
       runtime_state: 'running',
+      runtime_resume_mode: 'exact_live',
       presence_state: 'connected',
       connection_counts: {
         interactive_clients: 0,

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -21,6 +21,7 @@ const SESSION: SessionResource = {
   },
   status: {
     runtime_state: 'running',
+    runtime_resume_mode: 'exact_live',
     presence_state: 'connected',
     connection_counts: {
       interactive_clients: 1,
@@ -42,6 +43,7 @@ const SESSION: SessionResource = {
 const STATUS: SessionStatus = {
   state: 'active',
   runtime_state: 'running',
+  runtime_resume_mode: 'exact_live',
   presence_state: 'connected',
   connection_counts: SESSION.status.connection_counts,
   stop_eligibility: SESSION.status.stop_eligibility,
@@ -123,6 +125,7 @@ describe('SessionViewModelBuilder', () => {
       id: SESSION.id,
       ownerMode: 'shared',
       runtimeBinding: 'docker_runtime_pool',
+      canJoin: true,
     });
   });
 
@@ -165,5 +168,57 @@ describe('SessionViewModelBuilder', () => {
       canDisconnect: true,
     }]);
     expect(viewModel.canDisconnectAll).toBe(true);
+  });
+
+  it('exposes runtime release only for disconnected runtime candidates', () => {
+    const releasableSession: SessionResource = {
+      ...SESSION,
+      state: 'idle',
+      status: {
+        ...SESSION.status,
+        presence_state: 'idle',
+        connection_counts: {
+          interactive_clients: 0,
+          owner_clients: 0,
+          viewer_clients: 0,
+          recorder_clients: 0,
+          automation_clients: 0,
+          total_clients: 0,
+        },
+        stop_eligibility: { allowed: true, blockers: [] },
+      },
+    };
+
+    const viewModel = SessionViewModelBuilder.detail({
+      session: releasableSession,
+      connected: false,
+      loading: false,
+      error: null,
+    });
+
+    expect(viewModel.canRelease).toBe(true);
+    expect(viewModel.facts).toContainEqual({
+      label: 'resume',
+      value: 'exact_live',
+      testId: 'session-runtime-resume-mode',
+    });
+  });
+
+  it('blocks join actions for stopped sessions', () => {
+    const stoppedSession: SessionResource = {
+      ...SESSION,
+      state: 'stopped',
+      stopped_at: '2026-05-04T19:05:00Z',
+    };
+
+    const viewModel = SessionViewModelBuilder.list({
+      sessions: [stoppedSession],
+      selectedSessionId: stoppedSession.id,
+      authenticated: true,
+      loading: false,
+      error: null,
+    });
+
+    expect(viewModel.selectedSession?.canJoin).toBe(false);
   });
 });

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -231,7 +231,7 @@ describe('SessionViewModelBuilder', () => {
     });
   });
 
-  it('blocks join actions for stopped sessions', () => {
+  it('allows start actions for stopped sessions', () => {
     const stoppedSession: SessionResource = {
       ...SESSION,
       state: 'stopped',
@@ -246,6 +246,6 @@ describe('SessionViewModelBuilder', () => {
       error: null,
     });
 
-    expect(viewModel.selectedSession?.canJoin).toBe(false);
+    expect(viewModel.selectedSession?.canJoin).toBe(true);
   });
 });

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -167,7 +167,34 @@ describe('SessionViewModelBuilder', () => {
       role: 'owner',
       canDisconnect: true,
     }]);
+    expect(viewModel.canStop).toBe(false);
+    expect(viewModel.canKill).toBe(false);
+    expect(viewModel.canRelease).toBe(false);
     expect(viewModel.canDisconnectAll).toBe(true);
+  });
+
+  it('disables lifecycle actions when remote status reports live clients', () => {
+    const viewModel = SessionViewModelBuilder.detail({
+      session: {
+        ...SESSION,
+        status: {
+          ...SESSION.status,
+          stop_eligibility: { allowed: true, blockers: [] },
+        },
+      },
+      status: {
+        ...STATUS,
+        stop_eligibility: { allowed: true, blockers: [] },
+      },
+      connected: false,
+      loading: false,
+      error: null,
+    });
+
+    expect(viewModel.canStop).toBe(false);
+    expect(viewModel.canKill).toBe(false);
+    expect(viewModel.canRelease).toBe(false);
+    expect(viewModel.hint).toContain('Disconnect');
   });
 
   it('exposes runtime release only for disconnected runtime candidates', () => {

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -161,8 +161,12 @@ function toSelectedSession(session: SessionResource): SelectedSessionViewModel {
     ...toListItem(session),
     ownerMode: session.owner_mode,
     runtimeBinding: session.runtime.binding,
-    canJoin: session.state !== 'stopped',
+    canJoin: canConnectSession(session.state),
   };
+}
+
+function canConnectSession(state: string): boolean {
+  return ['pending', 'starting', 'ready', 'active', 'idle', 'released', 'stopped'].includes(state);
 }
 
 function statusFacts(status: SessionStatus | null): SessionFactViewModel[] {

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -103,6 +103,7 @@ export class SessionViewModelBuilder {
     const stopEligibility = status?.stop_eligibility ?? session.status.stop_eligibility;
     const connectionCount = status?.connection_counts.total_clients
       ?? session.status.connection_counts.total_clients;
+    const hasLiveClients = input.connected || connectionCount > 0;
     return {
       title: session.id,
       facts: [
@@ -128,12 +129,12 @@ export class SessionViewModelBuilder {
         role: connection.role,
         canDisconnect: !input.loading,
       })) ?? [],
-      hint: resolveHint(input.connected, stopEligibility),
+      hint: resolveHint(hasLiveClients, stopEligibility),
       statusHint: status ? null : 'Live status is loaded from the session status API.',
       canRefresh: !input.loading,
-      canStop: !input.loading && !input.connected && stopEligibility.allowed,
-      canKill: !input.loading && !input.connected,
-      canRelease: !input.loading && !input.connected && stopEligibility.allowed && !['released', 'stopped'].includes(session.state),
+      canStop: !input.loading && !hasLiveClients && stopEligibility.allowed,
+      canKill: !input.loading && !hasLiveClients,
+      canRelease: !input.loading && !hasLiveClients && stopEligibility.allowed && !['released', 'stopped'].includes(session.state),
       canDisconnectAll: !input.loading && (status?.connections.length ?? 0) > 0,
       loading: input.loading,
       error: input.error,

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -16,6 +16,7 @@ export type SessionListItemViewModel = {
 export type SelectedSessionViewModel = SessionListItemViewModel & {
   readonly ownerMode: string;
   readonly runtimeBinding: string;
+  readonly canJoin: boolean;
 };
 
 export type SessionListPanelViewModel = {
@@ -49,6 +50,7 @@ export type SessionDetailPanelViewModel = {
   readonly canRefresh: boolean;
   readonly canStop: boolean;
   readonly canKill: boolean;
+  readonly canRelease: boolean;
   readonly canDisconnectAll: boolean;
   readonly loading: boolean;
   readonly error: string | null;
@@ -91,6 +93,7 @@ export class SessionViewModelBuilder {
         canRefresh: false,
         canStop: false,
         canKill: false,
+        canRelease: false,
         canDisconnectAll: false,
         loading: input.loading,
         error: input.error,
@@ -108,12 +111,14 @@ export class SessionViewModelBuilder {
         { label: 'idle override', value: session.idle_timeout_sec?.toString() ?? 'default', testId: 'session-idle-timeout' },
         { label: 'labels', value: labelSummary(session.labels ?? {}), testId: 'session-labels' },
         { label: 'runtime', value: session.status.runtime_state, testId: 'session-runtime-state' },
+        { label: 'resume', value: session.status.runtime_resume_mode, testId: 'session-runtime-resume-mode' },
         { label: 'presence', value: session.status.presence_state, testId: 'session-presence-state' },
         { label: 'clients', value: String(connectionCount), testId: 'session-total-clients' },
         { label: 'binding', value: session.runtime.binding },
         { label: 'transport', value: session.connect.compatibility_mode },
         { label: 'created', value: session.created_at },
         { label: 'updated', value: session.updated_at },
+        ...(session.runtime_released_at ? [{ label: 'runtime released', value: session.runtime_released_at }] : []),
         ...(session.stopped_at ? [{ label: 'stopped', value: session.stopped_at }] : []),
         ...statusFacts(status),
       ],
@@ -128,6 +133,7 @@ export class SessionViewModelBuilder {
       canRefresh: !input.loading,
       canStop: !input.loading && !input.connected && stopEligibility.allowed,
       canKill: !input.loading && !input.connected,
+      canRelease: !input.loading && !input.connected && stopEligibility.allowed && !['released', 'stopped'].includes(session.state),
       canDisconnectAll: !input.loading && (status?.connections.length ?? 0) > 0,
       loading: input.loading,
       error: input.error,
@@ -154,6 +160,7 @@ function toSelectedSession(session: SessionResource): SelectedSessionViewModel {
     ...toListItem(session),
     ownerMode: session.owner_mode,
     runtimeBinding: session.runtime.binding,
+    canJoin: session.state !== 'stopped',
   };
 }
 

--- a/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/workflow-operations-view-model.test.ts
@@ -189,6 +189,7 @@ const SESSION: SessionResource = {
   },
   status: {
     runtime_state: 'running',
+    runtime_resume_mode: 'exact_live',
     presence_state: 'connected',
     connection_counts: {
       interactive_clients: 1,

--- a/code/web/bpane-admin/src/lib/session/browser-session-connector.test.ts
+++ b/code/web/bpane-admin/src/lib/session/browser-session-connector.test.ts
@@ -122,6 +122,35 @@ describe('BrowserSessionConnector', () => {
       camera: true,
     });
   });
+
+  it('clears stale SDK mount state before connecting', async () => {
+    const handle = { disconnect: vi.fn() };
+    const connector = new BrowserSessionConnector({
+      controlClient: new ControlClient({
+        baseUrl: 'http://localhost:8932',
+        accessTokenProvider: () => 'owner-token',
+        fetchImpl: ticketFetch(),
+      }),
+      sdkProvider: {
+        load: async () => ({
+          BpaneSession: {
+            connect: async (options) => {
+              expect(options.container.childElementCount).toBe(0);
+              expect(options.container.getAttribute('style')).toBeNull();
+              return handle;
+            },
+          },
+        }),
+      },
+    });
+    const container = document.createElement('div');
+    container.style.width = '1280px';
+    container.innerHTML = '<canvas></canvas><canvas></canvas>';
+
+    const connection = await connector.connect(SESSION, container);
+
+    expect(connection.handle).toBe(handle);
+  });
 });
 
 function ticketFetch(): FetchLike {

--- a/code/web/bpane-admin/src/lib/session/browser-session-connector.test.ts
+++ b/code/web/bpane-admin/src/lib/session/browser-session-connector.test.ts
@@ -25,6 +25,7 @@ const SESSION: SessionResource = {
   },
   status: {
     runtime_state: 'running',
+    runtime_resume_mode: 'exact_live',
     presence_state: 'connected',
     connection_counts: {
       interactive_clients: 1,

--- a/code/web/bpane-admin/src/lib/session/browser-session-connector.ts
+++ b/code/web/bpane-admin/src/lib/session/browser-session-connector.ts
@@ -34,6 +34,7 @@ export class BrowserSessionConnector {
     container: HTMLElement,
     preferences: BrowserSessionConnectPreferences = DEFAULT_BROWSER_SESSION_CONNECT_PREFERENCES,
   ): Promise<LiveBrowserSessionConnection> {
+    resetSessionContainer(container);
     const access = await this.#controlClient.issueSessionAccessToken(session.id);
     if (access.token_type !== 'session_connect_ticket') {
       throw new Error(`unsupported session access token type ${access.token_type}`);
@@ -56,4 +57,9 @@ export class BrowserSessionConnector {
       handle,
     };
   }
+}
+
+function resetSessionContainer(container: HTMLElement): void {
+  container.replaceChildren();
+  container.removeAttribute('style');
 }

--- a/code/web/bpane-client/js/__tests__/session-resize-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-resize-runtime.test.ts
@@ -268,4 +268,32 @@ describe('SessionResizeRuntime', () => {
     expect(resizeObserver.disconnect).toHaveBeenCalledOnce();
     expect(sendResizeRequest).not.toHaveBeenCalled();
   });
+
+  it('clears fixed resolution container styles on destroy without sending a resize', () => {
+    const largeContainer = createContainer(1600, 1000);
+    const {
+      runtime,
+      resizeObserver,
+      sendResizeRequest,
+    } = createRuntime({
+      container: largeContainer.container,
+    });
+
+    runtime.applyClientAccessState(0x02, 1280, 720);
+    expect(largeContainer.container.style.width).toBe('1280px');
+    expect(largeContainer.container.style.height).toBe('720px');
+
+    sendResizeRequest.mockClear();
+    runtime.destroy();
+
+    expect(runtime.isResolutionLocked()).toBe(false);
+    expect(largeContainer.container.style.flex).toBe('');
+    expect(largeContainer.container.style.width).toBe('');
+    expect(largeContainer.container.style.height).toBe('');
+    expect(largeContainer.container.style.resize).toBe('');
+    expect(largeContainer.container.style.maxWidth).toBe('');
+    expect(largeContainer.container.style.maxHeight).toBe('');
+    expect(resizeObserver.disconnect).toHaveBeenCalled();
+    expect(sendResizeRequest).not.toHaveBeenCalled();
+  });
 });

--- a/code/web/bpane-client/js/__tests__/session-surface-runtime.test.ts
+++ b/code/web/bpane-client/js/__tests__/session-surface-runtime.test.ts
@@ -91,6 +91,7 @@ describe('SessionSurfaceRuntime', () => {
 
   it('tears down observers, compositor hooks, and mounted canvases on destroy', () => {
     const container = createContainer();
+    container.style.position = 'absolute';
     const tileCompositor = createTileCompositor();
     const runtime = new SessionSurfaceRuntime({
       container,
@@ -106,6 +107,7 @@ describe('SessionSurfaceRuntime', () => {
 
     expect(disconnect).toHaveBeenCalledOnce();
     expect(container.querySelectorAll('canvas')).toHaveLength(0);
+    expect(container.style.position).toBe('absolute');
     expect(tileCompositor.setCacheMissHandler).toHaveBeenLastCalledWith(null);
     expect(tileCompositor.setWebGLRenderer).toHaveBeenCalledWith(null);
   });

--- a/code/web/bpane-client/js/__tests__/session.test.ts
+++ b/code/web/bpane-client/js/__tests__/session.test.ts
@@ -109,7 +109,12 @@ function createMockTransport() {
   const bidiStream = new MockBidiStream();
   const incomingBidi = new MockReadableStream();
   const datagramReadable = new MockReadableStream();
-  const closedPromise = new Promise<void>(() => {}); // never resolves by default
+  let resolveClosed = () => {};
+  let rejectClosed = (_error: unknown) => {};
+  const closedPromise = new Promise<void>((resolve, reject) => {
+    resolveClosed = resolve;
+    rejectClosed = reject;
+  });
 
   const transport = {
     ready: Promise.resolve(),
@@ -126,6 +131,8 @@ function createMockTransport() {
     _bidiStream: bidiStream,
     _incomingBidi: incomingBidi,
     _datagramReadable: datagramReadable,
+    _resolveClosed: resolveClosed,
+    _rejectClosed: rejectClosed,
   };
 
   return transport;
@@ -514,6 +521,23 @@ describe('BpaneSession', () => {
       const { session } = await createSession();
       session.disconnect();
       expect(mockTransport.close).toHaveBeenCalled();
+    });
+
+    it('tears down mounted browser state when the transport closes first', async () => {
+      const onDisconnect = vi.fn();
+      const { session, container } = await createSession({ onDisconnect });
+
+      expect(container.querySelectorAll('canvas')).toHaveLength(2);
+
+      mockTransport._resolveClosed();
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      expect(container.querySelectorAll('canvas')).toHaveLength(0);
+      expect(onDisconnect).toHaveBeenCalledWith('transport closed');
+
+      session.disconnect();
+      expect(onDisconnect).toHaveBeenCalledTimes(1);
+      expect(container.querySelectorAll('canvas')).toHaveLength(0);
     });
 
     it('starts and stops programmatic recording from the composed session output', async () => {
@@ -1374,9 +1398,10 @@ describe('BpaneSession', () => {
       (globalThis as any).WebTransport = undefined;
       const { BpaneSession } = await import('../bpane.js');
       const { UnsupportedFeatureError } = await import('../shared/errors.js');
+      const container = createContainer();
 
       const error = await BpaneSession.connect({
-        container: createContainer(),
+        container,
         gatewayUrl: 'https://localhost:4433',
         token: 'test',
         onError,
@@ -1388,6 +1413,7 @@ describe('BpaneSession', () => {
         message: 'WebTransport is unavailable in this browser',
       });
       expect(onError).toHaveBeenCalledWith(error);
+      expect(container.querySelectorAll('canvas')).toHaveLength(0);
     });
 
     it('rejects microphone start when disabled in session options', async () => {
@@ -1442,6 +1468,7 @@ describe('BpaneSession', () => {
 
     it('calls onError when WebTransport fails', async () => {
       const onError = vi.fn();
+      const container = createContainer();
       (globalThis as any).WebTransport = vi.fn(() => ({
         ready: Promise.reject(new Error('connection failed')),
         closed: new Promise(() => {}),
@@ -1453,13 +1480,14 @@ describe('BpaneSession', () => {
       const { BpaneSession } = await import('../bpane.js');
 
       await expect(BpaneSession.connect({
-        container: createContainer(),
+        container,
         gatewayUrl: 'https://localhost:4433',
         token: 'test',
         onError,
       })).rejects.toThrow('connection failed');
 
       expect(onError).toHaveBeenCalled();
+      expect(container.querySelectorAll('canvas')).toHaveLength(0);
     });
   });
 });

--- a/code/web/bpane-client/js/session-resize-runtime.ts
+++ b/code/web/bpane-client/js/session-resize-runtime.ts
@@ -106,7 +106,9 @@ export class SessionResizeRuntime {
       this.clearTimeoutFn(this.resizeTimeout);
       this.resizeTimeout = null;
     }
+    this.resolutionLocked = false;
     this.resizeObserver.disconnect();
+    this.clearContainerSizing();
   }
 
   private setResolutionLock(width: number, height: number): void {
@@ -147,12 +149,7 @@ export class SessionResizeRuntime {
     }
 
     this.resolutionLocked = false;
-    this.container.style.flex = '';
-    this.container.style.width = '';
-    this.container.style.height = '';
-    this.container.style.resize = '';
-    this.container.style.maxWidth = '';
-    this.container.style.maxHeight = '';
+    this.clearContainerSizing();
     this.resizeObserver.observe(this.container);
 
     const dims = this.getContainerResizeDims();
@@ -169,6 +166,15 @@ export class SessionResizeRuntime {
       this.cursorEl.width = width;
       this.cursorEl.height = height;
     }
+  }
+
+  private clearContainerSizing(): void {
+    this.container.style.flex = '';
+    this.container.style.width = '';
+    this.container.style.height = '';
+    this.container.style.resize = '';
+    this.container.style.maxWidth = '';
+    this.container.style.maxHeight = '';
   }
 
   private computeScale(): number {

--- a/code/web/bpane-client/js/session-surface-runtime.ts
+++ b/code/web/bpane-client/js/session-surface-runtime.ts
@@ -43,6 +43,7 @@ export class SessionSurfaceRuntime {
   private readonly resizeRuntime: SessionResizeRuntime;
   private readonly recordingSurfaceRuntime: SessionRecordingSurfaceRuntime;
   private readonly videoDisplayRuntime: SessionVideoDisplayRuntime;
+  private readonly previousContainerPosition: string;
   private glRenderer: WebGLTileRenderer | null = null;
   private renderDiagnostics: WebGLRendererDiagnostics = {
     backend: 'canvas2d',
@@ -55,6 +56,7 @@ export class SessionSurfaceRuntime {
   constructor(input: SessionSurfaceRuntimeInput) {
     this.container = input.container;
     this.tileCompositor = input.tileCompositor;
+    this.previousContainerPosition = this.container.style.position;
 
     this.canvas = document.createElement('canvas');
     this.canvas.style.width = '100%';
@@ -231,5 +233,6 @@ export class SessionSurfaceRuntime {
       this.cursorEl.parentNode.removeChild(this.cursorEl);
       this.cursorEl = null;
     }
+    this.container.style.position = this.previousContainerPosition;
   }
 }

--- a/code/web/bpane-client/js/session/bpane-session.ts
+++ b/code/web/bpane-client/js/session/bpane-session.ts
@@ -63,6 +63,7 @@ export class BpaneSession {
   private videoDecoderRuntime: SessionVideoDecoderRuntime;
   private recordingRuntime: SessionRecordingRuntime;
   private stats = new SessionStats();
+  private destroyed = false;
 
   private constructor(options: BpaneOptions) {
     this.options = options;
@@ -128,11 +129,7 @@ export class BpaneSession {
           this.options.onConnect?.();
         },
         onDisconnect: (reason) => {
-          if (!this.connected) {
-            return;
-          }
-          this.connected = false;
-          this.options.onDisconnect?.(reason);
+          this.teardown(reason, { closeTransport: true, notify: true });
         },
         onError: (error) => {
           this.options.onError?.(error);
@@ -177,21 +174,26 @@ export class BpaneSession {
   static async connect(options: BpaneOptions): Promise<BpaneSession> {
     SessionConnectOptionsValidator.validate(options);
     const session = new BpaneSession(options);
-    session.microphoneEncoderSupported = await AudioController.isMicrophoneSupported();
-    session.cameraEncoderSupported = await CameraController.isSupported();
-    await session.setupTransport();
-    session.input = new InputController({
-      canvas: session.surfaceRuntime.getCanvas(),
-      sendFrame: (channelId, payload) => session.sendFrame(channelId, payload),
-      drawCursor: (_shape, x, y) => session.surfaceRuntime.drawCursorMove(x, y),
-      getRemoteDims: () => ({
-        width: session.remoteWidth || session.surfaceRuntime.getCanvas().width,
-        height: session.remoteHeight || session.surfaceRuntime.getCanvas().height,
-      }),
-      clipboardEnabled: options.clipboard !== false,
-    });
-    session.input.setup();
-    return session;
+    try {
+      session.microphoneEncoderSupported = await AudioController.isMicrophoneSupported();
+      session.cameraEncoderSupported = await CameraController.isSupported();
+      await session.setupTransport();
+      session.input = new InputController({
+        canvas: session.surfaceRuntime.getCanvas(),
+        sendFrame: (channelId, payload) => session.sendFrame(channelId, payload),
+        drawCursor: (_shape, x, y) => session.surfaceRuntime.drawCursorMove(x, y),
+        getRemoteDims: () => ({
+          width: session.remoteWidth || session.surfaceRuntime.getCanvas().width,
+          height: session.remoteHeight || session.surfaceRuntime.getCanvas().height,
+        }),
+        clipboardEnabled: options.clipboard !== false,
+      });
+      session.input.setup();
+      return session;
+    } catch (error) {
+      session.teardown('connect failed', { closeTransport: true, notify: false });
+      throw error;
+    }
   }
 
   getFrameCount(): number { return this.stats.frameCount; }
@@ -277,7 +279,17 @@ export class BpaneSession {
   }
 
   disconnect(): void {
-    if (!this.connected) return;
+    this.teardown('user disconnected', { closeTransport: true, notify: true });
+  }
+
+  private teardown(
+    reason: string,
+    options: { readonly closeTransport: boolean; readonly notify: boolean },
+  ): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
     this.connected = false;
     this.recordingRuntime.destroy();
     if (this.input) {
@@ -291,9 +303,12 @@ export class BpaneSession {
       this.fileTransfer.destroy();
       this.fileTransfer = null;
     }
-    this.transportRuntime.disconnect();
+    if (options.closeTransport) {
+      this.transportRuntime.disconnect();
+    }
     this.surfaceRuntime.destroy();
     this.tileCompositor.reset();
+    this.nalReassembler = new NalReassembler();
     this.sendRuntime.destroy();
     this.remoteWidth = 0;
     this.remoteHeight = 0;
@@ -310,7 +325,9 @@ export class BpaneSession {
       keyboardLayout: false,
     };
     this.stats.frameCount = 0;
-    this.options.onDisconnect?.('user disconnected');
+    if (options.notify) {
+      this.options.onDisconnect?.(reason);
+    }
   }
 
   private clearVideoOverlay(): void {

--- a/code/web/bpane-client/scripts/run-admin-session-detail-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-detail-smoke.mjs
@@ -4,8 +4,10 @@ import { chromium } from 'playwright-core';
 import {
   cleanupAdminBeforeRun,
   cleanupAdminSmoke,
+  disconnectEmbeddedBrowser,
   ensureAdminLoggedIn,
   openAdminTab,
+  waitForBrowserConnected,
 } from './admin-smoke-lib.mjs';
 import { DEFAULTS, createLogger, launchChrome, parseSmokeArgs, poll } from './workflow-smoke-lib.mjs';
 
@@ -37,6 +39,7 @@ async function run() {
     await verifySessionDetail(page, options, sessionId);
     await verifyListDeepLink(page, options, sessionId);
     await verifyLiveWorkspaceDetailLink(page, options, sessionId);
+    await verifyDetailLifecycleDisabledWithLiveClient(page, options, sessionId);
     await emitSummary(page, options, sessionId, log);
   } finally {
     await cleanupAdminSmoke(page, options, log);
@@ -93,9 +96,60 @@ async function verifyLiveWorkspaceDetailLink(page, options, sessionId) {
   await row.click();
   const detailLink = page.getByTestId('session-detail-link');
   await detailLink.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
-  const href = await detailLink.getAttribute('href');
+  const href = await poll(
+    'live workspace detail link selection',
+    async () => await detailLink.getAttribute('href'),
+    (value) => value?.includes(`/sessions/${sessionId}`),
+    options.connectTimeoutMs,
+    100,
+  );
   if (!href?.includes(`/sessions/${sessionId}`)) {
     throw new Error(`Expected live workspace detail link for ${sessionId}, got ${href}`);
+  }
+}
+
+async function verifyDetailLifecycleDisabledWithLiveClient(page, options, sessionId) {
+  const detailPage = await page.context().newPage();
+  try {
+    await ensureAdminLoggedIn(detailPage, options);
+    await detailPage.goto(adminRouteUrl(options, `sessions/${sessionId}`), { waitUntil: 'domcontentloaded' });
+    await detailPage.getByTestId('session-inspector-detail').waitFor({
+      state: 'visible',
+      timeout: options.connectTimeoutMs,
+    });
+
+    await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
+    await openAdminTab(page, 'sessions');
+    const row = page.locator(`[data-testid="session-row"][data-session-id="${sessionId}"]`);
+    await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+    await row.click();
+    await poll(
+      'live workspace selected session before join',
+      async () => await page.getByTestId('session-detail-link').getAttribute('href').catch(() => ''),
+      (value) => value?.includes(`/sessions/${sessionId}`),
+      options.connectTimeoutMs,
+      100,
+    );
+    await page.getByTestId('session-join').click();
+    await waitForBrowserConnected(page, options);
+    await detailPage.getByTestId('session-inspector-detail-refresh').click();
+
+    await poll(
+      'session detail live client count',
+      async () => await detailPage.getByTestId('session-total-clients').textContent().catch(() => ''),
+      (value) => Number(value) > 0,
+      options.connectTimeoutMs,
+      100,
+    );
+    for (const testId of ['session-release-runtime', 'session-stop', 'session-kill']) {
+      const disabled = await detailPage.getByTestId(testId).isDisabled();
+      if (!disabled) {
+        throw new Error(`Expected ${testId} to be disabled while another admin page is connected.`);
+      }
+    }
+  } finally {
+    await detailPage.close().catch(() => {});
+    await disconnectEmbeddedBrowser(page, options).catch(() => {});
   }
 }
 

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -76,7 +76,11 @@ async function run() {
     await page.getByTestId('session-stop').click();
     await waitForSessionState(page, options, sessionId, 'stopped');
     await expectLifecycleMessage(page, options, 'Selected session stopped.');
-    await expectStoppedSessionJoinDisabled(page, options);
+    await reconnectStoppedSession(page, options, sessionId);
+    await disconnectEmbeddedBrowser(page, options);
+    await waitForStopEnabled(page, options, sessionId);
+    await page.getByTestId('session-stop').click();
+    await waitForSessionState(page, options, sessionId, 'stopped');
     await emitSummary(page, options, sessionId, stopDisabled, log);
   } finally {
     await cleanupAdminSmoke(page, options, log);
@@ -157,15 +161,18 @@ async function expectRuntimeResumeMode(page, options, expectedText) {
   );
 }
 
-async function expectStoppedSessionJoinDisabled(page, options) {
+async function reconnectStoppedSession(page, options, sessionId) {
   await openAdminTab(page, 'sessions');
   await poll(
-    'admin stopped session join disabled',
-    async () => await page.getByTestId('session-join').isDisabled(),
+    'admin stopped session join enabled',
+    async () => await page.getByTestId('session-join').isEnabled(),
     Boolean,
     options.connectTimeoutMs,
     100,
   );
+  await page.getByTestId('session-join').click();
+  await waitForBrowserConnected(page, options);
+  await expectRuntimeResumeMode(page, options, 'profile_restart');
 }
 
 async function expectGlobalMessage(page, options, matches) {

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -8,7 +8,6 @@ import {
   ensureAdminLoggedIn,
   openAdminTab,
   waitForBrowserConnected,
-  waitForKillEnabled,
   waitForSessionState,
   waitForStopEnabled,
 } from './admin-smoke-lib.mjs';
@@ -56,24 +55,28 @@ async function run() {
       throw new Error('Expected session stop to be disabled while embedded browser is connected.');
     }
 
-    log('Disconnecting through the session inspector and stopping the selected session.');
+    log('Disconnecting through the session inspector and releasing the selected session runtime.');
     await disconnectThroughSessionInspector(page, options);
+    await waitForStopEnabled(page, options, sessionId);
+    await page.getByTestId('session-release-runtime').click();
+    await waitForSessionState(page, options, sessionId, 'released');
+    await expectLifecycleMessage(page, options, 'Selected session runtime was released.');
+    await expectRuntimeResumeMode(page, options, 'released');
+
+    log(`Reconnecting released session ${sessionId}.`);
+    await openAdminTab(page, 'sessions');
+    await page.getByTestId('session-join').click();
+    await waitForBrowserConnected(page, options);
+    await openAdminTab(page, 'lifecycle');
+    await expectRuntimeResumeMode(page, options, 'profile_restart');
+    await disconnectEmbeddedBrowser(page, options);
+
+    log(`Stopping reconnected session ${sessionId}.`);
     await waitForStopEnabled(page, options, sessionId);
     await page.getByTestId('session-stop').click();
     await waitForSessionState(page, options, sessionId, 'stopped');
     await expectLifecycleMessage(page, options, 'Selected session stopped.');
-
-    log(`Reconnecting stopped session ${sessionId}.`);
-    await openAdminTab(page, 'sessions');
-    await page.getByTestId('session-join').click();
-    await waitForBrowserConnected(page, options);
-    await disconnectEmbeddedBrowser(page, options);
-
-    log(`Force killing reconnected session ${sessionId}.`);
-    await waitForKillEnabled(page, options, sessionId);
-    await page.getByTestId('session-kill').click();
-    await waitForSessionState(page, options, sessionId, 'stopped');
-    await expectLifecycleMessage(page, options, 'Selected session was force killed.');
+    await expectStoppedSessionJoinDisabled(page, options);
     await emitSummary(page, options, sessionId, stopDisabled, log);
   } finally {
     await cleanupAdminSmoke(page, options, log);
@@ -137,6 +140,29 @@ async function expectLifecycleMessage(page, options, expectedText) {
     `admin lifecycle message ${expectedText}`,
     async () => await page.getByTestId('session-lifecycle-message').textContent().catch(() => ''),
     (message) => message.includes(expectedText),
+    options.connectTimeoutMs,
+    100,
+  );
+}
+
+async function expectRuntimeResumeMode(page, options, expectedText) {
+  await openAdminTab(page, 'lifecycle');
+  await page.getByTestId('session-detail-refresh').click();
+  await poll(
+    `admin runtime resume mode ${expectedText}`,
+    async () => await page.getByTestId('session-runtime-resume-mode').textContent().catch(() => ''),
+    (value) => value === expectedText,
+    options.connectTimeoutMs,
+    100,
+  );
+}
+
+async function expectStoppedSessionJoinDisabled(page, options) {
+  await openAdminTab(page, 'sessions');
+  await poll(
+    'admin stopped session join disabled',
+    async () => await page.getByTestId('session-join').isDisabled(),
+    Boolean,
     options.connectTimeoutMs,
     100,
   );

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -38,6 +38,7 @@ async function run() {
     sessionId = await resolveSelectedSessionId(page, options);
     await waitForMcpDelegationReady(page, options);
     await waitForBrowserConnected(page, options);
+    await expectSessionDisconnectControl(page);
     await expectGlobalMessage(page, options, (message) => message.trim().length > 0);
     await dismissGlobalMessage(page, options);
     await verifyBrowserPolicyPanel(page);
@@ -69,7 +70,7 @@ async function run() {
     await waitForBrowserConnected(page, options);
     await openAdminTab(page, 'lifecycle');
     await expectRuntimeResumeMode(page, options, 'profile_restart');
-    await disconnectEmbeddedBrowser(page, options);
+    await disconnectThroughSessionArea(page, options);
 
     log(`Stopping reconnected session ${sessionId}.`);
     await waitForStopEnabled(page, options, sessionId);
@@ -137,6 +138,25 @@ async function disconnectThroughSessionInspector(page, options) {
     options.connectTimeoutMs,
   );
   await expectLifecycleMessage(page, options, 'Disconnected all live clients.');
+}
+
+async function disconnectThroughSessionArea(page, options) {
+  await openAdminTab(page, 'sessions');
+  await page.getByTestId('session-disconnect').click();
+  await poll(
+    'admin embedded browser disconnect through session area',
+    async () => await page.getByTestId('browser-status').textContent(),
+    (status) => status === 'Disconnected',
+    options.connectTimeoutMs,
+  );
+}
+
+async function expectSessionDisconnectControl(page) {
+  await openAdminTab(page, 'sessions');
+  const disconnectEnabled = await page.getByTestId('session-disconnect').isEnabled();
+  if (!disconnectEnabled) {
+    throw new Error('Expected session area disconnect control to be enabled after browser connect.');
+  }
 }
 
 async function expectLifecycleMessage(page, options, expectedText) {

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -6,12 +6,13 @@ import {
   cleanupAdminSmoke,
   disconnectEmbeddedBrowser,
   ensureAdminLoggedIn,
+  getAdminAccessToken,
   openAdminTab,
   waitForBrowserConnected,
   waitForSessionState,
   waitForStopEnabled,
 } from './admin-smoke-lib.mjs';
-import { DEFAULTS, createLogger, launchChrome, parseSmokeArgs, poll } from './workflow-smoke-lib.mjs';
+import { DEFAULTS, apiOrigin, createLogger, fetchJson, launchChrome, parseSmokeArgs, poll } from './workflow-smoke-lib.mjs';
 
 async function run() {
   const options = parseSmokeArgs(process.argv.slice(2), 'run-admin-session-smoke.mjs');
@@ -39,6 +40,7 @@ async function run() {
     await waitForMcpDelegationReady(page, options);
     await waitForBrowserConnected(page, options);
     await expectSessionDisconnectControl(page);
+    await verifySessionSwitchDisconnect(page, options, sessionId);
     await expectGlobalMessage(page, options, (message) => message.trim().length > 0);
     await dismissGlobalMessage(page, options);
     await verifyBrowserPolicyPanel(page);
@@ -157,6 +159,62 @@ async function expectSessionDisconnectControl(page) {
   if (!disconnectEnabled) {
     throw new Error('Expected session area disconnect control to be enabled after browser connect.');
   }
+}
+
+async function verifySessionSwitchDisconnect(page, options, originalSessionId) {
+  const accessToken = await getAdminAccessToken(page);
+  const switchTarget = await createSwitchTargetSession(accessToken, options);
+
+  await openAdminTab(page, 'sessions');
+  await waitForSessionRow(page, options, switchTarget.id);
+  await page.locator(`[data-testid="session-row"][data-session-id="${switchTarget.id}"]`).click();
+  await poll(
+    'admin browser disconnect on session switch',
+    async () => await page.getByTestId('browser-status').textContent(),
+    (status) => status === 'Disconnected',
+    options.connectTimeoutMs,
+    100,
+  );
+  const disconnectEnabled = await page.getByTestId('session-disconnect').isEnabled();
+  if (disconnectEnabled) {
+    throw new Error('Expected session area disconnect control to be disabled after switching away from the live session.');
+  }
+
+  await page.locator(`[data-testid="session-row"][data-session-id="${originalSessionId}"]`).click();
+  await poll(
+    'admin session join enabled after switch-back',
+    async () => await page.getByTestId('session-join').isEnabled(),
+    Boolean,
+    options.connectTimeoutMs,
+    100,
+  );
+  await page.getByTestId('session-join').click();
+  await waitForBrowserConnected(page, options);
+  await expectSessionDisconnectControl(page);
+}
+
+async function createSwitchTargetSession(accessToken, options) {
+  return await fetchJson(`${apiOrigin(options)}/api/v1/sessions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ labels: { suite: 'admin-session-switch-smoke' } }),
+  });
+}
+
+async function waitForSessionRow(page, options, sessionId) {
+  await poll(
+    `admin session row ${sessionId}`,
+    async () => {
+      const row = page.locator(`[data-testid="session-row"][data-session-id="${sessionId}"]`);
+      return await row.isVisible().catch(() => false);
+    },
+    Boolean,
+    options.connectTimeoutMs,
+    100,
+  );
 }
 
 async function expectLifecycleMessage(page, options, expectedText) {

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -1920,6 +1920,32 @@ paths:
                 $ref: '#/components/schemas/SessionStopConflictResponse'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/sessions/{session_id}/release:
+    parameters:
+      - $ref: '#/components/parameters/SessionId'
+    post:
+      tags: [Sessions]
+      summary: Release the live runtime while preserving the session resource and profile
+      operationId: releaseSessionRuntime
+      responses:
+        '200':
+          description: Session runtime released
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: Session runtime cannot be released while blockers remain
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionStopConflictResponse'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions/{session_id}/kill:
     parameters:
       - $ref: '#/components/parameters/SessionId'
@@ -2211,6 +2237,7 @@ components:
         - ready
         - active
         - idle
+        - released
         - stopping
         - stopped
         - failed
@@ -4192,7 +4219,16 @@ components:
         - not_started
         - starting
         - running
+        - released
         - stopping
+        - stopped
+    SessionRuntimeResumeMode:
+      type: string
+      enum:
+        - fresh_start
+        - exact_live
+        - profile_restart
+        - released
         - stopped
     SessionPresenceState:
       type: string
@@ -4304,6 +4340,7 @@ components:
       type: object
       required:
         - runtime_state
+        - runtime_resume_mode
         - presence_state
         - connection_counts
         - stop_eligibility
@@ -4311,6 +4348,8 @@ components:
       properties:
         runtime_state:
           $ref: '#/components/schemas/SessionRuntimeState'
+        runtime_resume_mode:
+          $ref: '#/components/schemas/SessionRuntimeResumeMode'
         presence_state:
           $ref: '#/components/schemas/SessionPresenceState'
         connection_counts:
@@ -4340,6 +4379,7 @@ components:
         - status
         - created_at
         - updated_at
+        - runtime_released_at
         - stopped_at
       properties:
         id:
@@ -4392,6 +4432,10 @@ components:
         updated_at:
           type: string
           format: date-time
+        runtime_released_at:
+          type: string
+          format: date-time
+          nullable: true
         stopped_at:
           type: string
           format: date-time
@@ -4776,6 +4820,7 @@ components:
       required:
         - state
         - runtime_state
+        - runtime_resume_mode
         - presence_state
         - connection_counts
         - stop_eligibility
@@ -4797,6 +4842,8 @@ components:
           $ref: '#/components/schemas/SessionLifecycleState'
         runtime_state:
           $ref: '#/components/schemas/SessionRuntimeState'
+        runtime_resume_mode:
+          $ref: '#/components/schemas/SessionRuntimeResumeMode'
         presence_state:
           $ref: '#/components/schemas/SessionPresenceState'
         connection_counts:


### PR DESCRIPTION
## Summary
- add explicit session runtime release semantics and API/status/OpenAPI coverage
- harden admin reconnect behavior for released/stopped sessions, stale surfaces, session switching, and same-page reconnect cleanup
- extend admin/session smokes for release, stopped restart, session-area disconnect, and switch-away/switch-back reconnect behavior

## Validation
- `cargo test -p bpane-gateway`
- `cd code/web/bpane-admin && npm run check`
- targeted admin view-model/session connector tests
- `cd code/web/bpane-client && npx tsc --noEmit`
- targeted bpane-client session lifecycle tests
- `node --check code/web/bpane-client/scripts/run-admin-session-smoke.mjs`
- `git diff --check`
- rebuilt `deploy-web`
- `cd code/web/bpane-client && npm run smoke:admin-session -- --headless`

Closes #120