### PR TITLE
Add session templates and catalog filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Current product shape:
   - WebTransport gateway and shared-session coordinator.
   - `transport.rs`: browser connection loop, per-client policy, relay behavior.
   - `session_hub.rs`: fan-out, late-join bootstrap, viewer cap, telemetry.
-  - `session_control.rs`: versioned session-control store and Postgres integration, including workflows, credential bindings, file workspaces, and approved extension metadata.
+  - `session_control.rs`: versioned session-control store and Postgres integration, including session templates, workflows, credential bindings, file workspaces, and approved extension metadata.
   - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
   - `credential_provider.rs`: credential binding secret-provider boundary. Local compose uses HashiCorp Vault dev mode and the current implementation targets Vault KV v2.
   - `workflow_source.rs`: workflow source contract and git ref resolution. Workflow definition versions can pin git-backed source metadata to an immutable commit at publish time without embedding source blobs into the control plane.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,7 @@ Current product shape:
 Run these in `code/web/bpane-client`:
 - `npx tsc --noEmit`
 - `npm run smoke:automation-tasks -- --headless`
+- `npm run smoke:bpane-cli -- --headless`
 - `npm run smoke:file-workspaces -- --headless`
 - `npm test`
 - `npm run build`

--- a/ARCH.md
+++ b/ARCH.md
@@ -262,9 +262,13 @@ service.
 - **HTTP API** (`api.rs`, :8932):
   - canonical frozen v1 contract: `openapi/bpane-control-v1.yaml`
   - `POST /api/v1/sessions` — create a persistent session resource
-  - `GET /api/v1/sessions` — list owner-scoped sessions
+  - `GET /api/v1/sessions` — list owner-scoped sessions, with catalog filters for template id, lifecycle/runtime state, labels, integration context, limit, and offset
   - `GET /api/v1/sessions/{id}` — fetch one owner-scoped session resource
   - `DELETE /api/v1/sessions/{id}` — safe-stop one owner-scoped session resource
+  - `POST /api/v1/session-templates` — create a reusable owner-scoped session template
+  - `GET /api/v1/session-templates` — list reusable owner-scoped session templates
+  - `GET /api/v1/session-templates/{id}` — fetch one session template
+  - `PUT /api/v1/session-templates/{id}` — replace a session template and increment its version
   - `POST /api/v1/sessions/{id}/access-tokens` — mint a short-lived session-scoped connect ticket
   - `POST /api/v1/sessions/{id}/stop` — explicit safe-stop with blocker reporting
   - `POST /api/v1/sessions/{id}/release` — release the live runtime while preserving the session resource and profile

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ Session templates store reusable defaults for session creation, including owner
 mode, viewport, idle timeout, labels, integration context, and recording policy.
 Creating a session with a UUID `template_id` merges those defaults before the
 session is persisted; explicit caller fields win over template defaults.
+The admin create-session configurator follows the same rule: selecting a
+template leaves owner mode and idle timeout unset unless the operator chooses an
+explicit override, and the API payload preview shows the exact fields that will
+be sent.
 `GET /api/v1/sessions` accepts catalog filters such as `template_id`, `state`,
 `runtime_state`, `label.<key>`, `integration.<key>`, `limit`, and `offset`.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current support and scope:
 - Shared sessions: collaborative by default, intended for small curated groups rather than broadcast-scale delivery.
 - Owner/viewer mode: optional exclusive-owner mode is supported in the gateway; restricted viewers are read-only.
 - Camera: disabled by default in the compose stack and requires browser H.264 encode support plus a mapped `v4l2loopback` device.
-- Control plane: owner-scoped v1 APIs now cover sessions, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
+- Control plane: owner-scoped v1 APIs now cover sessions, session templates, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
 - Workflow execution: Git-backed workflow versions run through a gateway-managed `workflow-worker`; the current executor model is Playwright.
 - Workflow boundary: BrowserPane currently focuses on executing and supervising browser workflows. Broader scheduling, DAG orchestration, and cross-system coordination are expected to sit above BrowserPane rather than inside it.
 
@@ -121,7 +121,7 @@ bpane-gateway also talks to:
 | Project | Responsibility |
 | --- | --- |
 | `code/apps/bpane-host` | Linux host agent. Captures the desktop surface, classifies tiles, drives ROI H.264 video, emits audio, injects input, and handles clipboard, file transfer, resize, and camera ingress plumbing. |
-| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for sessions, automation tasks, recordings, workflows, files, credentials, and extensions. |
+| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for sessions, session templates, automation tasks, recordings, workflows, files, credentials, and extensions. |
 | `code/shared/bpane-protocol` | Shared binary wire contract. Defines channels, frame envelopes, typed protocol messages, and incremental frame decoding used by the Rust services and validated against the browser client. |
 | `code/web/bpane-client` | Real browser client. Renders tiles/video, decodes media, captures keyboard/mouse/clipboard input, and manages browser-side audio, camera, and file-transfer flows. |
 | `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes compatibility Streamable HTTP on `/mcp`, session-scoped Streamable HTTP on `/sessions/{id}/mcp`, compatibility SSE on `/sse`, session-scoped SSE on `/sessions/{id}/sse`, and integrates with gateway ownership APIs so automation can attach alongside interactive browser users through delegated session control. |
@@ -277,10 +277,21 @@ Canonical contract:
 - `GET /api/v1/sessions`
 - `GET /api/v1/sessions/{id}`
 - `DELETE /api/v1/sessions/{id}`
+- `POST /api/v1/session-templates`
+- `GET /api/v1/session-templates`
+- `GET /api/v1/session-templates/{id}`
+- `PUT /api/v1/session-templates/{id}`
 
 These endpoints are bearer-protected, owner-scoped, and stored in Postgres. The
 full contract is in the OpenAPI file; the route lists below call out the
 operator-facing surfaces that are most relevant for local development.
+
+Session templates store reusable defaults for session creation, including owner
+mode, viewport, idle timeout, labels, integration context, and recording policy.
+Creating a session with a UUID `template_id` merges those defaults before the
+session is persisted; explicit caller fields win over template defaults.
+`GET /api/v1/sessions` accepts catalog filters such as `template_id`, `state`,
+`runtime_state`, `label.<key>`, `integration.<key>`, `limit`, and `offset`.
 
 The admin console also uses a bearer-protected realtime WebSocket for
 owner-scoped snapshot updates:
@@ -401,6 +412,7 @@ Common session operations:
 ```bash
 ./scripts/bpane session list
 ./scripts/bpane session list --state stopped --label suite=smoke --limit 5
+./scripts/bpane session list --template-id <template-id> --label team=support
 ./scripts/bpane session create --label purpose=manual-test
 ./scripts/bpane session get <session-id>
 ./scripts/bpane session status <session-id>
@@ -409,6 +421,22 @@ Common session operations:
 ./scripts/bpane session disconnect-all <session-id>
 ./scripts/bpane session stop <session-id>
 ./scripts/bpane session kill <session-id>
+```
+
+Common session-template operations:
+
+```bash
+./scripts/bpane session-template create customer-debug-session \
+  --description "Support debug sessions" \
+  --label team=support \
+  --default-label purpose=debug \
+  --owner-mode collaborative \
+  --idle-timeout-sec 1800 \
+  --recording-mode manual
+./scripts/bpane session-template list
+./scripts/bpane session-template get <template-id>
+./scripts/bpane session-template update <template-id> --name customer-debug-session --default-label purpose=debug
+./scripts/bpane session create --template-id <template-id> --label case=INC-1234
 ```
 
 MCP delegation and recovery operations:

--- a/README.md
+++ b/README.md
@@ -231,8 +231,9 @@ The default local auth flow is OIDC-based:
 - click `Login`
 - authenticate against the local Keycloak realm
 - use the demo account `demo / demo-demo`
-- return to the admin console and either select an existing session or click `Start New Session`
+- return to the admin console and either select an existing session or create a new one, optionally from a session template
 - the admin console joins the selected owner-scoped `/api/v1/sessions` resource, or creates a new one before opening WebTransport
+- the live session panel and session inspector show the applied template, and the inspector can filter sessions by template, lifecycle state, and runtime state
 - sessions created from the admin console use a 5 minute idle timeout and are stopped automatically if they remain unused or become idle without any browser viewers or MCP owner
 - reconnecting a stopped session now restarts the same session resource instead of creating a new one
 - switching the selected session disconnects the embedded browser from the previous live session before selecting the new one

--- a/code/apps/bpane-gateway/migrations/20260521000100_session_templates.sql
+++ b/code/apps/bpane-gateway/migrations/20260521000100_session_templates.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS control_session_templates (
+    id UUID PRIMARY KEY,
+    owner_subject TEXT NOT NULL,
+    owner_issuer TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+    defaults JSONB NOT NULL DEFAULT '{}'::jsonb,
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS control_session_templates_owner_idx
+    ON control_session_templates (owner_subject, owner_issuer, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS control_session_templates_owner_name_idx
+    ON control_session_templates (owner_subject, owner_issuer, name);

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::body::Bytes;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::Response;
@@ -38,10 +38,12 @@ use crate::session_access::SessionAutomationAccessTokenClaims;
 use crate::session_control::{
     CompleteSessionRecordingRequest, CreateSessionRequest, FailSessionRecordingRequest,
     PersistCompletedSessionRecordingRequest, PersistSessionFileBindingRequest,
-    SessionLifecycleState, SessionListResponse, SessionOwnerMode, SessionRecordingFormat,
-    SessionRecordingListResponse, SessionRecordingMode, SessionRecordingPolicy,
-    SessionRecordingResource, SessionRecordingState, SessionRecordingTerminationReason,
-    SessionResource, SetAutomationDelegateRequest, StoredSession, StoredSessionRecording,
+    PersistSessionTemplateRequest, SessionLifecycleState, SessionListResponse, SessionOwnerMode,
+    SessionRecordingFormat, SessionRecordingListResponse, SessionRecordingMode,
+    SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
+    SessionRecordingTerminationReason, SessionResource, SessionTemplateDefaults,
+    SessionTemplateListResponse, SessionTemplateResource, SetAutomationDelegateRequest,
+    StoredSession, StoredSessionRecording,
 };
 use crate::session_files::{
     SessionFileBindingListResponse, SessionFileBindingResource, SessionFileListResponse,
@@ -91,6 +93,7 @@ mod router;
 mod runtime_access;
 mod session_bindings;
 mod session_files;
+mod session_templates;
 mod sessions;
 mod types;
 mod workflow_definitions;

--- a/code/apps/bpane-gateway/src/api/router.rs
+++ b/code/apps/bpane-gateway/src/api/router.rs
@@ -29,6 +29,7 @@ pub(crate) fn build_api_router(state: Arc<ApiState>) -> Router {
         .merge(automation_tasks::automation_task_routes())
         .merge(recordings::recording_routes())
         .merge(session_files::session_file_routes())
+        .merge(session_templates::session_template_routes())
         .merge(sessions::session_operation_routes())
         .merge(recordings::recording_operation_routes())
         .route("/api/v1/workflow/operations", get(get_workflow_operations))

--- a/code/apps/bpane-gateway/src/api/session_bindings.rs
+++ b/code/apps/bpane-gateway/src/api/session_bindings.rs
@@ -135,6 +135,75 @@ async fn resolve_session_extensions(
     Ok(extensions)
 }
 
+pub(super) async fn resolve_session_template_defaults(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    request: CreateSessionRequest,
+) -> Result<CreateSessionRequest, (StatusCode, Json<ErrorResponse>)> {
+    let Some(template_id) = request.template_id.clone() else {
+        return Ok(request);
+    };
+    let Ok(template_uuid) = Uuid::parse_str(&template_id) else {
+        return Ok(request);
+    };
+    let Some(template) = state
+        .session_store
+        .get_session_template_for_owner(principal, template_uuid)
+        .await
+        .map_err(map_session_store_error)?
+    else {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("session template {template_id} not found"),
+            }),
+        ));
+    };
+
+    Ok(merge_template_defaults(request, template.defaults))
+}
+
+fn merge_template_defaults(
+    mut request: CreateSessionRequest,
+    defaults: SessionTemplateDefaults,
+) -> CreateSessionRequest {
+    request.owner_mode = request.owner_mode.or(defaults.owner_mode);
+    if request.viewport.is_none() {
+        request.viewport = defaults.viewport;
+    }
+    request.idle_timeout_sec = request.idle_timeout_sec.or(defaults.idle_timeout_sec);
+
+    let mut labels = defaults.labels;
+    labels.extend(request.labels);
+    request.labels = labels;
+
+    request.integration_context =
+        merge_integration_context(defaults.integration_context, request.integration_context);
+
+    if request.recording == SessionRecordingPolicy::default() {
+        if let Some(recording) = defaults.recording {
+            request.recording = recording;
+        }
+    }
+
+    request
+}
+
+fn merge_integration_context(
+    defaults: Option<Value>,
+    override_value: Option<Value>,
+) -> Option<Value> {
+    match (defaults, override_value) {
+        (Some(Value::Object(mut default_object)), Some(Value::Object(override_object))) => {
+            default_object.extend(override_object);
+            Some(Value::Object(default_object))
+        }
+        (_, Some(value)) => Some(value),
+        (Some(value), None) => Some(value),
+        (None, None) => None,
+    }
+}
+
 pub(super) async fn create_owned_session(
     state: &ApiState,
     principal: &AuthenticatedPrincipal,
@@ -242,6 +311,8 @@ pub(super) async fn resolve_task_session_binding(
             existing_session_id: None,
             create_session: Some(create_session_request),
         }) => {
+            let create_session_request =
+                resolve_session_template_defaults(state, principal, create_session_request).await?;
             let owner_mode = resolve_owner_mode(state, create_session_request.owner_mode)?;
             let created = create_owned_session(
                 state,
@@ -283,6 +354,8 @@ pub(super) async fn resolve_task_session_binding(
                     }),
                 )
             })?;
+            let create_session_request =
+                resolve_session_template_defaults(state, principal, create_session_request).await?;
             let owner_mode = resolve_owner_mode(state, create_session_request.owner_mode)?;
             let created = create_owned_session(
                 state,

--- a/code/apps/bpane-gateway/src/api/session_templates.rs
+++ b/code/apps/bpane-gateway/src/api/session_templates.rs
@@ -1,0 +1,113 @@
+use axum::routing::{get, post};
+
+use super::*;
+
+pub(super) fn session_template_routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route(
+            "/api/v1/session-templates",
+            post(create_session_template).get(list_session_templates),
+        )
+        .route(
+            "/api/v1/session-templates/{template_id}",
+            get(get_session_template).put(update_session_template),
+        )
+}
+
+async fn list_session_templates(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionTemplateListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let templates = state
+        .session_store
+        .list_session_templates_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?
+        .into_iter()
+        .map(|template| template.to_resource())
+        .collect();
+    Ok(Json(SessionTemplateListResponse { templates }))
+}
+
+async fn create_session_template(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertSessionTemplateRequest>,
+) -> Result<(StatusCode, Json<SessionTemplateResource>), (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let template = state
+        .session_store
+        .create_session_template(&principal, persist_template_request(request))
+        .await
+        .map_err(map_session_store_error)?;
+    Ok((StatusCode::CREATED, Json(template.to_resource())))
+}
+
+async fn get_session_template(
+    headers: HeaderMap,
+    Path(template_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<SessionTemplateResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let template = state
+        .session_store
+        .get_session_template_for_owner(&principal, template_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session template {template_id} not found"),
+                }),
+            )
+        })?;
+    Ok(Json(template.to_resource()))
+}
+
+async fn update_session_template(
+    headers: HeaderMap,
+    Path(template_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertSessionTemplateRequest>,
+) -> Result<Json<SessionTemplateResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let template = state
+        .session_store
+        .update_session_template_for_owner(
+            &principal,
+            template_id,
+            persist_template_request(request),
+        )
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("session template {template_id} not found"),
+                }),
+            )
+        })?;
+    Ok(Json(template.to_resource()))
+}
+
+fn persist_template_request(
+    request: UpsertSessionTemplateRequest,
+) -> PersistSessionTemplateRequest {
+    PersistSessionTemplateRequest {
+        name: request.name,
+        description: request.description,
+        labels: request.labels,
+        defaults: request.defaults,
+    }
+}

--- a/code/apps/bpane-gateway/src/api/sessions/crud.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/crud.rs
@@ -79,7 +79,7 @@ pub(super) async fn get_session(
 struct SessionCatalogFilters {
     template_id: Option<String>,
     states: Vec<SessionLifecycleState>,
-    runtime_states: Vec<String>,
+    runtime_states: Vec<crate::session_control::SessionRuntimeState>,
     labels: HashMap<String, String>,
     integration_context: HashMap<String, String>,
     limit: Option<usize>,
@@ -96,7 +96,7 @@ fn parse_session_catalog_filters(
         } else if key == "state" {
             filters.states = parse_session_states(&value)?;
         } else if key == "runtime_state" {
-            filters.runtime_states = parse_csv(&value);
+            filters.runtime_states = parse_session_runtime_states(&value)?;
         } else if key == "limit" {
             filters.limit = Some(parse_positive_usize("limit", &value)?);
         } else if key == "offset" {
@@ -131,6 +131,25 @@ fn parse_session_states(
             entry
                 .parse::<SessionLifecycleState>()
                 .map_err(|_| bad_request(&format!("unsupported session state filter: {entry}")))
+        })
+        .collect()
+}
+
+fn parse_session_runtime_states(
+    value: &str,
+) -> Result<Vec<crate::session_control::SessionRuntimeState>, (StatusCode, Json<ErrorResponse>)> {
+    parse_csv(value)
+        .into_iter()
+        .map(|entry| match entry.as_str() {
+            "not_started" => Ok(crate::session_control::SessionRuntimeState::NotStarted),
+            "starting" => Ok(crate::session_control::SessionRuntimeState::Starting),
+            "running" => Ok(crate::session_control::SessionRuntimeState::Running),
+            "released" => Ok(crate::session_control::SessionRuntimeState::Released),
+            "stopping" => Ok(crate::session_control::SessionRuntimeState::Stopping),
+            "stopped" => Ok(crate::session_control::SessionRuntimeState::Stopped),
+            _ => Err(bad_request(&format!(
+                "unsupported session runtime_state filter: {entry}"
+            ))),
         })
         .collect()
 }
@@ -212,17 +231,5 @@ fn session_resource_matches_catalog_filters(
     filters.runtime_states.is_empty()
         || filters
             .runtime_states
-            .iter()
-            .any(|state| state == session_runtime_state_name(resource.status.runtime_state))
-}
-
-fn session_runtime_state_name(state: crate::session_control::SessionRuntimeState) -> &'static str {
-    match state {
-        crate::session_control::SessionRuntimeState::NotStarted => "not_started",
-        crate::session_control::SessionRuntimeState::Starting => "starting",
-        crate::session_control::SessionRuntimeState::Running => "running",
-        crate::session_control::SessionRuntimeState::Released => "released",
-        crate::session_control::SessionRuntimeState::Stopping => "stopping",
-        crate::session_control::SessionRuntimeState::Stopped => "stopped",
-    }
+            .contains(&resource.status.runtime_state)
 }

--- a/code/apps/bpane-gateway/src/api/sessions/crud.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/crud.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use std::collections::HashMap;
 
 pub(super) async fn create_session(
     headers: HeaderMap,
@@ -8,6 +9,7 @@ pub(super) async fn create_session(
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let request = resolve_session_template_defaults(&state, &principal, request).await?;
     let owner_mode = resolve_owner_mode(&state, request.owner_mode)?;
     let stored = create_owned_session(&state, &principal, request, owner_mode, None).await?;
 
@@ -24,23 +26,35 @@ pub(super) async fn create_session(
 pub(super) async fn list_sessions(
     headers: HeaderMap,
     State(state): State<Arc<ApiState>>,
+    Query(raw_query): Query<HashMap<String, String>>,
 ) -> Result<Json<SessionListResponse>, (StatusCode, Json<ErrorResponse>)> {
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let filters = parse_session_catalog_filters(raw_query)?;
     let sessions = state
         .session_store
         .list_sessions_for_owner(&principal)
         .await
         .map_err(map_session_store_error)?;
-    let mut resources = Vec::with_capacity(sessions.len());
-    for session in sessions {
-        resources.push(
-            session_resource(&state, &session, None)
-                .await
-                .map_err(map_session_store_error)?,
-        );
+    let filtered = sessions
+        .into_iter()
+        .filter(|session| stored_session_matches_catalog_filters(session, &filters))
+        .collect::<Vec<_>>();
+    let mut resources = Vec::with_capacity(filtered.len());
+    for session in filtered {
+        let resource = session_resource(&state, &session, None)
+            .await
+            .map_err(map_session_store_error)?;
+        if session_resource_matches_catalog_filters(&resource, &filters) {
+            resources.push(resource);
+        }
     }
+    let resources = resources
+        .into_iter()
+        .skip(filters.offset)
+        .take(filters.limit.unwrap_or(usize::MAX))
+        .collect();
 
     Ok(Json(SessionListResponse {
         sessions: resources,
@@ -59,4 +73,156 @@ pub(super) async fn get_session(
             .await
             .map_err(map_session_store_error)?,
     ))
+}
+
+#[derive(Default)]
+struct SessionCatalogFilters {
+    template_id: Option<String>,
+    states: Vec<SessionLifecycleState>,
+    runtime_states: Vec<String>,
+    labels: HashMap<String, String>,
+    integration_context: HashMap<String, String>,
+    limit: Option<usize>,
+    offset: usize,
+}
+
+fn parse_session_catalog_filters(
+    query: HashMap<String, String>,
+) -> Result<SessionCatalogFilters, (StatusCode, Json<ErrorResponse>)> {
+    let mut filters = SessionCatalogFilters::default();
+    for (key, value) in query {
+        if key == "template_id" {
+            filters.template_id = Some(value);
+        } else if key == "state" {
+            filters.states = parse_session_states(&value)?;
+        } else if key == "runtime_state" {
+            filters.runtime_states = parse_csv(&value);
+        } else if key == "limit" {
+            filters.limit = Some(parse_positive_usize("limit", &value)?);
+        } else if key == "offset" {
+            filters.offset = parse_non_negative_usize("offset", &value)?;
+        } else if let Some(label_key) = key.strip_prefix("label.") {
+            if label_key.trim().is_empty() {
+                return Err(bad_request("label filter key must not be empty"));
+            }
+            filters.labels.insert(label_key.to_string(), value);
+        } else if let Some(context_key) = key.strip_prefix("integration.") {
+            if context_key.trim().is_empty() {
+                return Err(bad_request("integration filter key must not be empty"));
+            }
+            filters
+                .integration_context
+                .insert(context_key.to_string(), value);
+        } else {
+            return Err(bad_request(&format!(
+                "unsupported session query parameter: {key}"
+            )));
+        }
+    }
+    Ok(filters)
+}
+
+fn parse_session_states(
+    value: &str,
+) -> Result<Vec<SessionLifecycleState>, (StatusCode, Json<ErrorResponse>)> {
+    parse_csv(value)
+        .into_iter()
+        .map(|entry| {
+            entry
+                .parse::<SessionLifecycleState>()
+                .map_err(|_| bad_request(&format!("unsupported session state filter: {entry}")))
+        })
+        .collect()
+}
+
+fn parse_csv(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn parse_positive_usize(
+    name: &str,
+    value: &str,
+) -> Result<usize, (StatusCode, Json<ErrorResponse>)> {
+    let parsed = parse_non_negative_usize(name, value)?;
+    if parsed == 0 {
+        return Err(bad_request(&format!("{name} must be greater than zero")));
+    }
+    Ok(parsed)
+}
+
+fn parse_non_negative_usize(
+    name: &str,
+    value: &str,
+) -> Result<usize, (StatusCode, Json<ErrorResponse>)> {
+    value
+        .parse::<usize>()
+        .map_err(|_| bad_request(&format!("{name} must be a non-negative integer")))
+}
+
+fn bad_request(message: &str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse {
+            error: message.to_string(),
+        }),
+    )
+}
+
+fn stored_session_matches_catalog_filters(
+    session: &StoredSession,
+    filters: &SessionCatalogFilters,
+) -> bool {
+    if filters
+        .template_id
+        .as_ref()
+        .is_some_and(|template_id| session.template_id.as_ref() != Some(template_id))
+    {
+        return false;
+    }
+    if !filters.states.is_empty() && !filters.states.contains(&session.state) {
+        return false;
+    }
+    if !filters
+        .labels
+        .iter()
+        .all(|(key, value)| session.labels.get(key) == Some(value))
+    {
+        return false;
+    }
+    filters.integration_context.iter().all(|(key, value)| {
+        session
+            .integration_context
+            .as_ref()
+            .and_then(Value::as_object)
+            .and_then(|object| object.get(key))
+            .and_then(Value::as_str)
+            == Some(value.as_str())
+    })
+}
+
+fn session_resource_matches_catalog_filters(
+    resource: &SessionResource,
+    filters: &SessionCatalogFilters,
+) -> bool {
+    filters.runtime_states.is_empty()
+        || filters
+            .runtime_states
+            .iter()
+            .any(|state| state == session_runtime_state_name(resource.status.runtime_state))
+}
+
+fn session_runtime_state_name(state: crate::session_control::SessionRuntimeState) -> &'static str {
+    match state {
+        crate::session_control::SessionRuntimeState::NotStarted => "not_started",
+        crate::session_control::SessionRuntimeState::Starting => "starting",
+        crate::session_control::SessionRuntimeState::Running => "running",
+        crate::session_control::SessionRuntimeState::Released => "released",
+        crate::session_control::SessionRuntimeState::Stopping => "stopping",
+        crate::session_control::SessionRuntimeState::Stopped => "stopped",
+    }
 }

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -48,6 +48,7 @@ mod extensions;
 mod file_workspaces;
 mod recordings;
 mod session_files;
+mod session_templates;
 mod sessions;
 mod workflow_definitions;
 mod workflow_events;

--- a/code/apps/bpane-gateway/src/api/tests/session_templates.rs
+++ b/code/apps/bpane-gateway/src/api/tests/session_templates.rs
@@ -59,7 +59,8 @@ async fn creates_session_from_template_and_filters_catalog() {
                     json!({
                         "template_id": template_id,
                         "labels": {
-                            "case": "INC-1234"
+                            "case": "INC-1234",
+                            "purpose": "case-specific"
                         },
                         "integration_context": {
                             "ticket": "INC-1234"
@@ -77,7 +78,7 @@ async fn creates_session_from_template_and_filters_catalog() {
     assert_eq!(session["template_id"], template_id);
     assert_eq!(session["idle_timeout_sec"], 1800);
     assert_eq!(session["labels"]["team"], "support");
-    assert_eq!(session["labels"]["purpose"], "debug");
+    assert_eq!(session["labels"]["purpose"], "case-specific");
     assert_eq!(session["labels"]["case"], "INC-1234");
     assert_eq!(session["integration_context"]["source"], "template");
     assert_eq!(session["integration_context"]["ticket"], "INC-1234");
@@ -117,6 +118,188 @@ async fn creates_session_from_template_and_filters_catalog() {
     assert_eq!(mismatch_response.status(), StatusCode::OK);
     let mismatch = response_json(mismatch_response).await;
     assert!(mismatch["sessions"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn rejects_invalid_session_template_requests_and_missing_templates() {
+    let (app, token) = test_router();
+
+    let unauthorized = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/session-templates")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    for body in [
+        json!({ "name": "" }),
+        json!({ "name": "bad-description", "description": "" }),
+        json!({ "name": "bad-idle", "defaults": { "idle_timeout_sec": 0 } }),
+        json!({ "name": "bad-label", "defaults": { "labels": { "": "value" } } }),
+        json!({ "name": "bad-integration", "defaults": { "integration_context": "not-an-object" } }),
+        json!({
+            "name": "bad-recording",
+            "defaults": {
+                "recording": {
+                    "mode": "manual",
+                    "format": "webm",
+                    "retention_sec": 0
+                }
+            }
+        }),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/session-templates")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    let missing_template_id = Uuid::now_v7();
+    let missing_get = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/session-templates/{missing_template_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing_get.status(), StatusCode::NOT_FOUND);
+
+    let missing_update = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/session-templates/{missing_template_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "name": "missing" }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing_update.status(), StatusCode::NOT_FOUND);
+
+    let create_from_missing_template = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "template_id": missing_template_id.to_string() }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_from_missing_template.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn validates_session_catalog_filters_and_paginates_results() {
+    let (app, token) = test_router_with_docker_pool().await;
+
+    for body in [
+        json!({
+            "labels": { "team": "support", "case": "INC-1" },
+            "integration_context": { "ticket": "INC-1" }
+        }),
+        json!({
+            "labels": { "team": "support", "case": "INC-2" },
+            "integration_context": { "ticket": "INC-2" }
+        }),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    let filtered_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/sessions?label.team=support&runtime_state=not_started&state=ready&limit=1&offset=1")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(filtered_response.status(), StatusCode::OK);
+    let filtered = response_json(filtered_response).await;
+    assert_eq!(filtered["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(filtered["sessions"][0]["labels"]["team"], "support");
+
+    let integration_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/sessions?integration.ticket=INC-2")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(integration_response.status(), StatusCode::OK);
+    let integration = response_json(integration_response).await;
+    assert_eq!(integration["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(integration["sessions"][0]["labels"]["case"], "INC-2");
+
+    for uri in [
+        "/api/v1/sessions?unknown=1",
+        "/api/v1/sessions?state=bogus",
+        "/api/v1/sessions?runtime_state=bogus",
+        "/api/v1/sessions?limit=0",
+        "/api/v1/sessions?limit=not-a-number",
+        "/api/v1/sessions?offset=-1",
+        "/api/v1/sessions?label.=support",
+        "/api/v1/sessions?integration.=INC-1",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{uri}");
+    }
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/src/api/tests/session_templates.rs
+++ b/code/apps/bpane-gateway/src/api/tests/session_templates.rs
@@ -1,0 +1,214 @@
+use super::*;
+
+#[tokio::test]
+async fn creates_session_from_template_and_filters_catalog() {
+    let (app, token) = test_router();
+
+    let create_template_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/session-templates")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "customer-debug-session",
+                        "description": "Support debug template",
+                        "labels": { "team": "support" },
+                        "defaults": {
+                            "owner_mode": "collaborative",
+                            "idle_timeout_sec": 1800,
+                            "labels": {
+                                "team": "support",
+                                "purpose": "debug"
+                            },
+                            "integration_context": {
+                                "source": "template"
+                            },
+                            "recording": {
+                                "mode": "manual",
+                                "format": "webm",
+                                "retention_sec": 86400
+                            }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_template_response.status(), StatusCode::CREATED);
+    let template = response_json(create_template_response).await;
+    let template_id = template["id"].as_str().unwrap().to_string();
+    assert_eq!(template["name"], "customer-debug-session");
+    assert_eq!(template["version"], 1);
+    assert_eq!(template["defaults"]["labels"]["team"], "support");
+
+    let create_session_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "template_id": template_id,
+                        "labels": {
+                            "case": "INC-1234"
+                        },
+                        "integration_context": {
+                            "ticket": "INC-1234"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(create_session_response.status(), StatusCode::CREATED);
+    let session = response_json(create_session_response).await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+    assert_eq!(session["template_id"], template_id);
+    assert_eq!(session["idle_timeout_sec"], 1800);
+    assert_eq!(session["labels"]["team"], "support");
+    assert_eq!(session["labels"]["purpose"], "debug");
+    assert_eq!(session["labels"]["case"], "INC-1234");
+    assert_eq!(session["integration_context"]["source"], "template");
+    assert_eq!(session["integration_context"]["ticket"], "INC-1234");
+    assert_eq!(session["recording"]["mode"], "manual");
+    assert_eq!(session["recording"]["retention_sec"], 86400);
+
+    let filtered_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions?template_id={template_id}&label.team=support&integration.ticket=INC-1234"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(filtered_response.status(), StatusCode::OK);
+    let filtered = response_json(filtered_response).await;
+    assert_eq!(filtered["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(filtered["sessions"][0]["id"], session_id);
+
+    let mismatch_response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/v1/sessions?template_id={template_id}&label.team=sales"
+                ))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(mismatch_response.status(), StatusCode::OK);
+    let mismatch = response_json(mismatch_response).await;
+    assert!(mismatch["sessions"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn updates_session_template_with_incremented_version() {
+    let (app, token) = test_router();
+
+    let created = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/session-templates")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "template",
+                            "defaults": {
+                                "labels": { "team": "support" }
+                            }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let template_id = created["id"].as_str().unwrap();
+
+    let duplicate_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/session-templates")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "template",
+                        "defaults": {}
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(duplicate_response.status(), StatusCode::CONFLICT);
+
+    let updated_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/session-templates/{template_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "template",
+                        "defaults": {
+                            "idle_timeout_sec": 600,
+                            "labels": { "team": "support", "tier": "gold" }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated_response.status(), StatusCode::OK);
+    let updated = response_json(updated_response).await;
+    assert_eq!(updated["version"], 2);
+    assert_eq!(updated["defaults"]["idle_timeout_sec"], 600);
+    assert_eq!(updated["defaults"]["labels"]["tier"], "gold");
+
+    let list_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/session-templates")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_response.status(), StatusCode::OK);
+    let listed = response_json(list_response).await;
+    assert_eq!(listed["templates"].as_array().unwrap().len(), 1);
+    assert_eq!(listed["templates"][0]["version"], 2);
+}

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -23,7 +23,7 @@ use crate::session_access::{SessionAutomationAccessTokenManager, SessionConnectT
 use crate::session_control::{
     CreateSessionRequest, SessionConnectInfo, SessionLifecycleState, SessionOwnerMode,
     SessionRecordingFormat, SessionRecordingMode, SessionResource, SessionStatusSummary,
-    SessionStore,
+    SessionStore, SessionTemplateDefaults,
 };
 use crate::session_files::SessionFileBindingMode;
 use crate::session_hub::{SessionConnectionTelemetryRole, SessionTelemetrySnapshot};
@@ -285,6 +285,17 @@ pub(super) struct CreateFileWorkspaceRequest {
     pub(super) description: Option<String>,
     #[serde(default)]
     pub(super) labels: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+pub(super) struct UpsertSessionTemplateRequest {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+    #[serde(default)]
+    pub(super) labels: HashMap<String, String>,
+    #[serde(default)]
+    pub(super) defaults: SessionTemplateDefaults,
 }
 
 #[derive(Deserialize)]

--- a/code/apps/bpane-gateway/src/session_control/in_memory.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory.rs
@@ -5,6 +5,7 @@ mod automation_tasks;
 mod recordings;
 mod runtime_assignments;
 mod session_files;
+mod session_templates;
 mod sessions;
 mod state;
 mod workflow_definitions;

--- a/code/apps/bpane-gateway/src/session_control/in_memory/session_templates.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/session_templates.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+impl InMemorySessionStore {
+    pub(in crate::session_control) async fn create_session_template(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<StoredSessionTemplate, SessionStoreError> {
+        let now = Utc::now();
+        let mut templates = self.session_templates.lock().await;
+        if templates.iter().any(|template| {
+            template.owner_subject == principal.subject
+                && template.owner_issuer == principal.issuer
+                && template.name == request.name
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "session template {} already exists",
+                request.name
+            )));
+        }
+        let template = StoredSessionTemplate {
+            id: Uuid::now_v7(),
+            owner_subject: principal.subject.clone(),
+            owner_issuer: principal.issuer.clone(),
+            name: request.name,
+            description: request.description,
+            labels: request.labels,
+            defaults: request.defaults,
+            version: 1,
+            created_at: now,
+            updated_at: now,
+        };
+        templates.push(template.clone());
+        Ok(template)
+    }
+
+    pub(in crate::session_control) async fn list_session_templates_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredSessionTemplate>, SessionStoreError> {
+        let mut templates = self
+            .session_templates
+            .lock()
+            .await
+            .iter()
+            .filter(|template| {
+                template.owner_subject == principal.subject
+                    && template.owner_issuer == principal.issuer
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        templates.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(templates)
+    }
+
+    pub(in crate::session_control) async fn get_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        Ok(self
+            .session_templates
+            .lock()
+            .await
+            .iter()
+            .find(|template| {
+                template.id == id
+                    && template.owner_subject == principal.subject
+                    && template.owner_issuer == principal.issuer
+            })
+            .cloned())
+    }
+
+    pub(in crate::session_control) async fn update_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        let mut templates = self.session_templates.lock().await;
+        if templates.iter().any(|template| {
+            template.id != id
+                && template.owner_subject == principal.subject
+                && template.owner_issuer == principal.issuer
+                && template.name == request.name
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "session template {} already exists",
+                request.name
+            )));
+        }
+        let Some(template) = templates.iter_mut().find(|template| {
+            template.id == id
+                && template.owner_subject == principal.subject
+                && template.owner_issuer == principal.issuer
+        }) else {
+            return Ok(None);
+        };
+
+        template.name = request.name;
+        template.description = request.description;
+        template.labels = request.labels;
+        template.defaults = request.defaults;
+        template.version = template.version.saturating_add(1);
+        template.updated_at = Utc::now();
+        Ok(Some(template.clone()))
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub(in crate::session_control) struct InMemoryStoreState {
     pub(in crate::session_control) sessions: Mutex<Vec<StoredSession>>,
+    pub(in crate::session_control) session_templates: Mutex<Vec<StoredSessionTemplate>>,
     pub(in crate::session_control) automation_tasks: Mutex<Vec<StoredAutomationTask>>,
     pub(in crate::session_control) automation_task_events: Mutex<Vec<StoredAutomationTaskEvent>>,
     pub(in crate::session_control) automation_task_logs: Mutex<Vec<StoredAutomationTaskLog>>,
@@ -37,6 +38,7 @@ impl InMemoryStoreState {
     pub(super) fn new() -> Self {
         Self {
             sessions: Mutex::new(Vec::new()),
+            session_templates: Mutex::new(Vec::new()),
             automation_tasks: Mutex::new(Vec::new()),
             automation_task_events: Mutex::new(Vec::new()),
             automation_task_logs: Mutex::new(Vec::new()),

--- a/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
@@ -8,6 +8,7 @@ mod file_workspaces;
 mod recordings;
 mod runtime_assignments;
 mod session_files;
+mod session_templates;
 mod sessions;
 mod workflow_definitions;
 mod workflow_events;

--- a/code/apps/bpane-gateway/src/session_control/postgres/session_templates.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/session_templates.rs
@@ -1,0 +1,240 @@
+use super::*;
+
+const SESSION_TEMPLATE_COLUMNS: &str = r#"
+    id,
+    owner_subject,
+    owner_issuer,
+    name,
+    description,
+    labels,
+    defaults,
+    version,
+    created_at,
+    updated_at
+"#;
+
+pub(super) struct SessionTemplateRepository<'a> {
+    store: &'a PostgresSessionStore,
+}
+
+impl PostgresSessionStore {
+    fn session_template_repository(&self) -> SessionTemplateRepository<'_> {
+        SessionTemplateRepository { store: self }
+    }
+
+    pub(in crate::session_control) async fn create_session_template(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<StoredSessionTemplate, SessionStoreError> {
+        self.session_template_repository()
+            .create_session_template(principal, request)
+            .await
+    }
+
+    pub(in crate::session_control) async fn list_session_templates_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredSessionTemplate>, SessionStoreError> {
+        self.session_template_repository()
+            .list_session_templates_for_owner(principal)
+            .await
+    }
+
+    pub(in crate::session_control) async fn get_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        self.session_template_repository()
+            .get_session_template_for_owner(principal, id)
+            .await
+    }
+
+    pub(in crate::session_control) async fn update_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        self.session_template_repository()
+            .update_session_template_for_owner(principal, id, request)
+            .await
+    }
+}
+
+impl SessionTemplateRepository<'_> {
+    async fn create_session_template(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<StoredSessionTemplate, SessionStoreError> {
+        let now = Utc::now();
+        let defaults_value = serde_json::to_value(&request.defaults).map_err(|error| {
+            SessionStoreError::InvalidRequest(format!(
+                "session template defaults must be serializable: {error}"
+            ))
+        })?;
+        let query = format!(
+            r#"
+            INSERT INTO control_session_templates (
+                id,
+                owner_subject,
+                owner_issuer,
+                name,
+                description,
+                labels,
+                defaults,
+                version,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, 1, $8, $8)
+            RETURNING
+                {SESSION_TEMPLATE_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_one(
+                &query,
+                &[
+                    &Uuid::now_v7(),
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &json_labels(&request.labels),
+                    &defaults_value,
+                    &now,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "session template {} already exists",
+                        request.name
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to create session template: {error}"))
+            })?;
+        row_to_stored_session_template(&row)
+    }
+
+    async fn list_session_templates_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredSessionTemplate>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {SESSION_TEMPLATE_COLUMNS}
+            FROM control_session_templates
+            WHERE owner_subject = $1
+              AND owner_issuer = $2
+            ORDER BY created_at DESC
+            "#
+        );
+        let rows = self
+            .store
+            .db
+            .client()
+            .await?
+            .query(&query, &[&principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to list session templates: {error}"))
+            })?;
+        rows.iter().map(row_to_stored_session_template).collect()
+    }
+
+    async fn get_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {SESSION_TEMPLATE_COLUMNS}
+            FROM control_session_templates
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(&query, &[&id, &principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to fetch session template: {error}"))
+            })?;
+        row.as_ref().map(row_to_stored_session_template).transpose()
+    }
+
+    async fn update_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        let defaults_value = serde_json::to_value(&request.defaults).map_err(|error| {
+            SessionStoreError::InvalidRequest(format!(
+                "session template defaults must be serializable: {error}"
+            ))
+        })?;
+        let query = format!(
+            r#"
+            UPDATE control_session_templates
+            SET
+                name = $4,
+                description = $5,
+                labels = $6::jsonb,
+                defaults = $7::jsonb,
+                version = version + 1,
+                updated_at = NOW()
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            RETURNING
+                {SESSION_TEMPLATE_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                &query,
+                &[
+                    &id,
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &json_labels(&request.labels),
+                    &defaults_value,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "session template {} already exists",
+                        request.name
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to update session template: {error}"))
+            })?;
+        row.as_ref().map(row_to_stored_session_template).transpose()
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/rows.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows.rs
@@ -20,8 +20,8 @@ pub(super) use resources::{
     row_to_stored_credential_binding, row_to_stored_extension_definition,
     row_to_stored_extension_version, row_to_stored_file_workspace,
     row_to_stored_file_workspace_file, row_to_stored_session_file,
-    row_to_stored_session_file_binding, row_to_stored_workflow_definition,
-    row_to_stored_workflow_definition_version,
+    row_to_stored_session_file_binding, row_to_stored_session_template,
+    row_to_stored_workflow_definition, row_to_stored_workflow_definition_version,
 };
 pub(super) use runtime_assignments::{
     row_to_recording_worker_assignment, row_to_runtime_assignment,

--- a/code/apps/bpane-gateway/src/session_control/rows/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/resources.rs
@@ -218,6 +218,53 @@ pub(in crate::session_control) fn row_to_stored_file_workspace(
     })
 }
 
+pub(in crate::session_control) fn row_to_stored_session_template(
+    row: &Row,
+) -> Result<StoredSessionTemplate, SessionStoreError> {
+    let labels_value: Value = row.get("labels");
+    let labels = labels_value
+        .as_object()
+        .context("session template labels column must be a JSON object")
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+        .iter()
+        .map(|(key, value)| {
+            Ok((
+                key.clone(),
+                value
+                    .as_str()
+                    .context("session template label values must be strings")
+                    .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+                    .to_string(),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, SessionStoreError>>()?;
+    let defaults = serde_json::from_value::<SessionTemplateDefaults>(row.get("defaults")).map_err(
+        |error| {
+            SessionStoreError::Backend(format!(
+                "failed to decode session template defaults: {error}"
+            ))
+        },
+    )?;
+    let version = u32::try_from(row.get::<_, i32>("version")).map_err(|error| {
+        SessionStoreError::Backend(format!(
+            "session template version must be non-negative and fit u32: {error}"
+        ))
+    })?;
+
+    Ok(StoredSessionTemplate {
+        id: row.get("id"),
+        owner_subject: row.get("owner_subject"),
+        owner_issuer: row.get("owner_issuer"),
+        name: row.get("name"),
+        description: row.get("description"),
+        labels,
+        defaults,
+        version,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
 pub(in crate::session_control) fn row_to_stored_file_workspace_file(
     row: &Row,
 ) -> Result<StoredFileWorkspaceFile, SessionStoreError> {

--- a/code/apps/bpane-gateway/src/session_control/store/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/store/resources.rs
@@ -1,6 +1,72 @@
 use super::*;
 
 impl SessionStore {
+    pub async fn create_session_template(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<StoredSessionTemplate, SessionStoreError> {
+        validate_session_template_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.create_session_template(principal, request).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.create_session_template(principal, request).await
+            }
+        }
+    }
+
+    pub async fn list_session_templates_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredSessionTemplate>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.list_session_templates_for_owner(principal).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.list_session_templates_for_owner(principal).await
+            }
+        }
+    }
+
+    pub async fn get_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.get_session_template_for_owner(principal, id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.get_session_template_for_owner(principal, id).await
+            }
+        }
+    }
+
+    pub async fn update_session_template_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistSessionTemplateRequest,
+    ) -> Result<Option<StoredSessionTemplate>, SessionStoreError> {
+        validate_session_template_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .update_session_template_for_owner(principal, id, request)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .update_session_template_for_owner(principal, id, request)
+                    .await
+            }
+        }
+    }
+
     pub async fn create_file_workspace(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/tests/validation.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/validation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use serde_json::json;
 
 #[test]
 fn rejects_non_object_integration_context() {
@@ -38,6 +39,89 @@ fn rejects_zero_recording_retention() {
     .unwrap_err();
 
     assert!(matches!(error, SessionStoreError::InvalidRequest(_)));
+}
+
+#[test]
+fn rejects_invalid_session_template_defaults() {
+    for request in [
+        PersistSessionTemplateRequest {
+            name: "".to_string(),
+            description: None,
+            labels: HashMap::new(),
+            defaults: SessionTemplateDefaults::default(),
+        },
+        PersistSessionTemplateRequest {
+            name: "template".to_string(),
+            description: Some("".to_string()),
+            labels: HashMap::new(),
+            defaults: SessionTemplateDefaults::default(),
+        },
+        PersistSessionTemplateRequest {
+            name: "template".to_string(),
+            description: None,
+            labels: HashMap::from([("".to_string(), "value".to_string())]),
+            defaults: SessionTemplateDefaults::default(),
+        },
+        PersistSessionTemplateRequest {
+            name: "template".to_string(),
+            description: None,
+            labels: HashMap::new(),
+            defaults: SessionTemplateDefaults {
+                idle_timeout_sec: Some(0),
+                ..SessionTemplateDefaults::default()
+            },
+        },
+        PersistSessionTemplateRequest {
+            name: "template".to_string(),
+            description: None,
+            labels: HashMap::new(),
+            defaults: SessionTemplateDefaults {
+                integration_context: Some(Value::String("bad".to_string())),
+                ..SessionTemplateDefaults::default()
+            },
+        },
+        PersistSessionTemplateRequest {
+            name: "template".to_string(),
+            description: None,
+            labels: HashMap::new(),
+            defaults: SessionTemplateDefaults {
+                recording: Some(SessionRecordingPolicy {
+                    mode: SessionRecordingMode::Manual,
+                    format: SessionRecordingFormat::Webm,
+                    retention_sec: Some(0),
+                }),
+                ..SessionTemplateDefaults::default()
+            },
+        },
+    ] {
+        let error = validate_session_template_request(&request).unwrap_err();
+        assert!(matches!(error, SessionStoreError::InvalidRequest(_)));
+    }
+}
+
+#[test]
+fn accepts_valid_session_template_defaults() {
+    validate_session_template_request(&PersistSessionTemplateRequest {
+        name: "support-debug".to_string(),
+        description: Some("Support debug sessions".to_string()),
+        labels: HashMap::from([("team".to_string(), "support".to_string())]),
+        defaults: SessionTemplateDefaults {
+            owner_mode: Some(SessionOwnerMode::Collaborative),
+            viewport: Some(SessionViewport {
+                width: 1440,
+                height: 900,
+            }),
+            idle_timeout_sec: Some(1800),
+            labels: HashMap::from([("purpose".to_string(), "debug".to_string())]),
+            integration_context: Some(json!({ "source": "template" })),
+            recording: Some(SessionRecordingPolicy {
+                mode: SessionRecordingMode::Manual,
+                format: SessionRecordingFormat::Webm,
+                retention_sec: Some(86400),
+            }),
+        },
+    })
+    .expect("valid session template defaults should pass validation");
 }
 
 #[test]

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -307,6 +307,76 @@ pub struct CreateSessionRequest {
     pub extensions: Vec<AppliedExtension>,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SessionTemplateDefaults {
+    #[serde(default)]
+    pub owner_mode: Option<SessionOwnerMode>,
+    #[serde(default)]
+    pub viewport: Option<SessionViewport>,
+    #[serde(default)]
+    pub idle_timeout_sec: Option<u32>,
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
+    #[serde(default)]
+    pub integration_context: Option<Value>,
+    #[serde(default)]
+    pub recording: Option<crate::session_control::SessionRecordingPolicy>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistSessionTemplateRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub defaults: SessionTemplateDefaults,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredSessionTemplate {
+    pub id: Uuid,
+    pub owner_subject: String,
+    pub owner_issuer: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub defaults: SessionTemplateDefaults,
+    pub version: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SessionTemplateResource {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub defaults: SessionTemplateDefaults,
+    pub version: u32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionTemplateListResponse {
+    pub templates: Vec<SessionTemplateResource>,
+}
+
+impl StoredSessionTemplate {
+    pub fn to_resource(&self) -> SessionTemplateResource {
+        SessionTemplateResource {
+            id: self.id,
+            name: self.name.clone(),
+            description: self.description.clone(),
+            labels: self.labels.clone(),
+            defaults: self.defaults.clone(),
+            version: self.version,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct SetAutomationDelegateRequest {
     pub client_id: String,

--- a/code/apps/bpane-gateway/src/session_control/validation/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/mod.rs
@@ -19,7 +19,10 @@ pub(super) use resources::{
     validate_file_workspace_request, validate_session_file_binding_request,
     validate_session_file_request,
 };
-pub(super) use sessions::{validate_automation_delegate_request, validate_create_request};
+pub(super) use sessions::{
+    validate_automation_delegate_request, validate_create_request,
+    validate_session_template_request,
+};
 pub(super) use workflows::{
     validate_workflow_definition_request, validate_workflow_definition_version_request,
     validate_workflow_run_event_request, validate_workflow_run_log_request,

--- a/code/apps/bpane-gateway/src/session_control/validation/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/sessions.rs
@@ -61,6 +61,60 @@ pub(in crate::session_control) fn validate_create_request(
     Ok(())
 }
 
+pub(in crate::session_control) fn validate_session_template_request(
+    request: &PersistSessionTemplateRequest,
+) -> Result<(), SessionStoreError> {
+    if request.name.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "session template name must not be empty".to_string(),
+        ));
+    }
+    if let Some(description) = &request.description {
+        if description.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "session template description must not be empty when provided".to_string(),
+            ));
+        }
+    }
+    validate_label_map(&request.labels, "session template labels")?;
+    validate_template_defaults(&request.defaults)?;
+    Ok(())
+}
+
+fn validate_template_defaults(defaults: &SessionTemplateDefaults) -> Result<(), SessionStoreError> {
+    let request = CreateSessionRequest {
+        owner_mode: defaults.owner_mode,
+        viewport: defaults.viewport.clone(),
+        idle_timeout_sec: defaults.idle_timeout_sec,
+        labels: defaults.labels.clone(),
+        integration_context: defaults.integration_context.clone(),
+        recording: defaults.recording.clone().unwrap_or_default(),
+        ..CreateSessionRequest::default()
+    };
+    validate_create_request(&request)?;
+    validate_label_map(&defaults.labels, "session template default labels")?;
+    Ok(())
+}
+
+fn validate_label_map(
+    labels: &std::collections::HashMap<String, String>,
+    context: &str,
+) -> Result<(), SessionStoreError> {
+    for (key, value) in labels {
+        if key.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(format!(
+                "{context} must not contain empty keys"
+            )));
+        }
+        if value.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(format!(
+                "{context} must not contain empty values"
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub(in crate::session_control) fn validate_automation_delegate_request(
     request: &SetAutomationDelegateRequest,
 ) -> Result<(), SessionStoreError> {

--- a/code/apps/bpane-gateway/tests/compose_api_surface.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface.rs
@@ -3,8 +3,8 @@ mod suite;
 
 use suite::{
     automation_access_boundaries, credentials_extensions, ownership_boundaries,
-    recording_artifacts, session_churn, session_compatibility, sessions_recordings, support,
-    workflow_run_controls, workflows_events, workspaces_automation,
+    recording_artifacts, session_churn, session_compatibility, session_templates,
+    sessions_recordings, support, workflow_run_controls, workflows_events, workspaces_automation,
 };
 
 #[tokio::test]
@@ -14,6 +14,15 @@ async fn compose_sessions_and_recordings_api_surface() -> anyhow::Result<()> {
     let harness = support::ComposeHarness::connect().await?;
     harness.cleanup_active_sessions().await?;
     sessions_recordings::run(&harness).await
+}
+
+#[tokio::test]
+#[ignore = "requires running local compose stack"]
+async fn compose_session_templates_catalog_api_surface() -> anyhow::Result<()> {
+    let _guard = support::suite_lock().lock().await;
+    let harness = support::ComposeHarness::connect().await?;
+    harness.cleanup_active_sessions().await?;
+    session_templates::run(&harness).await
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
@@ -4,6 +4,7 @@ pub mod ownership_boundaries;
 pub mod recording_artifacts;
 pub mod session_churn;
 pub mod session_compatibility;
+pub mod session_templates;
 pub mod sessions_recordings;
 pub mod support;
 pub mod workflow_run_controls;

--- a/code/apps/bpane-gateway/tests/compose_api_surface/session_templates.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/session_templates.rs
@@ -1,0 +1,201 @@
+use anyhow::{anyhow, Result};
+use reqwest::StatusCode;
+use serde_json::json;
+use uuid::Uuid;
+
+use super::support::{json_array, json_id, label_map, recording_policy, ComposeHarness};
+
+pub async fn run(harness: &ComposeHarness) -> Result<()> {
+    let template_name = harness.unique_name("compose-session-template");
+    let template = harness
+        .post_json(
+            "/api/v1/session-templates",
+            json!({
+                "name": template_name,
+                "description": "Compose e2e session template",
+                "labels": label_map("session-templates"),
+                "defaults": {
+                    "owner_mode": "collaborative",
+                    "idle_timeout_sec": 1800,
+                    "labels": {
+                        "team": "support",
+                        "purpose": "debug"
+                    },
+                    "integration_context": {
+                        "source": "compose-template"
+                    },
+                    "recording": recording_policy("manual")
+                }
+            }),
+        )
+        .await?;
+    let template_id = json_id(&template, "id")?;
+    if template["version"] != json!(1) {
+        return Err(anyhow!("template create did not initialize version=1"));
+    }
+
+    let duplicate = harness
+        .post_json_outcome(
+            "/api/v1/session-templates",
+            json!({
+                "name": template_name,
+                "defaults": {}
+            }),
+        )
+        .await?;
+    if duplicate.status != StatusCode::CONFLICT {
+        return Err(anyhow!(
+            "duplicate template create returned {} instead of 409: {}",
+            duplicate.status,
+            duplicate.body
+        ));
+    }
+
+    let invalid_template = harness
+        .post_json_outcome(
+            "/api/v1/session-templates",
+            json!({
+                "name": "invalid-compose-template",
+                "defaults": {
+                    "idle_timeout_sec": 0
+                }
+            }),
+        )
+        .await?;
+    if invalid_template.status != StatusCode::BAD_REQUEST {
+        return Err(anyhow!(
+            "invalid template create returned {} instead of 400: {}",
+            invalid_template.status,
+            invalid_template.body
+        ));
+    }
+
+    let fetched_template = harness
+        .get_json(&format!("/api/v1/session-templates/{template_id}"))
+        .await?;
+    if fetched_template["id"] != json!(template_id)
+        || fetched_template["defaults"]["labels"]["team"] != json!("support")
+    {
+        return Err(anyhow!("template lookup returned unexpected data"));
+    }
+
+    let templates = harness.get_json("/api/v1/session-templates").await?;
+    let templates = json_array(&templates, "templates")?;
+    if !templates
+        .iter()
+        .any(|candidate| candidate.get("id") == Some(&json!(template_id)))
+    {
+        return Err(anyhow!("template list did not include {template_id}"));
+    }
+
+    let updated_template = harness
+        .put_json(
+            &format!("/api/v1/session-templates/{template_id}"),
+            json!({
+                "name": template_name,
+                "description": "Compose e2e session template updated",
+                "labels": label_map("session-templates"),
+                "defaults": {
+                    "idle_timeout_sec": 1200,
+                    "labels": {
+                        "team": "support",
+                        "purpose": "debug",
+                        "tier": "gold"
+                    },
+                    "integration_context": {
+                        "source": "compose-template-updated"
+                    },
+                    "recording": recording_policy("manual")
+                }
+            }),
+        )
+        .await?;
+    if updated_template["version"] != json!(2)
+        || updated_template["defaults"]["labels"]["tier"] != json!("gold")
+    {
+        return Err(anyhow!(
+            "template update did not increment version or persist defaults"
+        ));
+    }
+
+    let missing_template = Uuid::now_v7();
+    let missing_create = harness
+        .post_json_outcome(
+            "/api/v1/sessions",
+            json!({
+                "template_id": missing_template.to_string()
+            }),
+        )
+        .await?;
+    if missing_create.status != StatusCode::NOT_FOUND {
+        return Err(anyhow!(
+            "missing template session create returned {} instead of 404: {}",
+            missing_create.status,
+            missing_create.body
+        ));
+    }
+
+    let run_id = harness.unique_name("session-template-e2e");
+    let session = harness
+        .post_json(
+            "/api/v1/sessions",
+            json!({
+                "template_id": template_id,
+                "labels": {
+                    "run_id": run_id,
+                    "purpose": "case-specific"
+                },
+                "integration_context": {
+                    "ticket": run_id
+                }
+            }),
+        )
+        .await?;
+    let session_id = json_id(&session, "id")?;
+    if session["template_id"] != json!(template_id)
+        || session["labels"]["team"] != json!("support")
+        || session["labels"]["tier"] != json!("gold")
+        || session["labels"]["purpose"] != json!("case-specific")
+        || session["integration_context"]["source"] != json!("compose-template-updated")
+        || session["integration_context"]["ticket"] != json!(run_id)
+        || session["recording"]["mode"] != json!("manual")
+    {
+        return Err(anyhow!(
+            "session create did not merge template defaults and caller overrides: {session}"
+        ));
+    }
+
+    let filtered = harness
+        .get_json(&format!(
+            "/api/v1/sessions?template_id={template_id}&label.team=support&integration.ticket={run_id}&runtime_state=not_started&limit=1"
+        ))
+        .await?;
+    let filtered_sessions = json_array(&filtered, "sessions")?;
+    if filtered_sessions.len() != 1 || filtered_sessions[0]["id"] != json!(session_id) {
+        return Err(anyhow!(
+            "catalog filters did not return the templated session: {filtered}"
+        ));
+    }
+
+    let invalid_query = harness
+        .get_json_outcome("/api/v1/sessions?runtime_state=bogus")
+        .await?;
+    if invalid_query.status != StatusCode::BAD_REQUEST {
+        return Err(anyhow!(
+            "invalid catalog runtime_state returned {} instead of 400: {}",
+            invalid_query.status,
+            invalid_query.body
+        ));
+    }
+
+    let deleted = harness
+        .delete_json(&format!("/api/v1/sessions/{session_id}"))
+        .await?;
+    if deleted["state"] != json!("stopped") {
+        return Err(anyhow!(
+            "templated session cleanup did not stop the session"
+        ));
+    }
+
+    Ok(())
+}

--- a/code/apps/bpane-gateway/tests/compose_api_surface/support.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/support.rs
@@ -310,6 +310,10 @@ impl ComposeHarness {
             .await
     }
 
+    pub async fn put_json(&self, path: &str, body: Value) -> Result<Value> {
+        self.send_json(Method::PUT, path, Some(body), None).await
+    }
+
     pub async fn post_json_outcome_without_bearer(
         &self,
         path: &str,

--- a/code/web/bpane-admin/src/lib/api/control-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.test.ts
@@ -4,7 +4,9 @@ import { ControlClient, type FetchLike } from './control-client';
 const SESSION = {
   id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
   state: 'active',
+  template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   owner_mode: 'shared',
+  integration_context: { ticket: 'INC-1234' },
   connect: {
     gateway_url: 'https://localhost:4433',
     transport_path: '/session',
@@ -39,6 +41,22 @@ const SESSION = {
   stopped_at: null,
 };
 
+const TEMPLATE = {
+  id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+  name: 'Support triage',
+  description: 'Default support case browser session',
+  labels: { team: 'support' },
+  defaults: {
+    owner_mode: 'collaborative',
+    idle_timeout_sec: 1800,
+    labels: { team: 'support' },
+    integration_context: { source: 'template' },
+  },
+  version: 1,
+  created_at: '2026-05-04T18:00:00Z',
+  updated_at: '2026-05-04T18:00:00Z',
+};
+
 describe('ControlClient', () => {
   it('lists owner-visible sessions with bearer auth', async () => {
     const fetchImpl = jsonFetch({ sessions: [SESSION] });
@@ -64,6 +82,58 @@ describe('ControlClient', () => {
     );
   });
 
+  it('lists session templates with bearer auth', async () => {
+    const fetchImpl = jsonFetch({ templates: [TEMPLATE] });
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    const response = await client.listSessionTemplates();
+
+    expect(response.templates[0]).toMatchObject({
+      id: TEMPLATE.id,
+      name: 'Support triage',
+      defaults: expect.objectContaining({
+        idle_timeout_sec: 1800,
+      }),
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('http://localhost:8932/api/v1/session-templates'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('passes catalog filters to the session list endpoint', async () => {
+    const fetchImpl = jsonFetch({ sessions: [SESSION] });
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    await client.listSessions({
+      templateId: TEMPLATE.id,
+      states: ['active'],
+      runtimeStates: ['running'],
+      labels: { team: 'support' },
+      integrationContext: { ticket: 'INC-1234' },
+      limit: 25,
+      offset: 50,
+    });
+
+    const url = fetchImpl.mock.calls[0]?.[0] as URL;
+    expect(url.pathname).toBe('/api/v1/sessions');
+    expect(url.searchParams.get('template_id')).toBe(TEMPLATE.id);
+    expect(url.searchParams.get('state')).toBe('active');
+    expect(url.searchParams.get('runtime_state')).toBe('running');
+    expect(url.searchParams.get('label.team')).toBe('support');
+    expect(url.searchParams.get('integration.ticket')).toBe('INC-1234');
+    expect(url.searchParams.get('limit')).toBe('25');
+    expect(url.searchParams.get('offset')).toBe('50');
+  });
+
   it('creates sessions through the frozen v1 endpoint', async () => {
     const fetchImpl = jsonFetch(SESSION);
     const client = new ControlClient({
@@ -72,13 +142,21 @@ describe('ControlClient', () => {
       fetchImpl,
     });
 
-    await client.createSession({ idle_timeout_sec: 300, labels: { source: 'admin-smoke' } });
+    await client.createSession({
+      template_id: TEMPLATE.id,
+      idle_timeout_sec: 300,
+      labels: { source: 'admin-smoke' },
+    });
 
     expect(fetchImpl).toHaveBeenCalledWith(
       new URL('http://localhost:8932/api/v1/sessions'),
       expect.objectContaining({
         method: 'POST',
-        body: JSON.stringify({ idle_timeout_sec: 300, labels: { source: 'admin-smoke' } }),
+        body: JSON.stringify({
+          template_id: TEMPLATE.id,
+          idle_timeout_sec: 300,
+          labels: { source: 'admin-smoke' },
+        }),
         headers: expect.objectContaining({
           'content-type': 'application/json',
         }),

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -22,8 +22,10 @@ import type {
   SessionFileBindingResource,
   SessionFileListResponse,
   SessionFileResource,
+  SessionListFilters,
   SessionListResponse,
   SessionResource,
+  SessionTemplateListResponse,
   SetAutomationDelegateCommand,
   UploadFileWorkspaceFileCommand,
 } from './control-types';
@@ -61,9 +63,14 @@ export class ControlClient {
     this.#fetchImpl = options.fetchImpl ?? fetch;
   }
 
-  async listSessions(): Promise<SessionListResponse> {
-    const payload = await this.#request('GET', '/api/v1/sessions');
+  async listSessions(filters: SessionListFilters = {}): Promise<SessionListResponse> {
+    const payload = await this.#request('GET', buildSessionListPath(filters));
     return ControlSessionMapper.toSessionList(payload);
+  }
+
+  async listSessionTemplates(): Promise<SessionTemplateListResponse> {
+    const payload = await this.#request('GET', '/api/v1/session-templates');
+    return ControlSessionMapper.toSessionTemplateList(payload);
   }
 
   async createSession(command: CreateSessionCommand = {}): Promise<SessionResource> {
@@ -345,5 +352,39 @@ export class ControlClient {
       contentType: options.contentType,
       headers: options.headers,
     });
+  }
+}
+
+function buildSessionListPath(filters: SessionListFilters): string {
+  const params = new URLSearchParams();
+  if (filters.templateId) {
+    params.set('template_id', filters.templateId);
+  }
+  appendCsvFilter(params, 'state', filters.states);
+  appendCsvFilter(params, 'runtime_state', filters.runtimeStates);
+  for (const [key, value] of Object.entries(filters.labels ?? {})) {
+    params.append(`label.${key}`, value);
+  }
+  for (const [key, value] of Object.entries(filters.integrationContext ?? {})) {
+    params.append(`integration.${key}`, value);
+  }
+  if (filters.limit !== undefined && filters.limit !== null) {
+    params.set('limit', String(filters.limit));
+  }
+  if (filters.offset !== undefined && filters.offset !== null) {
+    params.set('offset', String(filters.offset));
+  }
+  const query = params.toString();
+  return query ? `/api/v1/sessions?${query}` : '/api/v1/sessions';
+}
+
+function appendCsvFilter(
+  params: URLSearchParams,
+  key: string,
+  values: readonly string[] | undefined,
+): void {
+  const filtered = values?.map((value) => value.trim()).filter(Boolean) ?? [];
+  if (filtered.length > 0) {
+    params.set(key, filtered.join(','));
   }
 }

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -9,6 +9,10 @@ import type {
   SessionStatusSummary,
   SessionStopBlocker,
   SessionStopEligibility,
+  SessionTemplateDefaults,
+  SessionTemplateListResponse,
+  SessionTemplateResource,
+  SessionViewport,
 } from './control-types';
 import {
   expectBoolean,
@@ -31,8 +35,20 @@ export class ControlSessionMapper {
     };
   }
 
+  static toSessionTemplateList(payload: unknown): SessionTemplateListResponse {
+    const object = expectRecord(payload, 'session template list response');
+    const templates = object.templates;
+    if (!Array.isArray(templates)) {
+      throw new Error('session template list response must contain a templates array');
+    }
+    return {
+      templates: templates.map((template) => this.toSessionTemplateResource(template)),
+    };
+  }
+
   static toSessionResource(payload: unknown): SessionResource {
     const object = expectRecord(payload, 'session resource');
+    const templateId = optionalString(object.template_id, 'session resource template_id');
     const stoppedAt = optionalString(object.stopped_at, 'session resource stopped_at');
     const runtimeReleasedAt = optionalString(
       object.runtime_released_at,
@@ -42,9 +58,12 @@ export class ControlSessionMapper {
     return {
       id: expectString(object.id, 'session resource id'),
       state: expectString(object.state, 'session resource state'),
+      template_id: templateId ?? null,
       owner_mode: expectString(object.owner_mode, 'session resource owner_mode'),
+      viewport: toOptionalViewport(object.viewport, 'session resource viewport') ?? null,
       idle_timeout_sec: optionalNumber(object.idle_timeout_sec, 'session resource idle_timeout_sec') ?? null,
       labels: expectStringRecord(object.labels ?? {}, 'session resource labels'),
+      integration_context: optionalRecord(object.integration_context, 'session resource integration_context') ?? null,
       ...(automationDelegate !== undefined ? { automation_delegate: automationDelegate } : {}),
       connect: toConnectInfo(object.connect),
       runtime: toRuntimeInfo(object.runtime),
@@ -53,6 +72,21 @@ export class ControlSessionMapper {
       updated_at: expectString(object.updated_at, 'session resource updated_at'),
       ...(runtimeReleasedAt !== undefined ? { runtime_released_at: runtimeReleasedAt } : {}),
       ...(stoppedAt !== undefined ? { stopped_at: stoppedAt } : {}),
+    };
+  }
+
+  static toSessionTemplateResource(payload: unknown): SessionTemplateResource {
+    const object = expectRecord(payload, 'session template resource');
+    const description = optionalString(object.description, 'session template description');
+    return {
+      id: expectString(object.id, 'session template id'),
+      name: expectString(object.name, 'session template name'),
+      description: description ?? null,
+      labels: expectStringRecord(object.labels ?? {}, 'session template labels'),
+      defaults: toSessionTemplateDefaults(object.defaults ?? {}),
+      version: expectNumber(object.version, 'session template version'),
+      created_at: expectString(object.created_at, 'session template created_at'),
+      updated_at: expectString(object.updated_at, 'session template updated_at'),
     };
   }
 
@@ -73,6 +107,43 @@ function optionalNumber(value: unknown, label: string): number | null | undefine
     return value;
   }
   return expectNumber(value, label);
+}
+
+function optionalRecord(value: unknown, label: string): Readonly<Record<string, unknown>> | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return expectRecord(value, label);
+}
+
+function toOptionalViewport(value: unknown, label: string): SessionViewport | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  const object = expectRecord(value, label);
+  return {
+    width: expectNumber(object.width, `${label} width`),
+    height: expectNumber(object.height, `${label} height`),
+  };
+}
+
+function toSessionTemplateDefaults(value: unknown): SessionTemplateDefaults {
+  const object = expectRecord(value, 'session template defaults');
+  const ownerMode = optionalString(object.owner_mode, 'session template defaults owner_mode');
+  return {
+    ...(ownerMode !== undefined ? { owner_mode: ownerMode } : {}),
+    viewport: toOptionalViewport(object.viewport, 'session template defaults viewport') ?? null,
+    idle_timeout_sec: optionalNumber(
+      object.idle_timeout_sec,
+      'session template defaults idle_timeout_sec',
+    ) ?? null,
+    labels: expectStringRecord(object.labels ?? {}, 'session template defaults labels'),
+    integration_context: optionalRecord(
+      object.integration_context,
+      'session template defaults integration_context',
+    ) ?? null,
+    recording: optionalRecord(object.recording, 'session template defaults recording') ?? null,
+  };
 }
 
 function toConnectInfo(value: unknown): SessionConnectInfo {

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -4,6 +4,11 @@ export type SessionRuntimeInfo = {
   readonly cdp_endpoint?: string | null;
 };
 
+export type SessionViewport = {
+  readonly width: number;
+  readonly height: number;
+};
+
 export type SessionConnectInfo = {
   readonly gateway_url: string;
   readonly transport_path: string;
@@ -48,9 +53,12 @@ export type SessionStatusSummary = {
 export type SessionResource = {
   readonly id: string;
   readonly state: string;
+  readonly template_id?: string | null;
   readonly owner_mode: string;
+  readonly viewport?: SessionViewport | null;
   readonly idle_timeout_sec?: number | null;
   readonly labels?: Readonly<Record<string, string>>;
+  readonly integration_context?: Readonly<Record<string, unknown>> | null;
   readonly automation_delegate?: SessionAutomationDelegate | null;
   readonly connect: SessionConnectInfo;
   readonly runtime: SessionRuntimeInfo;
@@ -65,10 +73,46 @@ export type SessionListResponse = {
   readonly sessions: readonly SessionResource[];
 };
 
+export type SessionListFilters = {
+  readonly templateId?: string | null;
+  readonly states?: readonly string[];
+  readonly runtimeStates?: readonly string[];
+  readonly labels?: Readonly<Record<string, string>>;
+  readonly integrationContext?: Readonly<Record<string, string>>;
+  readonly limit?: number | null;
+  readonly offset?: number | null;
+};
+
+export type SessionTemplateDefaults = {
+  readonly owner_mode?: string | null;
+  readonly viewport?: SessionViewport | null;
+  readonly idle_timeout_sec?: number | null;
+  readonly labels?: Readonly<Record<string, string>>;
+  readonly integration_context?: Readonly<Record<string, unknown>> | null;
+  readonly recording?: Readonly<Record<string, unknown>> | null;
+};
+
+export type SessionTemplateResource = {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly defaults: SessionTemplateDefaults;
+  readonly version: number;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type SessionTemplateListResponse = {
+  readonly templates: readonly SessionTemplateResource[];
+};
+
 export type CreateSessionCommand = {
+  readonly template_id?: string | null;
   readonly owner_mode?: string;
   readonly idle_timeout_sec?: number;
   readonly labels?: Readonly<Record<string, string>>;
+  readonly integration_context?: Readonly<Record<string, unknown>> | null;
 };
 
 export type SetAutomationDelegateCommand = {

--- a/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionDetailRoute.svelte
@@ -6,6 +6,7 @@
     SessionFileBindingResource,
     SessionFileResource,
     SessionResource,
+    SessionTemplateResource,
   } from '../api/control-types';
   import type { SessionRecordingPlaybackResource, SessionRecordingResource } from '../api/recording-types';
   import type { SessionStatus } from '../api/session-status-types';
@@ -22,6 +23,7 @@
 
   let { controlClient, sessionId }: AdminSessionDetailRouteProps = $props();
   let session = $state<SessionResource | null>(null);
+  let sessionTemplates = $state<readonly SessionTemplateResource[]>([]);
   let status = $state<SessionStatus | null>(null);
   let files = $state<readonly SessionFileResource[]>([]);
   let bindings = $state<readonly SessionFileBindingResource[]>([]);
@@ -38,6 +40,7 @@
 
   const viewModel = $derived(SessionViewModelBuilder.detail({
     session,
+    sessionTemplates,
     status,
     connected,
     loading,
@@ -61,7 +64,8 @@
       ]);
       session = nextSession;
       status = nextStatus;
-      await loadRelatedResources();
+      const templateLoadError = await loadSessionTemplates();
+      await loadRelatedResources(templateLoadError ? [templateLoadError] : []);
       lastRefreshedAt = new Date().toISOString();
       if (showFeedback) {
         actionFeedback = lifecycleFeedback(
@@ -80,14 +84,14 @@
     }
   }
 
-  async function loadRelatedResources(): Promise<void> {
+  async function loadRelatedResources(initialErrors: readonly string[] = []): Promise<void> {
     const [fileResult, bindingResult, recordingResult, playbackResult] = await Promise.allSettled([
       controlClient.listSessionFiles(sessionId),
       controlClient.listSessionFileBindings(sessionId),
       controlClient.listSessionRecordings(sessionId),
       controlClient.getSessionRecordingPlayback(sessionId),
     ]);
-    const errors: string[] = [];
+    const errors: string[] = [...initialErrors];
     if (fileResult.status === 'fulfilled') {
       files = fileResult.value.files;
     } else {
@@ -113,6 +117,16 @@
       errors.push(errorMessage(playbackResult.reason, 'Recording playback summary failed'));
     }
     relatedError = errors.length > 0 ? errors.join(' | ') : null;
+  }
+
+  async function loadSessionTemplates(): Promise<string | null> {
+    try {
+      sessionTemplates = (await controlClient.listSessionTemplates()).templates;
+      return null;
+    } catch (templateLoadError) {
+      sessionTemplates = [];
+      return errorMessage(templateLoadError, 'Template catalog summary failed');
+    }
   }
 
   async function stopSession(): Promise<void> {

--- a/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
@@ -3,7 +3,7 @@
   import { goto } from '$app/navigation';
   import { onMount } from 'svelte';
   import type { ControlClient } from '../api/control-client';
-  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource, SessionTemplateResource } from '../api/control-types';
   import AdminMessage from '../presentation/AdminMessage.svelte';
   import type { AdminMessageFeedback } from '../presentation/admin-message-types';
   import SessionCreateConfigurator from '../presentation/SessionCreateConfigurator.svelte';
@@ -15,13 +15,20 @@
 
   let { controlClient }: AdminSessionListRouteProps = $props();
   let sessions = $state<readonly SessionResource[]>([]);
+  let sessionTemplates = $state<readonly SessionTemplateResource[]>([]);
   let loading = $state(false);
+  let templatesLoading = $state(false);
   let error = $state<string | null>(null);
+  let templateError = $state<string | null>(null);
   let actionFeedback = $state<AdminMessageFeedback | null>(null);
   let search = $state('');
+  let templateFilter = $state('');
+  let stateFilter = $state('');
+  let runtimeFilter = $state('');
 
   const viewModel = $derived(SessionViewModelBuilder.list({
     sessions,
+    sessionTemplates,
     selectedSessionId: null,
     authenticated: true,
     loading,
@@ -30,15 +37,32 @@
   const filteredSessions = $derived(filterSessions(viewModel.sessions, search));
 
   onMount(() => {
+    void loadSessionTemplates();
     void loadSessions(false);
   });
+
+  async function loadSessionTemplates(): Promise<void> {
+    templatesLoading = true;
+    templateError = null;
+    try {
+      sessionTemplates = (await controlClient.listSessionTemplates()).templates;
+    } catch (loadError) {
+      templateError = errorMessage(loadError);
+    } finally {
+      templatesLoading = false;
+    }
+  }
 
   async function loadSessions(showFeedback = true): Promise<void> {
     loading = true;
     error = null;
     actionFeedback = null;
     try {
-      sessions = (await controlClient.listSessions()).sessions;
+      sessions = (await controlClient.listSessions({
+        templateId: templateFilter || null,
+        states: stateFilter ? [stateFilter] : [],
+        runtimeStates: runtimeFilter ? [runtimeFilter] : [],
+      })).sessions;
       if (showFeedback) {
         actionFeedback = successFeedback(`${sessions.length} session${sessions.length === 1 ? '' : 's'} refreshed.`);
       }
@@ -83,6 +107,7 @@
       session.lifecycle,
       session.runtime,
       session.presence,
+      session.template,
       session.mcpDelegation,
       session.labels,
     ].some((value) => value.toLowerCase().includes(normalized)));
@@ -132,13 +157,74 @@
           bind:value={search}
         />
       </label>
-      <p class="m-0 text-sm text-admin-ink/62" data-testid="session-inspector-count">
+      <div class="grid gap-3 sm:grid-cols-3">
+        <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+          Template
+          <select
+            class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+            data-testid="session-inspector-template-filter"
+            bind:value={templateFilter}
+            disabled={loading || templatesLoading}
+            onchange={() => void loadSessions(false)}
+          >
+            <option value="">All templates</option>
+            {#each sessionTemplates as template}
+              <option value={template.id}>{template.name}</option>
+            {/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+          State
+          <select
+            class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+            data-testid="session-inspector-state-filter"
+            bind:value={stateFilter}
+            disabled={loading}
+            onchange={() => void loadSessions(false)}
+          >
+            <option value="">Any state</option>
+            {#each ['pending', 'starting', 'ready', 'active', 'idle', 'released', 'stopping', 'stopped', 'failed', 'expired'] as state}
+              <option value={state}>{state}</option>
+            {/each}
+          </select>
+        </label>
+        <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+          Runtime
+          <select
+            class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+            data-testid="session-inspector-runtime-filter"
+            bind:value={runtimeFilter}
+            disabled={loading}
+            onchange={() => void loadSessions(false)}
+          >
+            <option value="">Any runtime</option>
+            {#each ['not_started', 'starting', 'running', 'released', 'stopping', 'stopped'] as runtime}
+              <option value={runtime}>{runtime}</option>
+            {/each}
+          </select>
+        </label>
+      </div>
+      <p class="m-0 text-sm text-admin-ink/62 md:col-span-2" data-testid="session-inspector-count">
         {filteredSessions.length} of {viewModel.sessions.length} visible sessions
       </p>
     </div>
+    {#if templateError}
+      <div class="mt-3">
+        <AdminMessage
+          variant="warning"
+          title="Template catalog unavailable"
+          message={templateError}
+          testId="session-inspector-template-error"
+          compact={true}
+        />
+      </div>
+    {/if}
   </div>
 
   <SessionCreateConfigurator
+    {sessionTemplates}
+    {templatesLoading}
+    {templateError}
     loading={loading}
     submitTestId="session-inspector-new"
     submitLabel="Create and inspect"
@@ -186,7 +272,7 @@
           <span class="grid min-w-0 gap-1">
             <strong class="truncate font-mono text-sm" title={session.id}>{session.id}</strong>
             <span class="truncate text-xs text-admin-ink/58">
-              {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
+              <span data-testid="session-inspector-row-template">{session.template}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
             </span>
           </span>
           <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -8,7 +8,7 @@
     AdminWorkflowRunSnapshot,
   } from '../api/admin-event-snapshots';
   import type { ControlClient } from '../api/control-client';
-  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource, SessionTemplateResource } from '../api/control-types';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { McpBridgeConfig } from '../auth/auth-config';
   import BrowserEmbedPanel from '../presentation/BrowserEmbedPanel.svelte';
@@ -45,9 +45,12 @@
   let browserConnector = $derived(new BrowserSessionConnector({ controlClient }));
   let liveConnection = $state<LiveBrowserSessionConnection | null>(null);
   let sessions = $state<readonly SessionResource[]>([]);
+  let sessionTemplates = $state<readonly SessionTemplateResource[]>([]);
   let selectedSession = $state<SessionResource | null>(null);
   let sessionsLoading = $state(false);
   let sessionsError = $state<string | null>(null);
+  let templatesLoading = $state(false);
+  let templateError = $state<string | null>(null);
   let globalMessage = $state<AdminMessageFeedback | null>(null);
   let pendingSelectedSessionId = $state<string | null>(null);
   let browserConnecting = $state(false);
@@ -82,7 +85,7 @@
     sessionCount: sessions.length, fileCount: sessionFileCount, connected: browserConnected,
   }));
   const sessionListViewModel = $derived(SessionViewModelBuilder.list({
-    sessions, selectedSessionId: selectedSession?.id ?? null,
+    sessions, sessionTemplates, selectedSessionId: selectedSession?.id ?? null,
     authenticated: true, loading: sessionsLoading, error: sessionsError,
   }));
   $effect(() => {
@@ -113,8 +116,28 @@
       },
     });
     void loadSessions();
+    void loadSessionTemplates();
     return () => { subscription.close(); disconnectBrowser(false); };
   });
+  async function loadSessionTemplates(showFeedback = false): Promise<void> {
+    templatesLoading = true;
+    templateError = null;
+    try {
+      sessionTemplates = (await controlClient.listSessionTemplates()).templates;
+      if (showFeedback) {
+        showGlobalMessage(
+          'success',
+          'Template catalog refreshed',
+          `${sessionTemplates.length} template${sessionTemplates.length === 1 ? '' : 's'} refreshed.`,
+        );
+      }
+    } catch (error) {
+      templateError = errorMessage(error);
+      showGlobalMessage('warning', 'Template catalog unavailable', templateError);
+    } finally {
+      templatesLoading = false;
+    }
+  }
   async function loadSessions(showFeedback = false): Promise<void> {
     sessionsLoading = true;
     sessionsError = null;
@@ -342,7 +365,7 @@
   <BrowserWorkspaceOverlayLayout {adminOpen} {onAdminOpenChange}>
     {#snippet admin()}
     <AdminWorkspaceTabs
-      {controlClient} {workflowClient} {selectedSession} {mcpBridge} {liveConnection}
+      {controlClient} {workflowClient} {selectedSession} {sessionTemplates} {templatesLoading} {templateError} {mcpBridge} {liveConnection}
       {browserPreferences} {browserConnected} {workspaceViewModel} {sessionListViewModel} {logEntries} {globalMessage}
       {sessionFilesRefreshVersion} {recordingsRefreshVersion} {mcpDelegationRefreshVersion} onRefreshSessions={loadSessions}
       onCreateSession={(command) => void createSession(command)} onJoinSelectedSession={requestBrowserConnect}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -11,7 +11,7 @@
     Video,
   } from 'lucide-svelte';
   import type { ControlClient } from '../api/control-client';
-  import type { CreateSessionCommand, SessionResource } from '../api/control-types';
+  import type { CreateSessionCommand, SessionResource, SessionTemplateResource } from '../api/control-types';
   import type { WorkflowClient } from '../api/workflow-client';
   import type { McpBridgeConfig } from '../auth/auth-config';
   import AdminMessage from '../presentation/AdminMessage.svelte';
@@ -41,6 +41,9 @@
     readonly controlClient: ControlClient;
     readonly workflowClient: WorkflowClient;
     readonly selectedSession: SessionResource | null;
+    readonly sessionTemplates?: readonly SessionTemplateResource[];
+    readonly templatesLoading?: boolean;
+    readonly templateError?: string | null;
     readonly mcpBridge: McpBridgeConfig | null;
     readonly liveConnection: LiveBrowserSessionConnection | null;
     readonly browserConnected: boolean;
@@ -147,6 +150,9 @@
         {#if activePanel.id === 'sessions'}
         <SessionListPanel
           viewModel={props.sessionListViewModel}
+          sessionTemplates={props.sessionTemplates ?? []}
+          templatesLoading={props.templatesLoading ?? false}
+          templateError={props.templateError ?? null}
           connected={props.browserConnected}
           onRefresh={() => void props.onRefreshSessions(true)}
           onCreateSession={props.onCreateSession}

--- a/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
@@ -1,15 +1,19 @@
 <script lang="ts">
   import { base } from '$app/paths';
-  import type { CreateSessionCommand } from '../api/control-types';
+  import type { CreateSessionCommand, SessionTemplateResource } from '../api/control-types';
   import {
     SESSION_CREATE_OWNER_MODES,
     defaultSessionCreateFormState,
+    sessionTemplateDefaultsSummary,
     validateSessionCreateForm,
   } from './session-create-configurator';
   import AdminMessage from './AdminMessage.svelte';
 
   type SessionCreateConfiguratorProps = {
     readonly onCreateSession: (command: CreateSessionCommand) => void;
+    readonly sessionTemplates?: readonly SessionTemplateResource[];
+    readonly templatesLoading?: boolean;
+    readonly templateError?: string | null;
     readonly loading?: boolean;
     readonly disabled?: boolean;
     readonly submitTestId?: string;
@@ -23,6 +27,9 @@
 
   let {
     onCreateSession,
+    sessionTemplates = [],
+    templatesLoading = false,
+    templateError = null,
     loading = false,
     disabled = false,
     submitTestId = 'session-new',
@@ -35,11 +42,14 @@
   }: SessionCreateConfiguratorProps = $props();
 
   const defaults = defaultSessionCreateFormState();
+  let templateId = $state(defaults.templateId);
   let ownerMode = $state(defaults.ownerMode);
   let idleTimeoutSec = $state(defaults.idleTimeoutSec);
   let labels = $state(defaults.labels);
   let payloadOpenInternal = $state(false);
-  const validation = $derived(validateSessionCreateForm({ ownerMode, idleTimeoutSec, labels }));
+  const validation = $derived(validateSessionCreateForm({ templateId, ownerMode, idleTimeoutSec, labels }));
+  const selectedTemplate = $derived(sessionTemplates.find((template) => template.id === templateId) ?? null);
+  const selectedTemplateSummary = $derived(sessionTemplateDefaultsSummary(selectedTemplate));
   const rootClass = $derived(variant === 'panel'
     ? 'admin-panel mt-0 grid gap-4'
     : 'grid gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3');
@@ -48,6 +58,12 @@
   $effect(() => {
     if (payloadInitiallyOpen) {
       payloadOpenInternal = true;
+    }
+  });
+
+  $effect(() => {
+    if (templateId && !sessionTemplates.some((template) => template.id === templateId)) {
+      templateId = '';
     }
   });
 
@@ -84,7 +100,22 @@
       submit();
     }}
   >
-    <div class="grid gap-3 lg:grid-cols-[minmax(180px,1fr)_minmax(180px,1fr)]">
+    <div class="grid gap-3 xl:grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)_minmax(180px,1fr)]">
+      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+        Template
+        <select
+          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="session-create-template"
+          bind:value={templateId}
+          disabled={loading || disabled || templatesLoading}
+        >
+          <option value="">No template</option>
+          {#each sessionTemplates as template}
+            <option value={template.id}>{template.name}</option>
+          {/each}
+        </select>
+      </label>
+
       <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
         Owner mode
         <select
@@ -112,6 +143,38 @@
         />
       </label>
     </div>
+
+    {#if selectedTemplate || templateError || templatesLoading}
+      <section
+        class="rounded-xl border border-admin-ink/10 bg-admin-field/68 p-3 text-sm text-admin-ink/72"
+        aria-label="Selected session template"
+        data-testid="session-create-template-summary"
+      >
+        {#if templatesLoading}
+          <span class="font-bold text-[#c1d0e8]">Loading template catalog...</span>
+        {:else if templateError}
+          <AdminMessage
+            variant="warning"
+            title="Template catalog unavailable"
+            message={templateError}
+            compact={true}
+          />
+        {:else if selectedTemplate}
+          <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
+            <span class="min-w-0">
+              <strong class="block truncate text-admin-ink">{selectedTemplate.name}</strong>
+              <span class="block truncate text-xs text-admin-ink/58">{selectedTemplate.id}</span>
+            </span>
+            <span class="rounded-lg bg-admin-leaf/12 px-2 py-1 text-xs font-bold text-admin-leaf">
+              v{selectedTemplate.version}
+            </span>
+          </div>
+          <p class="m-0 mt-2 text-xs leading-normal text-admin-ink/62">
+            {selectedTemplateSummary}
+          </p>
+        {/if}
+      </section>
+    {/if}
 
     <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
       Labels

--- a/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
@@ -54,8 +54,11 @@
   const selectedTemplate = $derived(sessionTemplates.find((template) => template.id === templateId) ?? null);
   const selectedTemplateSummary = $derived(sessionTemplateDefaultsSummary(selectedTemplate));
   const rootClass = $derived(variant === 'panel'
-    ? 'admin-panel mt-0 grid gap-4'
-    : 'grid gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3');
+    ? 'admin-panel mt-0 grid min-w-0 gap-4'
+    : 'grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3');
+  const fieldGridClass = $derived(variant === 'panel'
+    ? 'grid min-w-0 gap-3 xl:grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)_minmax(180px,1fr)]'
+    : 'grid min-w-0 gap-3');
   const payloadOpen = $derived(controlledPayloadOpen ?? payloadOpenInternal);
 
   $effect(() => {
@@ -116,11 +119,11 @@
       submit();
     }}
   >
-    <div class="grid gap-3 xl:grid-cols-[minmax(220px,1.2fr)_minmax(180px,1fr)_minmax(180px,1fr)]">
-      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+    <div class={fieldGridClass}>
+      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
         Template
         <select
-          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
           data-testid="session-create-template"
           bind:value={templateId}
           disabled={loading || disabled || templatesLoading}
@@ -132,10 +135,10 @@
         </select>
       </label>
 
-      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
         Owner mode
         <select
-          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
           data-testid="session-create-owner-mode"
           bind:value={ownerMode}
           disabled={loading || disabled}
@@ -148,10 +151,10 @@
         </select>
       </label>
 
-      <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
         Idle timeout
         <input
-          class="min-h-11 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
           data-testid="session-create-idle-timeout"
           inputmode="numeric"
           placeholder="Backend default"
@@ -194,10 +197,10 @@
       </section>
     {/if}
 
-    <label class="grid gap-1 text-sm font-bold text-admin-ink/72">
+    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
       Labels
       <textarea
-        class="min-h-20 resize-y rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 py-2 text-admin-ink outline-none focus:border-admin-leaf/45"
+        class="min-h-20 min-w-0 resize-y rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 py-2 text-admin-ink outline-none focus:border-admin-leaf/45"
         data-testid="session-create-labels"
         placeholder="case=1234, purpose=import-repro"
         rows={variant === 'panel' ? 3 : 2}

--- a/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
@@ -3,6 +3,7 @@
   import type { CreateSessionCommand, SessionTemplateResource } from '../api/control-types';
   import {
     SESSION_CREATE_OWNER_MODES,
+    DEFAULT_SESSION_CREATE_OWNER_MODE,
     defaultSessionCreateFormState,
     sessionTemplateDefaultsSummary,
     validateSessionCreateForm,
@@ -47,6 +48,8 @@
   let idleTimeoutSec = $state(defaults.idleTimeoutSec);
   let labels = $state(defaults.labels);
   let payloadOpenInternal = $state(false);
+  let previousTemplateId = $state(defaults.templateId);
+  let ownerModeTouched = $state(false);
   const validation = $derived(validateSessionCreateForm({ templateId, ownerMode, idleTimeoutSec, labels }));
   const selectedTemplate = $derived(sessionTemplates.find((template) => template.id === templateId) ?? null);
   const selectedTemplateSummary = $derived(sessionTemplateDefaultsSummary(selectedTemplate));
@@ -65,6 +68,19 @@
     if (templateId && !sessionTemplates.some((template) => template.id === templateId)) {
       templateId = '';
     }
+  });
+
+  $effect(() => {
+    if (templateId === previousTemplateId) {
+      return;
+    }
+    if (templateId && !ownerModeTouched && ownerMode === DEFAULT_SESSION_CREATE_OWNER_MODE) {
+      ownerMode = '';
+    } else if (!templateId && !ownerMode) {
+      ownerMode = DEFAULT_SESSION_CREATE_OWNER_MODE;
+      ownerModeTouched = false;
+    }
+    previousTemplateId = templateId;
   });
 
   function submit(): void {
@@ -123,7 +139,9 @@
           data-testid="session-create-owner-mode"
           bind:value={ownerMode}
           disabled={loading || disabled}
+          onchange={() => { ownerModeTouched = true; }}
         >
+          <option value="">Template / backend default</option>
           {#each SESSION_CREATE_OWNER_MODES as mode}
             <option value={mode.value}>{mode.label}</option>
           {/each}

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { base } from '$app/paths';
-  import type { CreateSessionCommand } from '../api/control-types';
+  import type { CreateSessionCommand, SessionTemplateResource } from '../api/control-types';
   import AdminMessage from './AdminMessage.svelte';
   import SessionCreateConfigurator from './SessionCreateConfigurator.svelte';
   import SessionTable from './SessionTable.svelte';
@@ -8,6 +8,9 @@
 
   type SessionListPanelProps = {
     readonly viewModel: SessionListPanelViewModel;
+    readonly sessionTemplates?: readonly SessionTemplateResource[];
+    readonly templatesLoading?: boolean;
+    readonly templateError?: string | null;
     readonly connected: boolean;
     readonly onRefresh: () => void;
     readonly onCreateSession: (command: CreateSessionCommand) => void;
@@ -18,6 +21,9 @@
 
   let {
     viewModel,
+    sessionTemplates = [],
+    templatesLoading = false,
+    templateError = null,
     connected,
     onRefresh,
     onCreateSession,
@@ -47,8 +53,9 @@
     </div>
 
     {#if viewModel.selectedSession}
-      <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-4">
+      <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-5">
         {@render Fact('State', viewModel.selectedSession.lifecycle, 'session-selected-state')}
+        {@render Fact('Template', viewModel.selectedSession.template, 'session-selected-template')}
         {@render Fact('Runtime', viewModel.selectedSession.runtime, 'session-selected-runtime')}
         {@render Fact('Clients', String(viewModel.selectedSession.clients), 'session-selected-clients')}
         {@render Fact('MCP', viewModel.selectedSession.mcpDelegation, 'session-selected-mcp')}
@@ -90,6 +97,9 @@
   </section>
 
   <SessionCreateConfigurator
+    {sessionTemplates}
+    {templatesLoading}
+    {templateError}
     loading={viewModel.loading}
     disabled={!viewModel.authenticated}
     submitTestId="session-new"

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<div class="grid gap-3" aria-label="Owner-scoped sessions">
+<div class="grid min-w-0 gap-3" aria-label="Owner-scoped sessions">
   <section class="grid gap-3 rounded-[16px] border border-admin-leaf/25 bg-admin-leaf/10 p-3" aria-label="Selected session">
     <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">

--- a/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
@@ -37,7 +37,7 @@
           {/if}
         </span>
         <span class="min-w-0 truncate text-xs text-admin-ink/52">
-          {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
+          <span data-testid="session-row-template">{session.template}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
         </span>
       </span>
       <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
@@ -70,6 +70,22 @@ describe('session create configurator', () => {
   it('includes the selected template id in the create-session payload', () => {
     const validation = validateSessionCreateForm({
       templateId: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+      ownerMode: '',
+      idleTimeoutSec: '',
+      labels: '',
+    });
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.command).toEqual({
+      template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+    });
+    expect(validation.preview).toContain('"template_id"');
+    expect(validation.preview).not.toContain('"owner_mode"');
+  });
+
+  it('keeps explicit owner-mode overrides when a template is selected', () => {
+    const validation = validateSessionCreateForm({
+      templateId: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
       ownerMode: 'collaborative',
       idleTimeoutSec: '',
       labels: '',
@@ -80,7 +96,6 @@ describe('session create configurator', () => {
       template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
       owner_mode: 'collaborative',
     });
-    expect(validation.preview).toContain('"template_id"');
   });
 
   it('summarizes selected template defaults for the UI', () => {

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   defaultSessionCreateFormState,
   parseSessionCreateLabels,
+  sessionTemplateDefaultsSummary,
   validateSessionCreateForm,
 } from './session-create-configurator';
 
@@ -16,6 +17,7 @@ describe('session create configurator', () => {
 
   it('normalizes idle timeout and labels into a create-session payload', () => {
     const validation = validateSessionCreateForm({
+      templateId: '',
       ownerMode: 'exclusive_browser_owner',
       idleTimeoutSec: '1800',
       labels: 'case=1234\npurpose=import-repro, suite=admin',
@@ -35,6 +37,7 @@ describe('session create configurator', () => {
 
   it('rejects unsupported owner modes and invalid idle timeout values', () => {
     const validation = validateSessionCreateForm({
+      templateId: '',
       ownerMode: 'shared',
       idleTimeoutSec: '0',
       labels: '',
@@ -62,5 +65,43 @@ describe('session create configurator', () => {
       'Label "purpose=" must use non-empty key and value.',
       'Label "case" is duplicated.',
     ]);
+  });
+
+  it('includes the selected template id in the create-session payload', () => {
+    const validation = validateSessionCreateForm({
+      templateId: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+      ownerMode: 'collaborative',
+      idleTimeoutSec: '',
+      labels: '',
+    });
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.command).toEqual({
+      template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+      owner_mode: 'collaborative',
+    });
+    expect(validation.preview).toContain('"template_id"');
+  });
+
+  it('summarizes selected template defaults for the UI', () => {
+    expect(sessionTemplateDefaultsSummary({
+      id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+      name: 'Support triage',
+      description: null,
+      labels: {},
+      defaults: {
+        owner_mode: 'collaborative',
+        viewport: { width: 1440, height: 900 },
+        idle_timeout_sec: 1800,
+        labels: { team: 'support' },
+        integration_context: { ticket: 'INC-1234' },
+        recording: { mode: 'manual', format: 'webm' },
+      },
+      version: 1,
+      created_at: '2026-05-04T18:00:00Z',
+      updated_at: '2026-05-04T18:00:00Z',
+    })).toBe(
+      'owner=collaborative | idle=1800s | viewport=1440x900 | labels=team=support | integration=ticket | recording=manual',
+    );
   });
 });

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
@@ -1,4 +1,4 @@
-import type { CreateSessionCommand } from '../api/control-types';
+import type { CreateSessionCommand, SessionTemplateResource } from '../api/control-types';
 
 export const SESSION_CREATE_OWNER_MODES = [
   {
@@ -18,6 +18,7 @@ const OWNER_MODE_VALUES = new Set<string>(
 );
 
 export type SessionCreateFormState = {
+  readonly templateId: string;
   readonly ownerMode: string;
   readonly idleTimeoutSec: string;
   readonly labels: string;
@@ -30,6 +31,7 @@ export type SessionCreateValidation = {
 };
 
 type MutableCreateSessionCommand = {
+  template_id?: string;
   owner_mode?: string;
   idle_timeout_sec?: number;
   labels?: Readonly<Record<string, string>>;
@@ -37,6 +39,7 @@ type MutableCreateSessionCommand = {
 
 export function defaultSessionCreateFormState(): SessionCreateFormState {
   return {
+    templateId: '',
     ownerMode: DEFAULT_SESSION_CREATE_OWNER_MODE,
     idleTimeoutSec: '',
     labels: '',
@@ -48,6 +51,11 @@ export function validateSessionCreateForm(
 ): SessionCreateValidation {
   const errors: string[] = [];
   const command: MutableCreateSessionCommand = {};
+  const templateId = state.templateId.trim();
+  if (templateId) {
+    command.template_id = templateId;
+  }
+
   const ownerMode = state.ownerMode.trim() || DEFAULT_SESSION_CREATE_OWNER_MODE;
   if (OWNER_MODE_VALUES.has(ownerMode)) {
     command.owner_mode = ownerMode;
@@ -121,4 +129,36 @@ function parseIdleTimeoutSec(value: string, errors: string[]): number | undefine
     return undefined;
   }
   return parsed;
+}
+
+export function sessionTemplateDefaultsSummary(
+  template: SessionTemplateResource | null | undefined,
+): string {
+  if (!template) {
+    return 'No template defaults selected.';
+  }
+  const facts: string[] = [];
+  const defaults = template.defaults;
+  if (defaults.owner_mode) {
+    facts.push(`owner=${defaults.owner_mode}`);
+  }
+  if (defaults.idle_timeout_sec) {
+    facts.push(`idle=${defaults.idle_timeout_sec}s`);
+  }
+  if (defaults.viewport) {
+    facts.push(`viewport=${defaults.viewport.width}x${defaults.viewport.height}`);
+  }
+  const labels = Object.entries(defaults.labels ?? {});
+  if (labels.length > 0) {
+    facts.push(`labels=${labels.map(([key, value]) => `${key}=${value}`).join(',')}`);
+  }
+  const contextKeys = Object.keys(defaults.integration_context ?? {}).sort();
+  if (contextKeys.length > 0) {
+    facts.push(`integration=${contextKeys.join(',')}`);
+  }
+  if (defaults.recording) {
+    const mode = typeof defaults.recording.mode === 'string' ? defaults.recording.mode : 'configured';
+    facts.push(`recording=${mode}`);
+  }
+  return facts.length > 0 ? facts.join(' | ') : 'Template has no create-session defaults.';
 }

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
@@ -56,8 +56,10 @@ export function validateSessionCreateForm(
     command.template_id = templateId;
   }
 
-  const ownerMode = state.ownerMode.trim() || DEFAULT_SESSION_CREATE_OWNER_MODE;
-  if (OWNER_MODE_VALUES.has(ownerMode)) {
+  const ownerMode = state.ownerMode.trim();
+  if (!ownerMode) {
+    // Empty means "let the selected template or backend default decide".
+  } else if (OWNER_MODE_VALUES.has(ownerMode)) {
     command.owner_mode = ownerMode;
   } else {
     errors.push(`Owner mode "${ownerMode}" is not supported.`);

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -6,9 +6,11 @@ import { SessionViewModelBuilder } from './session-view-model';
 const SESSION: SessionResource = {
   id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
   state: 'active',
+  template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   owner_mode: 'shared',
   idle_timeout_sec: 1800,
   labels: { case: '1234', purpose: 'import-repro' },
+  integration_context: { ticket: 'INC-1234' },
   connect: {
     gateway_url: 'https://localhost:4433',
     transport_path: '/session',
@@ -38,6 +40,21 @@ const SESSION: SessionResource = {
   },
   created_at: '2026-05-04T19:00:00Z',
   updated_at: '2026-05-04T19:01:00Z',
+};
+
+const TEMPLATE = {
+  id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
+  name: 'Support triage',
+  description: null,
+  labels: { team: 'support' },
+  defaults: {
+    owner_mode: 'collaborative',
+    idle_timeout_sec: 1800,
+    labels: { team: 'support' },
+  },
+  version: 1,
+  created_at: '2026-05-04T18:00:00Z',
+  updated_at: '2026-05-04T18:00:00Z',
 };
 
 const STATUS: SessionStatus = {
@@ -105,6 +122,7 @@ describe('SessionViewModelBuilder', () => {
   it('maps sessions to compact list rows', () => {
     const viewModel = SessionViewModelBuilder.list({
       sessions: [SESSION],
+      sessionTemplates: [TEMPLATE],
       selectedSessionId: SESSION.id,
       authenticated: true,
       loading: false,
@@ -118,6 +136,8 @@ describe('SessionViewModelBuilder', () => {
       runtime: 'running',
       presence: 'connected',
       clients: 1,
+      template: 'Support triage (019df5c8...21c0)',
+      templateId: TEMPLATE.id,
       mcpDelegation: 'MCP not delegated',
       labels: 'case=1234, purpose=import-repro',
     });
@@ -145,6 +165,7 @@ describe('SessionViewModelBuilder', () => {
   it('adds full status facts and connection controls when status is loaded', () => {
     const viewModel = SessionViewModelBuilder.detail({
       session: SESSION,
+      sessionTemplates: [TEMPLATE],
       status: STATUS,
       connected: false,
       loading: false,
@@ -157,9 +178,19 @@ describe('SessionViewModelBuilder', () => {
       testId: 'session-mcp-owner',
     });
     expect(viewModel.facts).toContainEqual({
+      label: 'template',
+      value: 'Support triage (019df5c8...21c0)',
+      testId: 'session-template',
+    });
+    expect(viewModel.facts).toContainEqual({
       label: 'labels',
       value: 'case=1234, purpose=import-repro',
       testId: 'session-labels',
+    });
+    expect(viewModel.facts).toContainEqual({
+      label: 'integration',
+      value: 'ticket=INC-1234',
+      testId: 'session-integration-context',
     });
     expect(viewModel.connections).toEqual([{
       id: 7,

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -1,4 +1,8 @@
-import type { SessionResource, SessionStopEligibility } from '../api/control-types';
+import type {
+  SessionResource,
+  SessionStopEligibility,
+  SessionTemplateResource,
+} from '../api/control-types';
 import type { SessionStatus } from '../api/session-status-types';
 
 export type SessionListItemViewModel = {
@@ -9,6 +13,8 @@ export type SessionListItemViewModel = {
   readonly presence: string;
   readonly clients: number;
   readonly updatedAt: string;
+  readonly template: string;
+  readonly templateId: string | null;
   readonly mcpDelegation: string;
   readonly labels: string;
 };
@@ -59,15 +65,17 @@ export type SessionDetailPanelViewModel = {
 export class SessionViewModelBuilder {
   static list(input: {
     readonly sessions: readonly SessionResource[];
+    readonly sessionTemplates?: readonly SessionTemplateResource[];
     readonly selectedSessionId: string | null;
     readonly authenticated: boolean;
     readonly loading: boolean;
     readonly error: string | null;
   }): SessionListPanelViewModel {
     const selectedSession = input.sessions.find((session) => session.id === input.selectedSessionId) ?? null;
+    const templateLookup = templateLookupFrom(input.sessionTemplates ?? []);
     return {
-      sessions: input.sessions.map(toListItem),
-      selectedSession: selectedSession ? toSelectedSession(selectedSession) : null,
+      sessions: input.sessions.map((session) => toListItem(session, templateLookup)),
+      selectedSession: selectedSession ? toSelectedSession(selectedSession, templateLookup) : null,
       selectedSessionId: input.selectedSessionId,
       authenticated: input.authenticated,
       loading: input.loading,
@@ -77,6 +85,7 @@ export class SessionViewModelBuilder {
 
   static detail(input: {
     readonly session: SessionResource | null;
+    readonly sessionTemplates?: readonly SessionTemplateResource[];
     readonly status?: SessionStatus | null;
     readonly connected: boolean;
     readonly loading: boolean;
@@ -100,6 +109,7 @@ export class SessionViewModelBuilder {
       };
     }
     const status = input.status ?? null;
+    const templateLookup = templateLookupFrom(input.sessionTemplates ?? []);
     const stopEligibility = status?.stop_eligibility ?? session.status.stop_eligibility;
     const connectionCount = status?.connection_counts.total_clients
       ?? session.status.connection_counts.total_clients;
@@ -108,9 +118,19 @@ export class SessionViewModelBuilder {
       title: session.id,
       facts: [
         { label: 'state', value: session.state, testId: 'session-state' },
+        {
+          label: 'template',
+          value: templateLabel(session, templateLookup),
+          testId: 'session-template',
+        },
         { label: 'owner', value: session.owner_mode, testId: 'session-owner-mode' },
         { label: 'idle override', value: session.idle_timeout_sec?.toString() ?? 'default', testId: 'session-idle-timeout' },
         { label: 'labels', value: labelSummary(session.labels ?? {}), testId: 'session-labels' },
+        {
+          label: 'integration',
+          value: integrationContextSummary(session.integration_context ?? null),
+          testId: 'session-integration-context',
+        },
         { label: 'runtime', value: session.status.runtime_state, testId: 'session-runtime-state' },
         { label: 'resume', value: session.status.runtime_resume_mode, testId: 'session-runtime-resume-mode' },
         { label: 'presence', value: session.status.presence_state, testId: 'session-presence-state' },
@@ -142,7 +162,10 @@ export class SessionViewModelBuilder {
   }
 }
 
-function toListItem(session: SessionResource): SessionListItemViewModel {
+function toListItem(
+  session: SessionResource,
+  templates: ReadonlyMap<string, SessionTemplateResource>,
+): SessionListItemViewModel {
   return {
     id: session.id,
     shortId: shortId(session.id),
@@ -151,14 +174,19 @@ function toListItem(session: SessionResource): SessionListItemViewModel {
     presence: session.status.presence_state,
     clients: session.status.connection_counts.total_clients,
     updatedAt: session.updated_at,
+    template: templateLabel(session, templates),
+    templateId: session.template_id ?? null,
     mcpDelegation: mcpDelegationLabel(session),
     labels: labelSummary(session.labels ?? {}),
   };
 }
 
-function toSelectedSession(session: SessionResource): SelectedSessionViewModel {
+function toSelectedSession(
+  session: SessionResource,
+  templates: ReadonlyMap<string, SessionTemplateResource>,
+): SelectedSessionViewModel {
   return {
-    ...toListItem(session),
+    ...toListItem(session, templates),
     ownerMode: session.owner_mode,
     runtimeBinding: session.runtime.binding,
     canJoin: canConnectSession(session.state),
@@ -213,6 +241,44 @@ function labelSummary(labels: Readonly<Record<string, string>>): string {
     return 'No labels';
   }
   return entries.map(([key, value]) => `${key}=${value}`).join(', ');
+}
+
+function integrationContextSummary(context: Readonly<Record<string, unknown>> | null): string {
+  if (!context || Object.keys(context).length === 0) {
+    return 'No integration context';
+  }
+  return Object.entries(context)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${formatContextValue(value)}`)
+    .join(', ');
+}
+
+function formatContextValue(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+function templateLookupFrom(
+  templates: readonly SessionTemplateResource[],
+): ReadonlyMap<string, SessionTemplateResource> {
+  return new Map(templates.map((template) => [template.id, template]));
+}
+
+function templateLabel(
+  session: SessionResource,
+  templates: ReadonlyMap<string, SessionTemplateResource>,
+): string {
+  const templateId = session.template_id;
+  if (!templateId) {
+    return 'No template';
+  }
+  const template = templates.get(templateId);
+  return template ? `${template.name} (${shortId(template.id)})` : `Template ${shortId(templateId)}`;
 }
 
 function shortId(value: string): string {

--- a/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
+++ b/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
@@ -290,7 +290,7 @@ describe('bpane operator CLI', () => {
     expect(calls[0].init.headers.Authorization).toBe('Bearer token-1');
   });
 
-  it('filters session list output when filter options are present', async () => {
+  it('sends session list filters to the catalog API', async () => {
     const io = createIo();
     const { calls, fetchImpl } = createFetch(jsonResponse({
       sessions: [
@@ -322,25 +322,38 @@ describe('bpane operator CLI', () => {
     }));
 
     const code = await runBpaneCli(
-      ['session', 'list', '--state', 'stopped', '--label', 'suite=cli', '--limit', '1'],
+      [
+        'session',
+        'list',
+        '--state',
+        'stopped',
+        '--runtime-state',
+        'running',
+        '--label',
+        'suite=cli',
+        '--integration',
+        'ticket=INC-1',
+        '--template-id',
+        'template-1',
+        '--limit',
+        '1',
+      ],
       { BPANE_ACCESS_TOKEN: 'token-1' },
       io.io,
       fetchImpl,
     );
 
     expect(code).toBe(EXIT_CODES.ok);
-    expect(parseStdout(io)).toMatchObject({
-      filters: {
-        states: ['stopped'],
-        labels: { suite: 'cli' },
-        limit: 1,
-      },
-      total_count: 4,
-      matched_count: 2,
-      returned_count: 1,
-      sessions: [{ id: 'session-1' }],
-    });
+    expect(parseStdout(io).sessions).toHaveLength(4);
     expect(calls).toHaveLength(1);
+    const url = new URL(calls[0].url);
+    expect(`${url.origin}${url.pathname}`).toBe('http://localhost:8080/api/v1/sessions');
+    expect(url.searchParams.get('state')).toBe('stopped');
+    expect(url.searchParams.get('runtime_state')).toBe('running');
+    expect(url.searchParams.get('label.suite')).toBe('cli');
+    expect(url.searchParams.get('integration.ticket')).toBe('INC-1');
+    expect(url.searchParams.get('template_id')).toBe('template-1');
+    expect(url.searchParams.get('limit')).toBe('1');
   });
 
   it('requires a bearer token for session commands', async () => {
@@ -417,6 +430,116 @@ describe('bpane operator CLI', () => {
       integration_context: { ticket: 'abc' },
       extension_ids: ['018f1a5b-0784-71bf-ae46-0c973f00aa11'],
       recording: { mode: 'manual', format: 'webm', retention_sec: 3600 },
+    });
+  });
+
+  it('creates session templates with structured defaults', async () => {
+    const io = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({ id: 'template-1' }, 201));
+
+    const code = await runBpaneCli(
+      [
+        'session-template',
+        'create',
+        'customer-debug-session',
+        '--description',
+        'Support debug session',
+        '--label',
+        'team=support',
+        '--default-label',
+        'purpose=debug',
+        '--owner-mode',
+        'collaborative',
+        '--width',
+        '1440',
+        '--height',
+        '900',
+        '--idle-timeout-sec',
+        '1800',
+        '--integration-json',
+        '{"source":"template"}',
+        '--recording-mode',
+        'manual',
+        '--recording-retention-sec',
+        '86400',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      io.io,
+      fetchImpl,
+    );
+
+    expect(code).toBe(EXIT_CODES.ok);
+    expect(parseStdout(io)).toEqual({ id: 'template-1' });
+    expect(calls[0].url).toBe('http://localhost:8080/api/v1/session-templates');
+    expect(calls[0].init.method).toBe('POST');
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      name: 'customer-debug-session',
+      description: 'Support debug session',
+      labels: { team: 'support' },
+      defaults: {
+        owner_mode: 'collaborative',
+        viewport: { width: 1440, height: 900 },
+        idle_timeout_sec: 1800,
+        labels: { purpose: 'debug' },
+        integration_context: { source: 'template' },
+        recording: { mode: 'manual', format: 'webm', retention_sec: 86400 },
+      },
+    });
+  });
+
+  it('lists, fetches, and updates session templates', async () => {
+    const listIo = createIo();
+    const { calls, fetchImpl } = createFetch(
+      jsonResponse({ templates: [{ id: 'template-1' }] }),
+      jsonResponse({ id: 'template-1' }),
+      jsonResponse({ id: 'template-1', version: 2 }),
+    );
+
+    const listCode = await runBpaneCli(
+      ['session-template', 'list'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      listIo.io,
+      fetchImpl,
+    );
+    expect(listCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(listIo)).toEqual({ templates: [{ id: 'template-1' }] });
+
+    const getIo = createIo();
+    const getCode = await runBpaneCli(
+      ['session-template', 'get', 'template/with space'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      getIo.io,
+      fetchImpl,
+    );
+    expect(getCode).toBe(EXIT_CODES.ok);
+
+    const updateIo = createIo();
+    const updateCode = await runBpaneCli(
+      [
+        'session-template',
+        'update',
+        'template-1',
+        '--name',
+        'customer-debug-session',
+        '--default-label',
+        'purpose=debug',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      updateIo.io,
+      fetchImpl,
+    );
+    expect(updateCode).toBe(EXIT_CODES.ok);
+
+    expect(calls.map((call) => [call.url, call.init.method])).toEqual([
+      ['http://localhost:8080/api/v1/session-templates', undefined],
+      ['http://localhost:8080/api/v1/session-templates/template%2Fwith%20space', undefined],
+      ['http://localhost:8080/api/v1/session-templates/template-1', 'PUT'],
+    ]);
+    expect(JSON.parse(calls[2].init.body)).toEqual({
+      name: 'customer-debug-session',
+      defaults: {
+        labels: { purpose: 'debug' },
+      },
     });
   });
 

--- a/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
+++ b/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
@@ -487,6 +487,54 @@ describe('bpane operator CLI', () => {
     });
   });
 
+  it('validates session-template CLI input before fetching', async () => {
+    const missingNameIo = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({ ok: true }));
+
+    const missingNameCode = await runBpaneCli(
+      ['session-template', 'create'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      missingNameIo.io,
+      fetchImpl,
+    );
+    expect(missingNameCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(missingNameIo).code).toBe('USAGE');
+    expect(calls).toHaveLength(0);
+
+    const viewportIo = createIo();
+    const viewportCode = await runBpaneCli(
+      ['session-template', 'create', 'template', '--width', '1440'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      viewportIo.io,
+      fetchImpl,
+    );
+    expect(viewportCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(viewportIo).error).toContain('Use --width and --height together');
+    expect(calls).toHaveLength(0);
+
+    const labelIo = createIo();
+    const labelCode = await runBpaneCli(
+      ['session-template', 'create', 'template', '--default-label', 'bad'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      labelIo.io,
+      fetchImpl,
+    );
+    expect(labelCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(labelIo).error).toContain('--default-label must use key=value syntax');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('requires bearer tokens for session-template commands', async () => {
+    const io = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({ templates: [] }));
+
+    const code = await runBpaneCli(['session-template', 'list'], {}, io.io, fetchImpl);
+
+    expect(code).toBe(EXIT_CODES.auth);
+    expect(calls).toHaveLength(0);
+    expect(parseStderr(io).code).toBe('AUTH_REQUIRED');
+  });
+
   it('lists, fetches, and updates session templates', async () => {
     const listIo = createIo();
     const { calls, fetchImpl } = createFetch(

--- a/code/web/bpane-client/scripts/bpane-cli.mjs
+++ b/code/web/bpane-client/scripts/bpane-cli.mjs
@@ -22,6 +22,8 @@ const KNOWN_OPTIONS = new Set([
   'cleanup-action',
   'config',
   'confirm',
+  'default-label',
+  'description',
   'dry-run',
   'extension-id',
   'fail-on-issues',
@@ -29,19 +31,23 @@ const KNOWN_OPTIONS = new Set([
   'help',
   'idle-timeout-sec',
   'integration-json',
+  'integration',
   'label',
   'limit',
   'mcp-client-id',
   'mcp-control-url',
   'mcp-display-name',
   'mcp-issuer',
+  'name',
   'older-than-sec',
+  'offset',
   'owner-mode',
   'profile',
   'recording-mode',
   'recording-retention-sec',
   'save-token',
   'set-default',
+  'runtime-state',
   'state',
   'template-id',
   'token',
@@ -74,6 +80,10 @@ function usageText() {
     '  bpane session stop <session-id> [options]',
     '  bpane session kill <session-id> [options]',
     '  bpane session cleanup [options]',
+    '  bpane session-template create [template-name] [options]',
+    '  bpane session-template list [options]',
+    '  bpane session-template get <template-id> [options]',
+    '  bpane session-template update <template-id> [options]',
     '  bpane mcp doctor [session-id] [options]',
     '  bpane mcp preflight [session-id] [options]',
     '  bpane mcp repair <session-id> [options]',
@@ -98,7 +108,13 @@ function usageText() {
     '  --mcp-display-name <name> MCP delegate display name. Env: BPANE_MCP_DISPLAY_NAME.',
     '  --body-json <json>        Raw JSON request body for session create.',
     '  --label <key=value>       Repeatable session label filter or create label.',
+    '  --default-label <key=value> Repeatable template default session label.',
+    '  --integration <key=value> Repeatable session integration-context filter.',
     '  --state <state>           Repeatable cleanup state filter. Default: stopped.',
+    '  --runtime-state <state>   Repeatable session runtime-state filter.',
+    '  --template-id <id>        Session template id for create/list filters.',
+    '  --name <name>             Session template name for create/update.',
+    '  --description <text>      Session template description for create/update.',
     '  --cleanup-action <name>   Repeatable cleanup action: revoke-automation-owner, disconnect-all, stop, kill.',
     '  --older-than-sec <sec>    Cleanup age filter based on created_at.',
     '  --limit <count>           Limit filtered session list or cleanup candidates.',
@@ -198,6 +214,18 @@ function parseIntegerOption(options, name) {
   const value = Number.parseInt(raw, 10);
   if (!Number.isSafeInteger(value) || value < 1) {
     throw new CliError('USAGE', `--${name} must be a positive integer.`, EXIT_CODES.usage);
+  }
+  return value;
+}
+
+function parseNonNegativeIntegerOption(options, name) {
+  const raw = getOption(options, name);
+  if (raw === null || raw === '') {
+    return null;
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new CliError('USAGE', `--${name} must be a non-negative integer.`, EXIT_CODES.usage);
   }
   return value;
 }
@@ -379,6 +407,14 @@ function requiredSessionId(positionals, commandLabel) {
     throw new CliError('USAGE', `Usage: bpane ${commandLabel} <session-id>`, EXIT_CODES.usage);
   }
   return sessionId;
+}
+
+function requiredTemplateId(positionals, commandLabel) {
+  const templateId = positionals[2];
+  if (!templateId || positionals.length > 3) {
+    throw new CliError('USAGE', `Usage: bpane ${commandLabel} <template-id>`, EXIT_CODES.usage);
+  }
+  return templateId;
 }
 
 function requireAccessToken(config) {
@@ -604,6 +640,73 @@ function buildCreateSessionRequest(options) {
   return body;
 }
 
+function buildSessionTemplateDefaults(options) {
+  const defaults = {};
+  const ownerMode = getOption(options, 'owner-mode');
+  if (ownerMode) {
+    defaults.owner_mode = ownerMode;
+  }
+  const width = parseIntegerOption(options, 'width');
+  const height = parseIntegerOption(options, 'height');
+  if ((width === null) !== (height === null)) {
+    throw new CliError('USAGE', 'Use --width and --height together.', EXIT_CODES.usage);
+  }
+  if (width !== null && height !== null) {
+    defaults.viewport = { width, height };
+  }
+  const idleTimeoutSec = parseIntegerOption(options, 'idle-timeout-sec');
+  if (idleTimeoutSec !== null) {
+    defaults.idle_timeout_sec = idleTimeoutSec;
+  }
+  const labels = parseKeyValueOptions(options, 'default-label');
+  if (Object.keys(labels).length) {
+    defaults.labels = labels;
+  }
+  const integrationContext = parseJsonOption(options, 'integration-json');
+  if (integrationContext !== null) {
+    defaults.integration_context = integrationContext;
+  }
+  const recordingMode = getOption(options, 'recording-mode');
+  const recordingRetentionSec = parseIntegerOption(options, 'recording-retention-sec');
+  if (recordingMode || recordingRetentionSec !== null) {
+    defaults.recording = {
+      mode: recordingMode ?? 'disabled',
+      format: 'webm',
+      retention_sec: recordingRetentionSec,
+    };
+  }
+  return defaults;
+}
+
+function buildSessionTemplateRequest(options, fallbackName = null) {
+  const rawBody = parseJsonOption(options, 'body-json');
+  if (rawBody !== null) {
+    return rawBody;
+  }
+
+  const name = getOption(options, 'name') ?? fallbackName;
+  if (!name) {
+    throw new CliError(
+      'USAGE',
+      'Session template create/update requires --name or a positional template name.',
+      EXIT_CODES.usage,
+    );
+  }
+  const body = {
+    name,
+    defaults: buildSessionTemplateDefaults(options),
+  };
+  const description = getOption(options, 'description');
+  if (description !== null) {
+    body.description = description;
+  }
+  const labels = parseKeyValueOptions(options, 'label');
+  if (Object.keys(labels).length) {
+    body.labels = labels;
+  }
+  return body;
+}
+
 function sessionStateFilters(options, defaultStates = []) {
   const states = getOptions(options, 'state')
     .flatMap((value) => value.split(','))
@@ -612,15 +715,28 @@ function sessionStateFilters(options, defaultStates = []) {
   return states.length ? states : defaultStates;
 }
 
+function sessionRuntimeStateFilters(options) {
+  return getOptions(options, 'runtime-state')
+    .flatMap((value) => value.split(','))
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
 function sessionFilters(options, defaultStates = []) {
   const olderThanSec = parseIntegerOption(options, 'older-than-sec');
   const limit = parseIntegerOption(options, 'limit');
+  const offset = parseNonNegativeIntegerOption(options, 'offset');
   const labels = parseKeyValueOptions(options, 'label');
+  const integrationContext = parseKeyValueOptions(options, 'integration');
   return {
+    template_id: getOption(options, 'template-id'),
     states: sessionStateFilters(options, defaultStates),
+    runtime_states: sessionRuntimeStateFilters(options),
     labels,
+    integration_context: integrationContext,
     older_than_sec: olderThanSec,
     limit,
+    offset,
   };
 }
 
@@ -629,10 +745,14 @@ function cleanupFilters(options) {
 }
 
 function filtersAreActive(filters) {
-  return filters.states.length > 0
+  return filters.template_id !== null
+    || filters.states.length > 0
+    || filters.runtime_states.length > 0
     || Object.keys(filters.labels).length > 0
+    || Object.keys(filters.integration_context).length > 0
     || filters.older_than_sec !== null
-    || filters.limit !== null;
+    || filters.limit !== null
+    || filters.offset !== null;
 }
 
 function cleanupActions(options) {
@@ -669,14 +789,52 @@ function sessionMatchesLabels(session, labels) {
   return Object.entries(labels).every(([key, value]) => sessionLabels[key] === value);
 }
 
+function sessionMatchesIntegrationContext(session, integrationContext) {
+  const context = session.integration_context ?? {};
+  return Object.entries(integrationContext).every(([key, value]) => context[key] === value);
+}
+
 function filterSessions(sessions, filters) {
   const matched = sessions.filter((session) => {
-    return (!filters.states.length || filters.states.includes(session.state))
+    return (filters.template_id === null || session.template_id === filters.template_id)
+      && (!filters.states.length || filters.states.includes(session.state))
+      && (!filters.runtime_states.length || filters.runtime_states.includes(session.status?.runtime_state))
       && sessionMatchesLabels(session, filters.labels)
+      && sessionMatchesIntegrationContext(session, filters.integration_context)
       && sessionCreatedBefore(session, filters.older_than_sec);
   });
-  const limited = filters.limit === null ? matched : matched.slice(0, filters.limit);
+  const offset = filters.offset ?? 0;
+  const limited = filters.limit === null
+    ? matched.slice(offset)
+    : matched.slice(offset, offset + filters.limit);
   return { matched, limited };
+}
+
+function buildSessionListPath(filters, { includeLimit = true } = {}) {
+  const params = new URLSearchParams();
+  if (filters.template_id) {
+    params.set('template_id', filters.template_id);
+  }
+  if (filters.states.length) {
+    params.set('state', filters.states.join(','));
+  }
+  if (filters.runtime_states.length) {
+    params.set('runtime_state', filters.runtime_states.join(','));
+  }
+  for (const [key, value] of Object.entries(filters.labels)) {
+    params.append(`label.${key}`, value);
+  }
+  for (const [key, value] of Object.entries(filters.integration_context)) {
+    params.append(`integration.${key}`, value);
+  }
+  if (includeLimit && filters.limit !== null) {
+    params.set('limit', String(filters.limit));
+  }
+  if (includeLimit && filters.offset !== null) {
+    params.set('offset', String(filters.offset));
+  }
+  const query = params.toString();
+  return query ? `/api/v1/sessions?${query}` : '/api/v1/sessions';
 }
 
 function sessionSummary(session) {
@@ -1085,8 +1243,15 @@ async function handleSessionCommand(config, positionals, options) {
     });
   }
   if (action === 'list' && positionals.length === 2) {
-    const listed = await requestGateway(config, '/api/v1/sessions');
-    return filteredSessionList(listed, sessionFilters(options));
+    const filters = sessionFilters(options);
+    const listed = await requestGateway(
+      config,
+      buildSessionListPath(filters, { includeLimit: filters.older_than_sec === null }),
+    );
+    if (filters.older_than_sec !== null) {
+      return filteredSessionList(listed, filters);
+    }
+    return listed;
   }
   if (action === 'get') {
     const sessionId = requiredSessionId(positionals, 'session get');
@@ -1139,6 +1304,37 @@ async function handleSessionCommand(config, positionals, options) {
     return await cleanupSessions(config, options);
   }
   throw new CliError('USAGE', `Unknown session command: ${action ?? ''}`.trim(), EXIT_CODES.usage);
+}
+
+async function handleSessionTemplateCommand(config, positionals, options) {
+  const action = positionals[1];
+  if (action === 'create' && positionals.length <= 3) {
+    return await requestGateway(config, '/api/v1/session-templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildSessionTemplateRequest(options, positionals[2] ?? null)),
+    });
+  }
+  if (action === 'list' && positionals.length === 2) {
+    return await requestGateway(config, '/api/v1/session-templates');
+  }
+  if (action === 'get') {
+    const templateId = requiredTemplateId(positionals, 'session-template get');
+    return await requestGateway(config, `/api/v1/session-templates/${encodeURIComponent(templateId)}`);
+  }
+  if (action === 'update') {
+    const templateId = requiredTemplateId(positionals, 'session-template update');
+    return await requestGateway(config, `/api/v1/session-templates/${encodeURIComponent(templateId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildSessionTemplateRequest(options)),
+    });
+  }
+  throw new CliError(
+    'USAGE',
+    `Unknown session-template command: ${action ?? ''}`.trim(),
+    EXIT_CODES.usage,
+  );
 }
 
 async function handleMcpCommand(config, positionals, options) {
@@ -1358,6 +1554,9 @@ export async function runBpaneCli(argv, env = process.env, io = process, fetchIm
     } else if (scope === 'session') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleSessionCommand(config, positionals, options);
+    } else if (scope === 'session-template') {
+      const config = await buildConfig(options, env, fetchImpl);
+      result = await handleSessionTemplateCommand(config, positionals, options);
     } else if (scope === 'mcp') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleMcpCommand(config, positionals, options);

--- a/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
@@ -66,6 +66,7 @@ async function verifyCompactPayloadToggle(page, options, template) {
   await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
   await openAdminTab(page, 'sessions');
   await selectSessionTemplate(page, template, options);
+  await assertNoHorizontalOverflow(page, 'session-create-configurator', 'live session create configurator');
   const templateSummary = await page.getByTestId('session-create-template-summary').textContent();
   if (!templateSummary?.includes(template.name) || !templateSummary.includes('team=support')) {
     throw new Error(`Expected live configurator template summary for ${template.name}, got ${templateSummary}`);
@@ -102,6 +103,16 @@ async function verifyClientValidation(page) {
   const errorText = await page.getByTestId('session-create-error').textContent();
   if (!errorText?.includes('Idle timeout') || !errorText.includes('duplicated')) {
     throw new Error(`Expected validation errors for idle timeout and duplicate labels, got ${errorText}`);
+  }
+}
+
+async function assertNoHorizontalOverflow(page, testId, label) {
+  const size = await page.getByTestId(testId).evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+  }));
+  if (size.scrollWidth > size.clientWidth + 1) {
+    throw new Error(`${label} overflows horizontally: ${JSON.stringify(size)}`);
   }
 }
 

--- a/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
@@ -45,7 +45,7 @@ async function run() {
     });
 
     await verifyClientValidation(page);
-    await configureCollaborativeSession(page, options, template);
+    await configureTemplatedSession(page, options, template);
     await verifyPayloadPreview(page, template);
     await page.getByTestId('session-inspector-new').click();
     sessionId = await waitForSessionDetailUrl(page, options);
@@ -81,6 +81,9 @@ async function verifyCompactPayloadToggle(page, options, template) {
   if (preview.template_id !== template.id) {
     throw new Error(`Expected live configurator preview to include template_id ${template.id}, got ${previewText}`);
   }
+  if (Object.hasOwn(preview, 'owner_mode')) {
+    throw new Error(`Expected template default owner mode to remain unoverridden, got ${previewText}`);
+  }
   await page.waitForTimeout(1500);
   const stillVisible = await page.getByTestId('session-create-preview').isVisible().catch(() => false);
   if (!stillVisible) {
@@ -102,10 +105,11 @@ async function verifyClientValidation(page) {
   }
 }
 
-async function configureCollaborativeSession(page, options, template) {
+async function configureTemplatedSession(page, options, template) {
   await selectSessionTemplate(page, template, options);
   await page.getByTestId('session-create-owner-mode').selectOption('collaborative');
-  await page.getByTestId('session-create-idle-timeout').fill('1800');
+  await page.getByTestId('session-create-owner-mode').selectOption('');
+  await page.getByTestId('session-create-idle-timeout').fill('');
   await page.getByTestId('session-create-labels').fill('case=1234\npurpose=import-repro');
 }
 
@@ -115,8 +119,8 @@ async function verifyPayloadPreview(page, template) {
   const expectedLabels = { case: '1234', purpose: 'import-repro' };
   if (
     preview.template_id !== template.id
-    || preview.owner_mode !== 'collaborative'
-    || preview.idle_timeout_sec !== 1800
+    || Object.hasOwn(preview, 'owner_mode')
+    || Object.hasOwn(preview, 'idle_timeout_sec')
     || JSON.stringify(preview.labels) !== JSON.stringify(expectedLabels)
   ) {
     throw new Error(`Unexpected session create payload preview: ${previewText}`);
@@ -140,7 +144,7 @@ async function verifyDetailUi(page, options, sessionId, template) {
   const integration = await page.getByTestId('session-integration-context').textContent();
   if (
     ownerMode !== 'collaborative'
-    || idleTimeout !== '1800'
+    || idleTimeout !== '1200'
     || !detailTemplate?.includes(template.name)
     || !labels?.includes('purpose=import-repro')
     || !labels.includes('team=support')
@@ -190,8 +194,8 @@ function verifyCreatedSession(session, sessionId, template) {
   if (session.owner_mode !== 'collaborative') {
     throw new Error(`Expected collaborative owner mode, got ${session.owner_mode}`);
   }
-  if (session.idle_timeout_sec !== 1800) {
-    throw new Error(`Expected idle timeout 1800, got ${session.idle_timeout_sec}`);
+  if (session.idle_timeout_sec !== 1200) {
+    throw new Error(`Expected template idle timeout 1200, got ${session.idle_timeout_sec}`);
   }
   if (session.labels?.case !== '1234' || session.labels?.purpose !== 'import-repro' || session.labels?.team !== 'support') {
     throw new Error(`Expected configured labels, got ${JSON.stringify(session.labels)}`);

--- a/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
@@ -15,6 +15,7 @@ import {
   fetchJson,
   launchChrome,
   parseSmokeArgs,
+  poll,
 } from './workflow-smoke-lib.mjs';
 
 async function run() {
@@ -27,13 +28,15 @@ async function run() {
   const context = await browser.newContext({ viewport: { width: 1440, height: 980 } });
   const page = await context.newPage();
   let sessionId = '';
+  let template = null;
 
   try {
     log(`Opening ${options.pageUrl}`);
     await ensureAdminLoggedIn(page, options);
     await cleanupAdminBeforeRun(page, options, log);
+    template = await createSessionTemplate(page, options);
 
-    await verifyCompactPayloadToggle(page, options);
+    await verifyCompactPayloadToggle(page, options, template);
 
     await page.goto(adminRouteUrl(options, 'sessions'), { waitUntil: 'domcontentloaded' });
     await page.getByTestId('session-create-configurator').waitFor({
@@ -42,15 +45,16 @@ async function run() {
     });
 
     await verifyClientValidation(page);
-    await configureCollaborativeSession(page);
-    await verifyPayloadPreview(page);
+    await configureCollaborativeSession(page, options, template);
+    await verifyPayloadPreview(page, template);
     await page.getByTestId('session-inspector-new').click();
     sessionId = await waitForSessionDetailUrl(page, options);
 
     const session = await fetchSession(page, options, sessionId);
-    verifyCreatedSession(session, sessionId);
-    await verifyDetailUi(page, options, sessionId);
-    await emitSummary(page, options, session, log);
+    verifyCreatedSession(session, sessionId, template);
+    await verifyDetailUi(page, options, sessionId, template);
+    await verifyInspectorTemplateFilter(page, options, sessionId, template);
+    await emitSummary(page, options, session, template, log);
   } finally {
     await cleanupCreatedSession(page, options, sessionId, log);
     await context.close();
@@ -58,15 +62,25 @@ async function run() {
   }
 }
 
-async function verifyCompactPayloadToggle(page, options) {
+async function verifyCompactPayloadToggle(page, options, template) {
   await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
   await openAdminTab(page, 'sessions');
+  await selectSessionTemplate(page, template, options);
+  const templateSummary = await page.getByTestId('session-create-template-summary').textContent();
+  if (!templateSummary?.includes(template.name) || !templateSummary.includes('team=support')) {
+    throw new Error(`Expected live configurator template summary for ${template.name}, got ${templateSummary}`);
+  }
   const toggle = page.getByTestId('session-create-preview-toggle');
   await toggle.click();
   await page.getByTestId('session-create-preview').waitFor({
     state: 'visible',
     timeout: options.connectTimeoutMs,
   });
+  const previewText = await page.getByTestId('session-create-preview').textContent();
+  const preview = JSON.parse(previewText ?? '{}');
+  if (preview.template_id !== template.id) {
+    throw new Error(`Expected live configurator preview to include template_id ${template.id}, got ${previewText}`);
+  }
   await page.waitForTimeout(1500);
   const stillVisible = await page.getByTestId('session-create-preview').isVisible().catch(() => false);
   if (!stillVisible) {
@@ -88,18 +102,20 @@ async function verifyClientValidation(page) {
   }
 }
 
-async function configureCollaborativeSession(page) {
+async function configureCollaborativeSession(page, options, template) {
+  await selectSessionTemplate(page, template, options);
   await page.getByTestId('session-create-owner-mode').selectOption('collaborative');
   await page.getByTestId('session-create-idle-timeout').fill('1800');
   await page.getByTestId('session-create-labels').fill('case=1234\npurpose=import-repro');
 }
 
-async function verifyPayloadPreview(page) {
+async function verifyPayloadPreview(page, template) {
   const previewText = await page.getByTestId('session-create-preview').textContent();
   const preview = JSON.parse(previewText ?? '{}');
   const expectedLabels = { case: '1234', purpose: 'import-repro' };
   if (
-    preview.owner_mode !== 'collaborative'
+    preview.template_id !== template.id
+    || preview.owner_mode !== 'collaborative'
     || preview.idle_timeout_sec !== 1800
     || JSON.stringify(preview.labels) !== JSON.stringify(expectedLabels)
   ) {
@@ -107,7 +123,7 @@ async function verifyPayloadPreview(page) {
   }
 }
 
-async function verifyDetailUi(page, options, sessionId) {
+async function verifyDetailUi(page, options, sessionId, template) {
   await page.getByTestId('session-inspector-detail').waitFor({
     state: 'visible',
     timeout: options.connectTimeoutMs,
@@ -119,16 +135,57 @@ async function verifyDetailUi(page, options, sessionId) {
   await page.getByTestId('session-owner-mode').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   const ownerMode = await page.getByTestId('session-owner-mode').textContent();
   const idleTimeout = await page.getByTestId('session-idle-timeout').textContent();
+  const detailTemplate = await page.getByTestId('session-template').textContent();
   const labels = await page.getByTestId('session-labels').textContent();
-  if (ownerMode !== 'collaborative' || idleTimeout !== '1800' || !labels?.includes('purpose=import-repro')) {
-    throw new Error(`Unexpected configured session detail facts: ${ownerMode} / ${idleTimeout} / ${labels}`);
+  const integration = await page.getByTestId('session-integration-context').textContent();
+  if (
+    ownerMode !== 'collaborative'
+    || idleTimeout !== '1800'
+    || !detailTemplate?.includes(template.name)
+    || !labels?.includes('purpose=import-repro')
+    || !labels.includes('team=support')
+    || !integration?.includes('source=admin-smoke-template')
+  ) {
+    throw new Error(`Unexpected configured session detail facts: ${ownerMode} / ${idleTimeout} / ${detailTemplate} / ${labels} / ${integration}`);
   }
   await page.getByTestId('session-file-bindings').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
 }
 
-function verifyCreatedSession(session, sessionId) {
+async function verifyInspectorTemplateFilter(page, options, sessionId, template) {
+  await page.goto(adminRouteUrl(options, 'sessions'), { waitUntil: 'domcontentloaded' });
+  await page.getByTestId('session-inspector-list').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  await selectOptionWhenAvailable(page, page.getByTestId('session-inspector-template-filter'), template.id, options);
+  const row = page.locator(`[data-testid="session-inspector-row"][data-session-id="${sessionId}"]`);
+  await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  const rowTemplate = await row.getByTestId('session-inspector-row-template').textContent();
+  if (!rowTemplate?.includes(template.name)) {
+    throw new Error(`Expected inspector row template ${template.name}, got ${rowTemplate}`);
+  }
+  const count = await page.getByTestId('session-inspector-count').textContent();
+  if (!count?.includes('visible sessions')) {
+    throw new Error(`Expected inspector filter count to be visible, got ${count}`);
+  }
+
+  await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
+  await openAdminTab(page, 'sessions');
+  const liveRow = page.locator(`[data-testid="session-row"][data-session-id="${sessionId}"]`);
+  await liveRow.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await liveRow.click();
+  const selectedTemplate = await page.getByTestId('session-selected-template').textContent();
+  if (!selectedTemplate?.includes(template.name)) {
+    throw new Error(`Expected live selected session template ${template.name}, got ${selectedTemplate}`);
+  }
+}
+
+function verifyCreatedSession(session, sessionId, template) {
   if (session.id !== sessionId) {
     throw new Error(`Expected API session ${sessionId}, got ${session.id}`);
+  }
+  if (session.template_id !== template.id) {
+    throw new Error(`Expected template_id ${template.id}, got ${session.template_id}`);
   }
   if (session.owner_mode !== 'collaborative') {
     throw new Error(`Expected collaborative owner mode, got ${session.owner_mode}`);
@@ -136,9 +193,52 @@ function verifyCreatedSession(session, sessionId) {
   if (session.idle_timeout_sec !== 1800) {
     throw new Error(`Expected idle timeout 1800, got ${session.idle_timeout_sec}`);
   }
-  if (session.labels?.case !== '1234' || session.labels?.purpose !== 'import-repro') {
+  if (session.labels?.case !== '1234' || session.labels?.purpose !== 'import-repro' || session.labels?.team !== 'support') {
     throw new Error(`Expected configured labels, got ${JSON.stringify(session.labels)}`);
   }
+  if (session.integration_context?.source !== 'admin-smoke-template') {
+    throw new Error(`Expected template integration context, got ${JSON.stringify(session.integration_context)}`);
+  }
+}
+
+async function createSessionTemplate(page, options) {
+  const accessToken = await getAdminAccessToken(page);
+  const name = `Admin smoke template ${Date.now()}`;
+  return await fetchJson(`${apiOrigin(options)}/api/v1/session-templates`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      name,
+      description: 'Admin configurator smoke template',
+      labels: { suite: 'admin-session-configurator-smoke' },
+      defaults: {
+        owner_mode: 'collaborative',
+        idle_timeout_sec: 1200,
+        labels: { team: 'support' },
+        integration_context: { source: 'admin-smoke-template' },
+      },
+    }),
+  });
+}
+
+async function selectSessionTemplate(page, template, options) {
+  const selector = page.getByTestId('session-create-template');
+  await selectOptionWhenAvailable(page, selector, template.id, options);
+}
+
+async function selectOptionWhenAvailable(page, selector, value, options) {
+  await selector.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await poll(
+    `select option ${value}`,
+    async () => await selector.locator(`option[value="${value}"]`).count(),
+    (count) => count > 0,
+    options.connectTimeoutMs,
+    100,
+  );
+  await selector.selectOption(value);
 }
 
 async function fetchSession(page, options, sessionId) {
@@ -169,10 +269,12 @@ async function waitForSessionDetailUrl(page, options) {
   return sessionId;
 }
 
-async function emitSummary(page, options, session, log) {
+async function emitSummary(page, options, session, template, log) {
   const summary = {
     pageUrl: options.pageUrl,
     sessionId: session.id,
+    templateId: template.id,
+    templateName: template.name,
     ownerMode: session.owner_mode,
     idleTimeoutSec: session.idle_timeout_sec,
     labels: session.labels ?? {},

--- a/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
@@ -88,17 +88,94 @@ async function run() {
       throw new Error('CLI profile show did not return the smoke profile.');
     }
 
+    const template = runBpaneCli([
+      'session-template',
+      'create',
+      `customer-debug-${runLabel}`,
+      '--description',
+      'Operator CLI smoke template',
+      '--label',
+      'suite=bpane-cli-smoke',
+      '--default-label',
+      'team=support',
+      '--default-label',
+      'purpose=debug',
+      '--owner-mode',
+      'collaborative',
+      '--idle-timeout-sec',
+      '1800',
+      '--integration-json',
+      JSON.stringify({ source: 'bpane-cli-smoke-template' }),
+      '--recording-mode',
+      'manual',
+      '--recording-retention-sec',
+      '86400',
+    ], cliEnv);
+    const templateId = template.id;
+    if (!templateId || template.version !== 1) {
+      throw new Error(`CLI session-template create returned an invalid template: ${JSON.stringify(template)}`);
+    }
+
+    const listedTemplates = runBpaneCli(['session-template', 'list'], cliEnv);
+    if (!Array.isArray(listedTemplates.templates) || !listedTemplates.templates.some((item) => item.id === templateId)) {
+      throw new Error(`CLI session-template list did not include ${templateId}.`);
+    }
+
+    const fetchedTemplate = runBpaneCli(['session-template', 'get', templateId], cliEnv);
+    if (fetchedTemplate.id !== templateId || fetchedTemplate.defaults?.labels?.team !== 'support') {
+      throw new Error(`CLI session-template get returned unexpected template data: ${JSON.stringify(fetchedTemplate)}`);
+    }
+
+    const updatedTemplate = runBpaneCli([
+      'session-template',
+      'update',
+      templateId,
+      '--name',
+      `customer-debug-${runLabel}`,
+      '--description',
+      'Operator CLI smoke template updated',
+      '--default-label',
+      'team=support',
+      '--default-label',
+      'purpose=debug',
+      '--default-label',
+      'tier=gold',
+      '--idle-timeout-sec',
+      '1800',
+      '--recording-mode',
+      'manual',
+      '--recording-retention-sec',
+      '86400',
+    ], cliEnv);
+    if (updatedTemplate.id !== templateId || updatedTemplate.version !== 2 || updatedTemplate.defaults?.labels?.tier !== 'gold') {
+      throw new Error(`CLI session-template update did not increment the template version: ${JSON.stringify(updatedTemplate)}`);
+    }
+
     const created = runBpaneCli([
       'session',
       'create',
+      '--template-id',
+      templateId,
       '--label',
       'suite=bpane-cli-smoke',
       '--label',
       `run_id=${runLabel}`,
+      '--integration-json',
+      JSON.stringify({ ticket: runLabel }),
     ], cliEnv);
     sessionId = created.id;
     if (!sessionId) {
       throw new Error('CLI session create did not return an id.');
+    }
+    if (
+      created.template_id !== templateId
+      || created.labels?.team !== 'support'
+      || created.labels?.tier !== 'gold'
+      || created.labels?.run_id !== runLabel
+      || created.integration_context?.ticket !== runLabel
+      || created.recording?.mode !== 'manual'
+    ) {
+      throw new Error(`CLI session create did not apply template defaults: ${JSON.stringify(created)}`);
     }
 
     const listed = runBpaneCli(['session', 'list'], cliEnv);
@@ -106,8 +183,21 @@ async function run() {
       throw new Error(`CLI session list did not include ${sessionId}.`);
     }
 
-    const filteredList = runBpaneCli(['session', 'list', '--label', `run_id=${runLabel}`, '--limit', '1'], cliEnv);
-    if (filteredList.returned_count !== 1 || filteredList.sessions?.[0]?.id !== sessionId) {
+    const filteredList = runBpaneCli([
+      'session',
+      'list',
+      '--template-id',
+      templateId,
+      '--label',
+      `run_id=${runLabel}`,
+      '--integration',
+      `ticket=${runLabel}`,
+      '--runtime-state',
+      'not_started',
+      '--limit',
+      '1',
+    ], cliEnv);
+    if (!Array.isArray(filteredList.sessions) || filteredList.sessions.length !== 1 || filteredList.sessions[0]?.id !== sessionId) {
       throw new Error('CLI filtered session list did not return the smoke session.');
     }
 

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -4,9 +4,9 @@ info:
   version: 1.0.0
   description: >
     Frozen v1 owner-scoped BrowserPane control-plane contract. This document
-    covers the canonical `/api/v1` surfaces for sessions, automation tasks,
-    recordings, workflows, reusable files, credentials, approved extensions, and
-    admin realtime snapshots. Legacy global compatibility routes such as
+    covers the canonical `/api/v1` surfaces for sessions, session templates,
+    automation tasks, recordings, workflows, reusable files, credentials,
+    approved extensions, and admin realtime snapshots. Legacy global compatibility routes such as
     `/api/session/status` and `/api/session/mcp-owner` are intentionally excluded
     from this freeze and remain transitional.
 servers:
@@ -17,6 +17,7 @@ servers:
 tags:
   - name: Admin Events
   - name: Sessions
+  - name: Session Templates
   - name: Session Runtime
   - name: Session Recordings
   - name: Session Files
@@ -55,6 +56,51 @@ paths:
       tags: [Sessions]
       summary: List sessions visible to the authenticated owner or delegated automation principal
       operationId: listSessions
+      parameters:
+        - name: template_id
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Return only sessions created with the given template id.
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Comma-separated lifecycle states to include.
+        - name: runtime_state
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Comma-separated derived runtime states to include.
+        - name: label.<key>
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Dynamic label equality filter, for example `label.team=support`.
+        - name: integration.<key>
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Dynamic top-level integration-context string equality filter.
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          description: Maximum number of returned sessions after filtering.
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+          description: Number of matching sessions to skip after filtering.
       responses:
         '200':
           description: Owner-scoped session list
@@ -87,6 +133,94 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/session-templates:
+    get:
+      tags: [Session Templates]
+      summary: List owner-scoped session templates
+      operationId: listSessionTemplates
+      responses:
+        '200':
+          description: Owner-scoped session template list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplateListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    post:
+      tags: [Session Templates]
+      summary: Create an owner-scoped session template
+      operationId: createSessionTemplate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertSessionTemplateRequest'
+      responses:
+        '201':
+          description: Session template created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplateResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/session-templates/{template_id}:
+    parameters:
+      - $ref: '#/components/parameters/SessionTemplateId'
+    get:
+      tags: [Session Templates]
+      summary: Fetch one owner-scoped session template
+      operationId: getSessionTemplate
+      responses:
+        '200':
+          description: Session template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplateResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    put:
+      tags: [Session Templates]
+      summary: Replace one owner-scoped session template and increment its version
+      operationId: updateSessionTemplate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertSessionTemplateRequest'
+      responses:
+        '200':
+          description: Updated session template
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionTemplateResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
         '503':
@@ -2114,6 +2248,13 @@ components:
   parameters:
     SessionId:
       name: session_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    SessionTemplateId:
+      name: template_id
       in: path
       required: true
       schema:
@@ -4517,6 +4658,89 @@ components:
             format: uuid
         recording:
           $ref: '#/components/schemas/SessionRecordingPolicy'
+    SessionTemplateDefaults:
+      type: object
+      additionalProperties: false
+      properties:
+        owner_mode:
+          $ref: '#/components/schemas/SessionOwnerMode'
+        viewport:
+          $ref: '#/components/schemas/SessionViewport'
+        idle_timeout_sec:
+          type: integer
+          minimum: 1
+          nullable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        integration_context:
+          type: object
+          nullable: true
+          additionalProperties: true
+        recording:
+          allOf:
+            - $ref: '#/components/schemas/SessionRecordingPolicy'
+          nullable: true
+    UpsertSessionTemplateRequest:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        defaults:
+          $ref: '#/components/schemas/SessionTemplateDefaults'
+    SessionTemplateResource:
+      type: object
+      required:
+        - id
+        - name
+        - description
+        - labels
+        - defaults
+        - version
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        defaults:
+          $ref: '#/components/schemas/SessionTemplateDefaults'
+        version:
+          type: integer
+          minimum: 1
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SessionTemplateListResponse:
+      type: object
+      required: [templates]
+      properties:
+        templates:
+          type: array
+          items:
+            $ref: '#/components/schemas/SessionTemplateResource'
     SessionListResponse:
       type: object
       required: [sessions]


### PR DESCRIPTION
## Summary

- add owner-scoped session template resources, persistence, API routes, and template-default resolution during session creation
- add metadata-aware session catalog filters for template id, state, runtime state, labels, integration context, limit, and offset
- wire templates through CLI, OpenAPI/docs, and the admin app create/list/detail surfaces
- keep admin create payloads aligned with template semantics: template/default fields are omitted unless explicitly overridden
- fix the admin operations overlay session configurator so it fits the overlay width

Closes #24.

Follow-up: #124 tracks admin-side session template catalog management UX, including create/edit/duplicate/archive and richer validation.

## Validation

- `cargo test -p bpane-gateway api::tests::session_templates -- --nocapture`
- `cargo test -p bpane-gateway session_control::tests::validation -- --nocapture`
- `cargo test -p bpane-gateway --test compose_api_surface compose_session_templates_catalog_api_surface -- --ignored --nocapture`
- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npm test`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && npm run bpane:cli -- --help`
- `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless --connect-timeout-ms 60000`
- `cd code/web/bpane-client && npm run smoke:admin-session-configurator -- --headless --connect-timeout-ms 60000`
- `cd code/web/bpane-client && npm run smoke:admin-session-detail -- --headless --connect-timeout-ms 60000`
- `cd code/web/bpane-client && npm run smoke:admin-session -- --headless --connect-timeout-ms 60000`