### PR TITLE
Harden egress proxy auth validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ Current product shape:
   - The gateway is configured to auto-launch workflow workers against the `deploy-workflow-worker` image on the compose network. Build that image before workflow-run smoke tests or local workflow execution.
   - The gateway mounts the repo at `/workspace:ro` so local git-backed workflow sources can be resolved and materialized during development smokes.
 - `deploy/examples/egress-observer`
-  - Local egress observation fixtures. `compose.yml` runs a metadata-only Squid forward proxy at `bpane-egress-observer:3128`. `compose.tls.yml` runs a mitmproxy TLS-intercept proxy at `bpane-egress-tls-observer:3129` using local CA material prepared by `prepare-mitmproxy-ca.sh`.
+  - Local egress observation fixtures. `compose.yml` runs a metadata-only Squid forward proxy at `bpane-egress-observer:3128` and an auth-enforcing Squid proxy at `bpane-egress-auth-observer:3130` for proxy-auth validation. `compose.tls.yml` runs a mitmproxy TLS-intercept proxy at `bpane-egress-tls-observer:3129` using local CA material prepared by `prepare-mitmproxy-ca.sh`.
 
 ## Protocol and media facts
 

--- a/ARCH.md
+++ b/ARCH.md
@@ -543,11 +543,13 @@ The supported local operator CLI lives in
   and automation-access minting, connection disconnect, stop, kill, and bounded
   cleanup. Egress-profile create/update commands can attach a proxy-auth
   credential binding with `--proxy-credential-binding-id`.
-- `deploy/examples/egress-observer` provides a local Squid forward-proxy
-  example for metadata-only access-log observation and session/container IP
-  correlation, plus a mitmproxy TLS-intercept fixture for local inspection
-  checks with an explicit custom CA and sensitive-log sink. On localhost, the
-  admin app auto-creates owner-scoped local presets for both proxy variants.
+- `deploy/examples/egress-observer` provides local Squid forward-proxy
+  examples for metadata-only access-log observation, session/container IP
+  correlation, and authenticated proxy validation, plus a mitmproxy
+  TLS-intercept fixture for local inspection checks with an explicit custom CA
+  and sensitive-log sink. On localhost, the admin app auto-creates
+  owner-scoped local presets for the unauthenticated proxy and TLS-intercept
+  variants.
 - MCP commands cover health, authorize, revoke, set-default, clear-default,
   doctor, preflight, and repair.
 - `mcp repair` applies missing automation delegation and bridge default-session

--- a/README.md
+++ b/README.md
@@ -330,10 +330,13 @@ references, state, labels, and sanitized effective status; session resources,
 effective egress summary, and sanitized diagnostics without embedding proxy
 credentials or raw CA material. Diagnostics distinguish
 configuration-only evidence, runtime launch metadata, and the latest active
-browser probe. The active probe runs only against an already-ready session
+profile or browser probe. Egress-profile probes perform a real proxy request
+and, when a proxy credential binding is configured, resolve the binding only for
+that probe so operators can see whether proxy authentication succeeds or is
+rejected. The active browser probe runs only against an already-ready session
 runtime and stores sanitized public-IP, TLS issuer, and failure summary fields;
-it does not store requested URLs, headers, proxy credentials, CA material, or
-decrypted traffic.
+diagnostics do not store requested URLs, headers, proxy credentials, CA
+material, or decrypted traffic.
 Egress-side communication tracking belongs at the configured proxy or secure
 web gateway. BrowserPane emits safe correlation metadata instead: docker-backed
 runtime containers carry `browserpane.session_id` and egress-profile labels,
@@ -350,7 +353,8 @@ trust store before launch; non-file CA providers remain a provider-integration
 follow-up. If `proxy.credential_binding_id` is set, the gateway resolves the
 owner-visible credential binding through the configured secret provider at
 runtime launch and writes only a session-local proxy-auth file; credentials are
-not embedded in proxy URLs, API responses, Docker labels, or normal logs.
+not embedded in proxy URLs, API responses, CLI output, Docker labels, or normal
+logs.
 Browser context resources let callers name owner-scoped Chromium profile
 contexts and bind new sessions with `browser_context.mode=reusable` plus a
 `context_id`. Docker-backed runtimes materialize reusable contexts as a
@@ -588,8 +592,8 @@ name the sensitive-log sink:
 ```
 
 To observe egress traffic locally without changing the BrowserPane gateway,
-start the normal compose stack first, then start the example forward proxy and
-point an egress profile at it:
+start the normal compose stack first, then start the example forward proxies and
+point an egress profile at one of them:
 
 ```bash
 docker compose -f deploy/examples/egress-observer/compose.yml up --build
@@ -600,6 +604,15 @@ docker compose -f deploy/examples/egress-observer/compose.yml up --build
 docker compose -f deploy/examples/egress-observer/compose.yml logs -f egress-proxy
 deploy/examples/egress-observer/correlate-session-ip.sh
 ```
+
+The same compose file also starts an authenticated Squid fixture at
+`bpane-egress-auth-observer:3130` with local test credentials
+`proxy-user / proxy-pass`. Create a credential binding through the admin app or
+`POST /api/v1/credential-bindings`, attach its id with
+`--proxy-credential-binding-id`, and run
+`./scripts/bpane egress-profile diagnostics probe <egress-profile-id>` to prove
+the proxy accepts the binding. Bad credentials or unavailable secret backends
+surface as sanitized diagnostics instead of returning the secret value.
 
 For local HTTPS interception, run the mitmproxy-backed observer alongside the
 plain Squid observer:

--- a/code/apps/bpane-gateway/src/api/egress_profiles.rs
+++ b/code/apps/bpane-gateway/src/api/egress_profiles.rs
@@ -1,8 +1,8 @@
 use std::time::Duration as StdDuration;
 
 use axum::routing::{get, post};
-use reqwest::Url;
-use tokio::net::TcpStream;
+use reqwest::{redirect::Policy as RedirectPolicy, Proxy, Url};
+use serde::Deserialize;
 
 use super::*;
 
@@ -10,6 +10,7 @@ const DEFAULT_PROFILE_REACHABILITY_TIMEOUT_MS: u64 = 5_000;
 const MIN_PROFILE_REACHABILITY_TIMEOUT_MS: u64 = 250;
 const MAX_PROFILE_REACHABILITY_TIMEOUT_MS: u64 = 30_000;
 const MAX_PROFILE_REACHABILITY_FAILURE_LEN: usize = 360;
+const PROFILE_REACHABILITY_PROBE_URL: &str = "http://example.com/";
 
 pub(super) fn egress_profile_routes() -> Router<Arc<ApiState>> {
     Router::new()
@@ -183,7 +184,7 @@ async fn run_egress_profile_reachability_probe(
             )
         })?;
     let timeout = profile_reachability_timeout(payload.map(|value| value.0).unwrap_or_default())?;
-    let result = run_profile_reachability(&profile, timeout).await;
+    let result = run_profile_reachability(&state, &principal, &profile, timeout).await;
     let stored = state
         .session_store
         .upsert_egress_profile_reachability_probe_result(result)
@@ -293,13 +294,18 @@ fn profile_reachability_timeout(
 }
 
 async fn run_profile_reachability(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
     profile: &StoredEgressProfile,
     timeout: StdDuration,
 ) -> PersistEgressProfileReachabilityProbeResult {
     let observed_at = Utc::now();
-    let result = match profile.proxy.as_ref() {
-        Some(proxy) => probe_proxy_authority(&proxy.url, timeout).await,
-        None => Ok(()),
+    let result = match resolve_profile_proxy_auth(state, principal, profile).await {
+        Ok(proxy_auth) => match profile.proxy.as_ref() {
+            Some(proxy) => probe_proxy_request(&proxy.url, proxy_auth.as_ref(), timeout).await,
+            None => Ok(()),
+        },
+        Err(error) => Err(error),
     };
 
     match result {
@@ -320,25 +326,103 @@ async fn run_profile_reachability(
     }
 }
 
-async fn probe_proxy_authority(proxy_url: &str, timeout: StdDuration) -> Result<(), String> {
+#[derive(Debug, Clone, Deserialize)]
+struct ProfileProxyAuthSecret {
+    username: String,
+    password: String,
+}
+
+async fn resolve_profile_proxy_auth(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    profile: &StoredEgressProfile,
+) -> Result<Option<ProfileProxyAuthSecret>, String> {
+    let Some(binding_id) = profile
+        .proxy
+        .as_ref()
+        .and_then(|proxy| proxy.credential_binding_id)
+    else {
+        return Ok(None);
+    };
+    let Some(provider) = state.credential_provider.as_ref() else {
+        return Err("proxy auth credential provider unavailable".to_string());
+    };
+    let binding = state
+        .session_store
+        .get_credential_binding_for_owner(principal, binding_id)
+        .await
+        .map_err(|error| {
+            format!("proxy auth credential binding lookup failed for {binding_id}: {error}")
+        })?
+        .ok_or_else(|| {
+            format!("proxy auth credential binding {binding_id} is no longer available")
+        })?;
+    let secret = provider
+        .resolve_secret(&binding.external_ref)
+        .await
+        .map_err(|error| {
+            format!("proxy auth credential binding {binding_id} could not be resolved: {error}")
+        })?;
+    let payload: ProfileProxyAuthSecret = serde_json::from_value(secret.payload).map_err(|_| {
+        "proxy auth credential payload must include username and password strings".to_string()
+    })?;
+    if payload.username.trim().is_empty() || payload.password.trim().is_empty() {
+        return Err(
+            "proxy auth credential payload username and password must not be empty".to_string(),
+        );
+    }
+    if payload.username.contains(['\r', '\n']) || payload.password.contains(['\r', '\n']) {
+        return Err(
+            "proxy auth credential payload username and password must be single-line values"
+                .to_string(),
+        );
+    }
+    Ok(Some(payload))
+}
+
+async fn probe_proxy_request(
+    proxy_url: &str,
+    proxy_auth: Option<&ProfileProxyAuthSecret>,
+    timeout: StdDuration,
+) -> Result<(), String> {
     let url = Url::parse(proxy_url.trim())
         .map_err(|error| format!("proxy url could not be parsed: {error}"))?;
-    let host = url
-        .host_str()
-        .ok_or_else(|| "proxy url did not include a host".to_string())?;
-    let port = url.port_or_known_default().ok_or_else(|| {
+    if url.host_str().is_none() {
+        return Err("proxy url did not include a host".to_string());
+    }
+    url.port_or_known_default().ok_or_else(|| {
         "proxy url did not include a port and no default port is known".to_string()
     })?;
 
-    tokio::time::timeout(timeout, TcpStream::connect((host, port)))
+    let mut proxy = Proxy::all(proxy_url.trim())
+        .map_err(|error| format!("proxy request configuration failed: {error}"))?;
+    if let Some(auth) = proxy_auth {
+        proxy = proxy.basic_auth(&auth.username, &auth.password);
+    }
+    let client = reqwest::Client::builder()
+        .timeout(timeout)
+        .redirect(RedirectPolicy::none())
+        .proxy(proxy)
+        .build()
+        .map_err(|error| format!("proxy request client could not be built: {error}"))?;
+    let response = tokio::time::timeout(timeout, client.get(PROFILE_REACHABILITY_PROBE_URL).send())
         .await
-        .map_err(|_| {
-            format!(
-                "proxy TCP connection timed out after {}ms",
-                timeout.as_millis()
-            )
-        })?
-        .map_err(|error| format!("proxy TCP connection failed: {error}"))?;
+        .map_err(|_| format!("proxy request timed out after {}ms", timeout.as_millis()))?
+        .map_err(|error| format!("proxy request failed: {error}"))?;
+    if response.status() == reqwest::StatusCode::PROXY_AUTHENTICATION_REQUIRED {
+        return Err("proxy authentication was required or credentials were rejected".to_string());
+    }
+    if !response.status().is_success() {
+        let availability_hint = if response.status().is_server_error() {
+            "proxy or upstream target was unavailable"
+        } else {
+            "proxy or upstream target rejected the request"
+        };
+        return Err(format!(
+            "proxy request returned HTTP {}; {availability_hint}",
+            response.status().as_u16(),
+        ));
+    }
     Ok(())
 }
 

--- a/code/apps/bpane-gateway/src/api/sessions/egress_diagnostics.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/egress_diagnostics.rs
@@ -1,10 +1,13 @@
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::time::Duration as StdDuration;
 
 use chrono::DateTime;
 use futures_util::{SinkExt, StreamExt};
-use reqwest::Url;
+use reqwest::{header::HOST as HTTP_HOST, Url};
 use serde_json::json;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::{header::HOST as WS_HOST, HeaderValue as WsHeaderValue};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::super::*;
@@ -223,6 +226,7 @@ async fn run_browser_egress_probe(
     let endpoint = normalize_cdp_endpoint(cdp_endpoint)?;
     let target = create_cdp_target(&client, &endpoint, options.timeout).await?;
     let target_id = target.id.clone();
+    let cdp_host_header = cdp_http_host_header(&endpoint);
     let websocket_url = rewrite_websocket_url(
         target
             .web_socket_debugger_url
@@ -230,11 +234,20 @@ async fn run_browser_egress_probe(
             .ok_or_else(|| "CDP target did not include webSocketDebuggerUrl".to_string())?,
         &endpoint,
     )?;
+    let mut websocket_request = websocket_url
+        .as_str()
+        .into_client_request()
+        .map_err(|error| format!("CDP WebSocket request could not be built: {error}"))?;
+    let websocket_host = WsHeaderValue::from_str(&cdp_host_header)
+        .map_err(|error| format!("CDP WebSocket Host header could not be built: {error}"))?;
+    websocket_request
+        .headers_mut()
+        .insert(WS_HOST, websocket_host);
 
     let probe = async {
         let (socket, _) = tokio::time::timeout(
             options.timeout,
-            tokio_tungstenite::connect_async(websocket_url.as_str()),
+            tokio_tungstenite::connect_async(websocket_request),
         )
         .await
         .map_err(|_| "CDP WebSocket open timed out".to_string())?
@@ -331,24 +344,42 @@ async fn create_cdp_target(
     let target_url = endpoint
         .join("json/new?about%3Ablank")
         .map_err(|error| format!("failed to build CDP target URL: {error}"))?;
-    let response = tokio::time::timeout(timeout, client.put(target_url.clone()).send())
-        .await
-        .map_err(|_| "CDP target creation timed out".to_string())?
-        .map_err(|error| format!("CDP target creation failed: {error}"))?;
+    let host_header = cdp_http_host_header(endpoint);
+    let response = tokio::time::timeout(
+        timeout,
+        client
+            .put(target_url.clone())
+            .header(HTTP_HOST, host_header.clone())
+            .send(),
+    )
+    .await
+    .map_err(|_| "CDP target creation timed out".to_string())?
+    .map_err(|error| format!("CDP target creation failed: {error}"))?;
     let response = if response.status() == StatusCode::METHOD_NOT_ALLOWED
         || response.status() == StatusCode::NOT_FOUND
     {
-        tokio::time::timeout(timeout, client.get(target_url).send())
-            .await
-            .map_err(|_| "CDP target creation fallback timed out".to_string())?
-            .map_err(|error| format!("CDP target creation fallback failed: {error}"))?
+        tokio::time::timeout(
+            timeout,
+            client.get(target_url).header(HTTP_HOST, host_header).send(),
+        )
+        .await
+        .map_err(|_| "CDP target creation fallback timed out".to_string())?
+        .map_err(|error| format!("CDP target creation fallback failed: {error}"))?
     } else {
         response
     };
     if !response.status().is_success() {
+        let status = response.status();
+        let detail = response
+            .text()
+            .await
+            .map(|body| sanitize_failure_reason(&body))
+            .unwrap_or_else(|_| "egress probe failed".to_string());
+        if detail == "egress probe failed" {
+            return Err(format!("CDP target creation returned HTTP {status}"));
+        }
         return Err(format!(
-            "CDP target creation returned HTTP {}",
-            response.status()
+            "CDP target creation returned HTTP {status}: {detail}"
         ));
     }
     response
@@ -362,7 +393,34 @@ async fn close_cdp_target(client: &reqwest::Client, endpoint: &Url, target_id: O
         return;
     };
     if let Ok(url) = endpoint.join(&format!("json/close/{target_id}")) {
-        let _ = client.get(url).send().await;
+        let _ = client
+            .get(url)
+            .header(HTTP_HOST, cdp_http_host_header(endpoint))
+            .send()
+            .await;
+    }
+}
+
+fn cdp_http_host_header(endpoint: &Url) -> String {
+    let Some(host) = endpoint.host_str() else {
+        return "127.0.0.1".to_string();
+    };
+    let host_ip_candidate = host.trim_start_matches('[').trim_end_matches(']');
+    let safe_host =
+        if host.eq_ignore_ascii_case("localhost") || host_ip_candidate.parse::<IpAddr>().is_ok() {
+            if host_ip_candidate.contains(':') && !host.starts_with('[') {
+                format!("[{host}]")
+            } else {
+                host.to_string()
+            }
+        } else {
+            // Chromium's CDP HTTP server rejects Docker DNS names in Host. Keep the
+            // TCP destination unchanged, but present a loopback Host header.
+            "127.0.0.1".to_string()
+        };
+    match endpoint.port_or_known_default() {
+        Some(port) => format!("{safe_host}:{port}"),
+        None => safe_host,
     }
 }
 
@@ -560,5 +618,33 @@ fn sanitize_failure_reason(message: &str) -> String {
         "egress probe failed".to_string()
     } else {
         sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cdp_host_header_uses_loopback_for_docker_dns_names() {
+        let endpoint = Url::parse("http://bpane-runtime-abc:9223").unwrap();
+
+        assert_eq!(cdp_http_host_header(&endpoint), "127.0.0.1:9223");
+    }
+
+    #[test]
+    fn cdp_host_header_preserves_ip_and_localhost_endpoints() {
+        assert_eq!(
+            cdp_http_host_header(&Url::parse("http://172.28.0.12:9223").unwrap()),
+            "172.28.0.12:9223"
+        );
+        assert_eq!(
+            cdp_http_host_header(&Url::parse("http://localhost:9223").unwrap()),
+            "localhost:9223"
+        );
+        assert_eq!(
+            cdp_http_host_header(&Url::parse("http://[::1]:9223").unwrap()),
+            "[::1]:9223"
+        );
     }
 }

--- a/code/apps/bpane-gateway/src/api/tests/network_identity.rs
+++ b/code/apps/bpane-gateway/src/api/tests/network_identity.rs
@@ -1,4 +1,5 @@
 use super::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
 async fn manages_egress_profiles_and_session_network_identity() {
@@ -665,11 +666,7 @@ async fn active_egress_probe_failures_are_persisted_as_session_diagnostics() {
 #[tokio::test]
 async fn profile_reachability_probe_results_are_persisted_as_profile_diagnostics() {
     let (app, token) = test_router();
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let proxy_addr = listener.local_addr().unwrap();
-    let accept_task = tokio::spawn(async move {
-        let _ = listener.accept().await;
-    });
+    let (proxy_url, proxy_task) = start_profile_proxy_probe_server(None).await;
 
     let create_profile_response = app
         .clone()
@@ -682,7 +679,7 @@ async fn profile_reachability_probe_results_are_persisted_as_profile_diagnostics
                 .body(Body::from(
                     json!({
                         "name": "reachable-proxy",
-                        "proxy": { "url": format!("http://{proxy_addr}") }
+                        "proxy": { "url": proxy_url }
                     })
                     .to_string(),
                 ))
@@ -770,5 +767,258 @@ async fn profile_reachability_probe_results_are_persisted_as_profile_diagnostics
         true
     );
 
-    accept_task.abort();
+    let observed_request = proxy_task.await.unwrap();
+    assert!(observed_request.starts_with("GET http://example.com/"));
+}
+
+#[tokio::test]
+async fn profile_reachability_probe_validates_proxy_auth_without_leaking_secret() {
+    let (app, token) = test_router();
+    let expected_auth = "Basic cHJveHktdXNlcjpwcm94eS1wYXNz";
+
+    let valid_binding_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/credential-bindings")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "valid-proxy-auth",
+                        "provider": "vault_kv_v2",
+                        "allowed_origins": ["http://127.0.0.1"],
+                        "injection_mode": "form_fill",
+                        "secret_payload": {
+                            "username": "proxy-user",
+                            "password": "proxy-pass"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(valid_binding_response.status(), StatusCode::CREATED);
+    let valid_binding = response_json(valid_binding_response).await;
+    let valid_binding_id = valid_binding["id"].as_str().unwrap().to_string();
+
+    let (valid_proxy_url, valid_proxy_task) =
+        start_profile_proxy_probe_server(Some(expected_auth)).await;
+    let valid_profile_id = create_proxy_auth_profile(
+        &app,
+        &token,
+        "valid-auth-proxy",
+        &valid_proxy_url,
+        &valid_binding_id,
+    )
+    .await;
+    let valid_probe = run_profile_probe(&app, &token, &valid_profile_id).await;
+    assert_eq!(valid_probe["health"], "ready");
+    assert_eq!(valid_probe["proof"]["profile_reachability_collected"], true);
+    assert_eq!(valid_probe["proof"]["profile_reachability_healthy"], true);
+    assert_eq!(
+        valid_probe["proof"]["profile_reachability_failure"],
+        Value::Null
+    );
+    let valid_request = valid_proxy_task.await.unwrap();
+    assert!(valid_request
+        .to_ascii_lowercase()
+        .contains(&format!("proxy-authorization: {expected_auth}").to_ascii_lowercase()));
+    assert!(!valid_request.contains("proxy-pass"));
+
+    let invalid_binding_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/credential-bindings")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "invalid-proxy-auth",
+                        "provider": "vault_kv_v2",
+                        "allowed_origins": ["http://127.0.0.1"],
+                        "injection_mode": "form_fill",
+                        "secret_payload": {
+                            "username": "proxy-user",
+                            "password": "wrong-pass"
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(invalid_binding_response.status(), StatusCode::CREATED);
+    let invalid_binding = response_json(invalid_binding_response).await;
+    let invalid_binding_id = invalid_binding["id"].as_str().unwrap().to_string();
+
+    let (invalid_proxy_url, invalid_proxy_task) =
+        start_profile_proxy_probe_server(Some(expected_auth)).await;
+    let invalid_profile_id = create_proxy_auth_profile(
+        &app,
+        &token,
+        "invalid-auth-proxy",
+        &invalid_proxy_url,
+        &invalid_binding_id,
+    )
+    .await;
+    let invalid_probe = run_profile_probe(&app, &token, &invalid_profile_id).await;
+    assert_eq!(invalid_probe["health"], "attention");
+    assert_eq!(
+        invalid_probe["proof"]["profile_reachability_healthy"],
+        false
+    );
+    let failure = invalid_probe["proof"]["profile_reachability_failure"]
+        .as_str()
+        .unwrap();
+    assert!(failure.contains("proxy authentication"));
+    assert!(!failure.contains("wrong-pass"));
+    let invalid_request = invalid_proxy_task.await.unwrap();
+    assert!(invalid_request
+        .to_ascii_lowercase()
+        .contains("proxy-authorization: basic"));
+    assert!(!invalid_request.contains("wrong-pass"));
+
+    let malformed_binding_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/credential-bindings")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "malformed-proxy-auth",
+                        "provider": "vault_kv_v2",
+                        "allowed_origins": ["http://127.0.0.1"],
+                        "injection_mode": "form_fill",
+                        "secret_payload": {
+                            "username": "",
+                            "password": ""
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(malformed_binding_response.status(), StatusCode::CREATED);
+    let malformed_binding = response_json(malformed_binding_response).await;
+    let malformed_binding_id = malformed_binding["id"].as_str().unwrap().to_string();
+    let malformed_profile_id = create_proxy_auth_profile(
+        &app,
+        &token,
+        "malformed-auth-proxy",
+        "http://127.0.0.1:9",
+        &malformed_binding_id,
+    )
+    .await;
+    let malformed_probe = run_profile_probe(&app, &token, &malformed_profile_id).await;
+    assert_eq!(malformed_probe["health"], "attention");
+    let malformed_failure = malformed_probe["proof"]["profile_reachability_failure"]
+        .as_str()
+        .unwrap();
+    assert!(malformed_failure.contains("username and password must not be empty"));
+    assert!(!malformed_failure.contains("proxy-pass"));
+}
+
+async fn create_proxy_auth_profile(
+    app: &Router,
+    token: &str,
+    name: &str,
+    proxy_url: &str,
+    credential_binding_id: &str,
+) -> String {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/egress-profiles")
+                .header("authorization", bearer(token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": name,
+                        "proxy": {
+                            "url": proxy_url,
+                            "credential_binding_id": credential_binding_id
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    response_json(response).await["id"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+async fn run_profile_probe(app: &Router, token: &str, profile_id: &str) -> Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/egress-profiles/{profile_id}/diagnostics/probe"
+                ))
+                .header("authorization", bearer(token))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "timeout_ms": 1000 }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    response_json(response).await
+}
+
+async fn start_profile_proxy_probe_server(
+    expected_proxy_auth: Option<&str>,
+) -> (String, tokio::task::JoinHandle<String>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_url = format!("http://{}", listener.local_addr().unwrap());
+    let expected_proxy_auth = expected_proxy_auth.map(str::to_string);
+    let task = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        loop {
+            let read = stream.read(&mut buffer).await.unwrap();
+            if read == 0 {
+                break;
+            }
+            request.extend_from_slice(&buffer[..read]);
+            if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                break;
+            }
+        }
+        let request_text = String::from_utf8_lossy(&request).to_string();
+        let authenticated = expected_proxy_auth.as_ref().map_or(true, |expected| {
+            request_text
+                .lines()
+                .any(|line| line.eq_ignore_ascii_case(&format!("Proxy-Authorization: {expected}")))
+        });
+        let response = if authenticated {
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+        } else {
+            "HTTP/1.1 407 Proxy Authentication Required\r\nProxy-Authenticate: Basic realm=\"BrowserPane Test\"\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+        };
+        stream.write_all(response.as_bytes()).await.unwrap();
+        request_text
+    });
+    (proxy_url, task)
 }

--- a/code/apps/bpane-gateway/src/runtime_manager/docker/container.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager/docker/container.rs
@@ -304,6 +304,7 @@ impl DockerRuntimeManager {
                         "BPANE_CHROMIUM_PROXY_AUTH_FILE",
                         proxy_auth_config_path.to_string(),
                     );
+                    push_env(&mut env, "BPANE_URL", "about:blank".to_string());
                 }
             }
             if !profile.bypass_rules.is_empty() {

--- a/code/apps/bpane-gateway/src/runtime_manager/tests.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager/tests.rs
@@ -445,6 +445,10 @@ fn docker_runtime_maps_network_identity_to_launch_env() {
         Some("/run/bpane/session/egress/proxy-auth.json")
     );
     assert_eq!(
+        env.get("BPANE_URL").map(String::as_str),
+        Some("about:blank")
+    );
+    assert_eq!(
         env.get("BPANE_CHROMIUM_PROXY_BYPASS_LIST")
             .map(String::as_str),
         Some("localhost;*.internal.example")
@@ -547,6 +551,7 @@ fn docker_runtime_maps_network_identity_to_launch_env() {
     assert!(args.contains(
         &"BPANE_CHROMIUM_PROXY_AUTH_FILE=/run/bpane/session/egress/proxy-auth.json".to_string()
     ));
+    assert!(args.contains(&"BPANE_URL=about:blank".to_string()));
     assert!(args.contains(
         &"browserpane.egress_profile_id=019db438-c74a-7ef2-810c-792e298faf12".to_string()
     ));

--- a/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { tick } from 'svelte';
   import { Copy, Network, RefreshCw, ShieldCheck, ShieldOff } from 'lucide-svelte';
   import type {
     CreateEgressProfileCommand,
@@ -45,6 +46,8 @@
   let form = $state(emptyEgressProfileForm());
   let mutating = $state(false);
   let feedback = $state<AdminMessageFeedback | null>(null);
+  let editorSection = $state<HTMLElement | null>(null);
+  let nameInput = $state<HTMLInputElement | null>(null);
   const rows = $derived(egressProfileRows(profiles, search));
   const selectedProfile = $derived(profiles.find((profile) => profile.id === selectedProfileId) ?? null);
   const selectedRow = $derived(rows.find((row) => row.id === selectedProfileId) ?? null);
@@ -81,6 +84,7 @@
     editorOpen = true;
     form = emptyEgressProfileForm();
     feedback = null;
+    void revealEditor();
   }
 
   function closeEditor(): void {
@@ -99,6 +103,7 @@
     editorOpen = true;
     form = formFromEgressProfile(profile);
     feedback = null;
+    void revealEditor();
   }
 
   function cloneSelected(): void {
@@ -115,6 +120,14 @@
       title: 'Clone prepared',
       message: 'Review the copied profile payload before saving it as a new profile.',
     };
+    void revealEditor();
+  }
+
+  async function revealEditor(): Promise<void> {
+    await tick();
+    editorSection?.scrollIntoView({ block: 'start', behavior: 'auto' });
+    nameInput?.focus({ preventScroll: true });
+    nameInput?.select();
   }
 
   async function saveProfile(): Promise<void> {
@@ -385,7 +398,7 @@
   </section>
 
   {#if editorOpen}
-    <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile editor">
+    <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile editor" bind:this={editorSection}>
       <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
         <div class="min-w-0">
           <p class="admin-eyebrow mb-1">Profile editor</p>
@@ -399,7 +412,7 @@
       <form class="grid min-w-0 gap-3" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Name
-          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-name" bind:value={form.name} disabled={disabled} />
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-name" bind:this={nameInput} bind:value={form.name} disabled={disabled} />
         </label>
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           State

--- a/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
@@ -238,10 +238,87 @@
 </script>
 
 <div class="grid min-w-0 gap-3" data-testid="egress-profile-catalog">
+  {#if error}
+    <AdminMessage variant="warning" title="Egress catalog unavailable" message={error} compact={true} />
+  {/if}
+  {#if feedback}
+    <AdminMessage variant={feedback.variant} title={feedback.title} message={feedback.message} compact={true} onDismiss={() => { feedback = null; }} />
+  {/if}
+
+  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile selection">
+    <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
+      <div class="min-w-0">
+        <p class="admin-eyebrow mb-1">Profile selection</p>
+        <p class="m-0 text-sm font-bold text-admin-ink/72" data-testid="egress-profile-count">
+          {rows.length} of {profiles.length} visible profiles
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-new" disabled={disabled} onclick={resetForm}>
+          <ShieldCheck size={15} aria-hidden="true" />
+          New profile
+        </button>
+        <button
+          class="admin-button-primary inline-flex items-center gap-2"
+          type="button"
+          data-testid="egress-profile-refresh"
+          disabled={disabled}
+          onclick={onRefresh}
+        >
+          <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
+          Refresh
+        </button>
+      </div>
+    </div>
+
+    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+      Search
+      <input
+        class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="egress-profile-search"
+        placeholder="Name, state, proxy, TLS"
+        bind:value={search}
+      />
+    </label>
+
+    {#if rows.length === 0}
+      <AdminMessage variant="empty" message="No egress profiles match the current filter." compact={true} />
+    {:else}
+      <div class="grid max-h-[min(360px,42vh)] min-w-0 gap-1 overflow-y-auto pr-1" aria-label="Visible egress profiles">
+        {#each rows as row (row.id)}
+          <button
+            class={`grid w-full min-w-0 cursor-pointer grid-cols-[4px_minmax(0,1fr)_auto] items-center gap-3 rounded-xl border p-2 text-left text-admin-ink/78 hover:border-admin-leaf/42 hover:bg-admin-field/84 ${rowClass(row.state, row.id === selectedProfileId)}`}
+            type="button"
+            data-testid="egress-profile-row"
+            data-profile-id={row.id}
+            aria-pressed={row.id === selectedProfileId}
+            onclick={() => selectProfile(row.id)}
+          >
+            <span class={`h-full min-h-12 rounded-full ${rowAccentClass(row.state, row.id === selectedProfileId)}`}></span>
+            <span class="grid min-w-0 gap-1">
+              <span class="flex min-w-0 items-center gap-2">
+                <strong class="min-w-0 truncate text-sm text-admin-ink" title={row.name}>{row.name}</strong>
+                {#if row.id === selectedProfileId}
+                  <span class="rounded-full bg-admin-leaf/14 px-2 py-0.5 text-[0.68rem] font-extrabold text-admin-leaf">selected</span>
+                {/if}
+              </span>
+              <span class="min-w-0 truncate text-xs text-admin-ink/52">
+                <span data-testid="egress-profile-row-health">{row.kind}</span> | updated {row.updatedAt}
+              </span>
+            </span>
+            <span class="grid justify-items-end text-xs text-[#c1d0e8]">
+              <span class="rounded-lg bg-admin-field/72 px-2 py-1">{row.state}</span>
+            </span>
+          </button>
+        {/each}
+      </div>
+    {/if}
+  </section>
+
   <section class="grid gap-3 rounded-[16px] border border-admin-leaf/25 bg-admin-leaf/10 p-3" aria-label="Selected egress profile">
     <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
-        <p class="admin-eyebrow mb-1">Selected egress profile</p>
+        <p class="admin-eyebrow mb-1">Selected profile</p>
         <h3 class="m-0 truncate text-base font-bold text-admin-ink" data-testid="egress-profile-selected-name" title={selectedProfile?.name ?? ''}>
           {selectedProfile?.name ?? 'No profile selected'}
         </h3>
@@ -258,15 +335,15 @@
     </div>
 
     {#if selectedProfile}
-      <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-3 xl:grid-cols-6">
+      <div class="grid min-w-0 gap-2 text-xs text-admin-ink/70">
         {@render ProfileFact('Mode', selectedRow?.kind ?? 'direct')}
         {@render ProfileFact('Health', selectedProfile.diagnostics.health, 'egress-profile-health')}
         {@render ProfileFact('Proxy', selectedProfile.effective.proxy_configured ? 'configured' : 'none')}
         {@render ProfileFact('Proxy auth', selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none')}
         {@render ProfileFact('TLS', selectedProfile.effective.tls_interception_enabled ? 'intercept' : 'metadata')}
-        {@render ProfileFact('Bypass', String(selectedProfile.effective.bypass_rule_count))}
+        {@render ProfileFact('Bypass rules', String(selectedProfile.effective.bypass_rule_count))}
       </div>
-      <p class="m-0 line-clamp-2 text-sm leading-normal text-admin-ink/64">
+      <p class="m-0 text-sm leading-normal text-admin-ink/64">
         {selectedProfile.description ?? 'No description configured for this outbound path.'}
       </p>
     {:else}
@@ -307,41 +384,19 @@
     </div>
   </section>
 
-  {#if error}
-    <AdminMessage variant="warning" title="Egress catalog unavailable" message={error} compact={true} />
-  {/if}
-  {#if feedback}
-    <AdminMessage variant={feedback.variant} title={feedback.title} message={feedback.message} compact={true} onDismiss={() => { feedback = null; }} />
-  {/if}
-
-  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile configurator">
-    <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
-      <div class="min-w-0">
-        <p class="admin-eyebrow mb-1">Profile configurator</p>
-        <h4 class="m-0 text-sm font-bold text-admin-ink">{editorOpen ? editorTitle : 'Create or update an approved egress path'}</h4>
-      </div>
-      <div class="flex flex-wrap gap-2">
-        <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-new" disabled={disabled} onclick={resetForm}>
-          <ShieldCheck size={15} aria-hidden="true" />
-          New profile
+  {#if editorOpen}
+    <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile editor">
+      <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
+        <div class="min-w-0">
+          <p class="admin-eyebrow mb-1">Profile editor</p>
+          <h4 class="m-0 text-sm font-bold text-admin-ink">{editorTitle}</h4>
+        </div>
+        <button class="admin-button-ghost" type="button" disabled={disabled} onclick={closeEditor}>
+          Cancel
         </button>
-        {#if editorOpen}
-          <button class="admin-button-ghost" type="button" disabled={disabled} onclick={closeEditor}>
-            Cancel
-          </button>
-        {/if}
       </div>
-    </div>
 
-    {#if !editorOpen}
-      <AdminMessage
-        variant="info"
-        message="Use New profile to define a new outbound path, or select a profile above and use Edit or Clone."
-        compact={true}
-      />
-    {:else}
-    <form class="grid min-w-0 gap-3" aria-label="Egress profile editor" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+      <form class="grid min-w-0 gap-3" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Name
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-name" bind:value={form.name} disabled={disabled} />
@@ -353,14 +408,10 @@
             <option value="disabled">disabled</option>
           </select>
         </label>
-      </div>
-
-      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-        Description
-        <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-description" bind:value={form.description} disabled={disabled} />
-      </label>
-
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Description
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-description" bind:value={form.description} disabled={disabled} />
+        </label>
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Labels
           <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-labels" placeholder="region=eu" bind:value={form.labels} disabled={disabled}></textarea>
@@ -369,9 +420,6 @@
           Bypass rules
           <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-bypass-rules" placeholder="localhost&#10;*.local" bind:value={form.bypassRules} disabled={disabled}></textarea>
         </label>
-      </div>
-
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Proxy URL
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-url" placeholder="http://bpane-egress-observer:3128" bind:value={form.proxyUrl} disabled={disabled} />
@@ -380,9 +428,6 @@
           Proxy auth binding ID
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-credential-binding-id" placeholder="credential binding UUID" bind:value={form.proxyCredentialBindingId} disabled={disabled} />
         </label>
-      </div>
-
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Observation mode
           <select class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-observation-mode" bind:value={form.observationMode} disabled={disabled}>
@@ -390,9 +435,6 @@
             <option value="tls_intercept">tls_intercept</option>
           </select>
         </label>
-      </div>
-
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Custom CA ref
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-custom-ca-ref" placeholder="file:///workspace/dev/egress-ca.pem" bind:value={form.customCaRef} disabled={disabled} />
@@ -401,9 +443,6 @@
           Custom CA name
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.customCaName} disabled={disabled} />
         </label>
-      </div>
-
-      <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Log-sink ref
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-log-sink-ref" placeholder="siem://browserpane/local-egress" bind:value={form.sensitiveLogSinkRef} disabled={disabled} />
@@ -412,95 +451,29 @@
           Log-sink name
           <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.sensitiveLogSinkName} disabled={disabled} />
         </label>
-      </div>
 
-      <button
-        class="admin-button-primary inline-flex w-fit items-center gap-2"
-        type="submit"
-        data-testid="egress-profile-save"
-        disabled={disabled || !canSave}
-      >
-        {#if mutating}
-          <RefreshCw class="animate-spin" size={15} aria-hidden="true" />
-          Saving
-        {:else}
-          <ShieldCheck size={15} aria-hidden="true" />
-          {editing ? 'Save profile' : 'Create profile'}
-        {/if}
-      </button>
-    </form>
-    {/if}
-  </section>
-
-  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile switcher">
-    <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
-      <div class="min-w-0">
-        <p class="admin-eyebrow mb-1">Profile switcher</p>
-        <p class="m-0 text-sm font-bold text-admin-ink/72" data-testid="egress-profile-count">
-          {rows.length} of {profiles.length} visible profiles
-        </p>
-      </div>
-      <button
-        class="admin-button-primary inline-flex items-center gap-2"
-        type="button"
-        data-testid="egress-profile-refresh"
-        disabled={disabled}
-        onclick={onRefresh}
-      >
-        <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
-        Refresh
-      </button>
-    </div>
-
-    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-      Search
-      <input
-        class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
-        data-testid="egress-profile-search"
-        placeholder="Name, state, proxy, TLS"
-        bind:value={search}
-      />
-    </label>
-
-    {#if rows.length === 0}
-      <AdminMessage variant="empty" message="No egress profiles match the current filter." compact={true} />
-    {:else}
-      <div class="grid max-h-[min(360px,42vh)] min-w-0 gap-1 overflow-y-auto pr-1" aria-label="Visible egress profiles">
-        {#each rows as row (row.id)}
-          <button
-            class={`grid w-full min-w-0 cursor-pointer grid-cols-[4px_minmax(0,1fr)_auto] items-center gap-3 rounded-xl border p-2 text-left text-admin-ink/78 hover:border-admin-leaf/42 hover:bg-admin-field/84 ${rowClass(row.state, row.id === selectedProfileId)}`}
-            type="button"
-            data-testid="egress-profile-row"
-            data-profile-id={row.id}
-            aria-pressed={row.id === selectedProfileId}
-            onclick={() => selectProfile(row.id)}
-          >
-            <span class={`h-full min-h-12 rounded-full ${rowAccentClass(row.state, row.id === selectedProfileId)}`}></span>
-            <span class="grid min-w-0 gap-1">
-              <span class="flex min-w-0 items-center gap-2">
-                <strong class="min-w-0 truncate text-sm text-admin-ink" title={row.name}>{row.name}</strong>
-                {#if row.id === selectedProfileId}
-                  <span class="rounded-full bg-admin-leaf/14 px-2 py-0.5 text-[0.68rem] font-extrabold text-admin-leaf">selected</span>
-                {/if}
-              </span>
-              <span class="min-w-0 truncate text-xs text-admin-ink/52">
-                <span data-testid="egress-profile-row-health">{row.kind}</span> | {row.description || 'no description'} | updated {row.updatedAt}
-              </span>
-            </span>
-            <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">
-              <span class="rounded-lg bg-admin-field/72 px-2 py-1">{row.state}</span>
-              <span class="rounded-lg bg-admin-field/72 px-2 py-1">{row.kind}</span>
-            </span>
-          </button>
-        {/each}
-      </div>
-    {/if}
-  </section>
+        <button
+          class="admin-button-primary inline-flex w-fit items-center gap-2"
+          type="submit"
+          data-testid="egress-profile-save"
+          disabled={disabled || !canSave}
+        >
+          {#if mutating}
+            <RefreshCw class="animate-spin" size={15} aria-hidden="true" />
+            Saving
+          {:else}
+            <ShieldCheck size={15} aria-hidden="true" />
+            {editing ? 'Save profile' : 'Create profile'}
+          {/if}
+        </button>
+      </form>
+    </section>
+  {/if}
 </div>
 
 {#snippet ProfileFact(label: string, value: string, testId?: string)}
-  <span class="min-w-0 rounded-xl bg-admin-field/72 p-2 font-bold uppercase">
-    {label}
-    <strong class="mt-1 block truncate font-mono text-admin-ink normal-case" data-testid={testId}>{value}</strong>
+  <span class="flex min-w-0 items-center justify-between gap-3 rounded-xl bg-admin-field/72 p-2 font-bold uppercase">
+    <span class="min-w-0 truncate">{label}</span>
+    <strong class="min-w-0 truncate text-right font-mono text-admin-ink normal-case" data-testid={testId}>{value}</strong>
   </span>
 {/snippet}

--- a/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
@@ -222,11 +222,18 @@
 
   function rowClass(state: string, selected: boolean): string {
     if (selected) {
-      return 'border-admin-leaf/42 bg-admin-leaf/12 text-admin-ink';
+      return 'border-admin-leaf/42 bg-admin-field/84';
     }
     return state === 'disabled'
-      ? 'border-admin-danger/24 bg-admin-danger/8 text-admin-ink/78'
-      : 'border-[#90a6cc]/18 bg-admin-field/70 text-admin-ink/82';
+      ? 'border-admin-danger/24 bg-admin-danger/8'
+      : 'border-admin-ink/10 bg-admin-panel/68';
+  }
+
+  function rowAccentClass(state: string, selected: boolean): string {
+    if (selected) {
+      return 'bg-admin-leaf';
+    }
+    return state === 'disabled' ? 'bg-admin-danger/62' : 'bg-admin-ink/12';
   }
 </script>
 
@@ -253,11 +260,11 @@
     {#if selectedProfile}
       <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-3 xl:grid-cols-6">
         {@render ProfileFact('Mode', selectedRow?.kind ?? 'direct')}
+        {@render ProfileFact('Health', selectedProfile.diagnostics.health, 'egress-profile-health')}
         {@render ProfileFact('Proxy', selectedProfile.effective.proxy_configured ? 'configured' : 'none')}
         {@render ProfileFact('Proxy auth', selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none')}
         {@render ProfileFact('TLS', selectedProfile.effective.tls_interception_enabled ? 'intercept' : 'metadata')}
         {@render ProfileFact('Bypass', String(selectedProfile.effective.bypass_rule_count))}
-        {@render ProfileFact('Updated', selectedProfile.updated_at)}
       </div>
       <p class="m-0 line-clamp-2 text-sm leading-normal text-admin-ink/64">
         {selectedProfile.description ?? 'No description configured for this outbound path.'}
@@ -307,102 +314,33 @@
     <AdminMessage variant={feedback.variant} title={feedback.title} message={feedback.message} compact={true} onDismiss={() => { feedback = null; }} />
   {/if}
 
-  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile switcher">
+  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile configurator">
     <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
       <div class="min-w-0">
-        <p class="admin-eyebrow mb-1">Profile switcher</p>
-        <p class="m-0 text-sm font-bold text-admin-ink/72" data-testid="egress-profile-count">
-          {rows.length} of {profiles.length} visible profiles
-        </p>
+        <p class="admin-eyebrow mb-1">Profile configurator</p>
+        <h4 class="m-0 text-sm font-bold text-admin-ink">{editorOpen ? editorTitle : 'Create or update an approved egress path'}</h4>
       </div>
       <div class="flex flex-wrap gap-2">
-        <button
-          class="admin-button-primary inline-flex items-center gap-2"
-          type="button"
-          data-testid="egress-profile-new"
-          disabled={disabled}
-          onclick={resetForm}
-        >
+        <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-new" disabled={disabled} onclick={resetForm}>
           <ShieldCheck size={15} aria-hidden="true" />
           New profile
         </button>
-        <button
-          class="admin-button-primary inline-flex items-center gap-2"
-          type="button"
-          data-testid="egress-profile-refresh"
-          disabled={disabled}
-          onclick={onRefresh}
-        >
-          <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
-          Refresh
-        </button>
-      </div>
-    </div>
-
-    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-      Search
-      <input
-        class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
-        data-testid="egress-profile-search"
-        placeholder="Name, state, proxy, TLS"
-        bind:value={search}
-      />
-    </label>
-
-    <div class="grid max-h-[min(48vh,34rem)] min-h-0 min-w-0 content-start gap-2 overflow-y-auto pr-1" aria-label="Visible egress profiles">
-      {#if rows.length === 0}
-        <p class="m-0 text-sm text-admin-ink/62">No egress profiles match the current filter.</p>
-      {:else}
-        {#each rows as row (row.id)}
-          <button
-            class={`grid min-w-0 gap-2 rounded-xl border p-3 text-left transition ${rowClass(row.state, row.id === selectedProfileId)}`}
-            type="button"
-            data-testid="egress-profile-row"
-            data-profile-id={row.id}
-            aria-pressed={row.id === selectedProfileId}
-            onclick={() => selectProfile(row.id)}
-          >
-            <span class="flex min-w-0 items-center justify-between gap-2">
-              <span class="truncate text-sm font-bold">{row.name}</span>
-              <span class={`shrink-0 rounded-lg border px-2 py-0.5 text-[11px] font-bold ${
-                row.state === 'ready'
-                  ? 'border-admin-leaf/30 bg-admin-leaf/12 text-admin-leaf'
-                  : 'border-admin-danger/32 bg-admin-danger/10 text-admin-danger'
-              }`}>
-                {row.state}
-              </span>
-            </span>
-            <span class="text-xs font-bold text-admin-ink/64" data-testid="egress-profile-row-health">
-              {row.kind} | updated {row.updatedAt}
-            </span>
-            <span class="flex min-w-0 flex-wrap gap-1">
-              {#each row.badges as badge}
-                {#if !badge.startsWith('health ') && !badge.endsWith('proof')}
-                  <span class="rounded-lg bg-admin-night/58 px-2 py-0.5 text-[11px] font-bold text-[#c1d0e8]">{badge}</span>
-                {/if}
-              {/each}
-            </span>
-            {#if row.description}
-              <span class="line-clamp-2 text-xs leading-normal text-admin-ink/62">{row.description}</span>
-            {/if}
+        {#if editorOpen}
+          <button class="admin-button-ghost" type="button" disabled={disabled} onclick={closeEditor}>
+            Cancel
           </button>
-        {/each}
-      {/if}
-    </div>
-  </section>
-
-  {#if editorOpen}
-    <form class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile editor" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
-      <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
-        <div class="min-w-0">
-          <p class="admin-eyebrow mb-1">Profile editor</p>
-          <h4 class="m-0 text-sm font-bold text-admin-ink">{editorTitle}</h4>
-        </div>
-        <button class="admin-button-ghost" type="button" disabled={disabled} onclick={closeEditor}>
-          Cancel
-        </button>
+        {/if}
       </div>
+    </div>
 
+    {#if !editorOpen}
+      <AdminMessage
+        variant="info"
+        message="Use New profile to define a new outbound path, or select a profile above and use Edit or Clone."
+        compact={true}
+      />
+    {:else}
+    <form class="grid min-w-0 gap-3" aria-label="Egress profile editor" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
       <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
           Name
@@ -491,65 +429,78 @@
         {/if}
       </button>
     </form>
-  {/if}
+    {/if}
+  </section>
 
-  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile detail view">
-    <div class="min-w-0">
-      <p class="admin-eyebrow mb-1">Profile detail</p>
-      <h3 class="m-0 text-base font-bold text-admin-ink">Diagnostics and effective configuration</h3>
+  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile switcher">
+    <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
+      <div class="min-w-0">
+        <p class="admin-eyebrow mb-1">Profile switcher</p>
+        <p class="m-0 text-sm font-bold text-admin-ink/72" data-testid="egress-profile-count">
+          {rows.length} of {profiles.length} visible profiles
+        </p>
+      </div>
+      <button
+        class="admin-button-primary inline-flex items-center gap-2"
+        type="button"
+        data-testid="egress-profile-refresh"
+        disabled={disabled}
+        onclick={onRefresh}
+      >
+        <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
+        Refresh
+      </button>
     </div>
 
-    {#if selectedProfile}
-      <div class="grid min-w-0 gap-2 rounded-xl border border-admin-ink/10 bg-admin-field/62 p-3">
-        <div class="grid min-w-0 gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          {@render DetailPill('State', selectedProfile.state)}
-          {@render DetailPill('Health', selectedProfile.diagnostics.health, 'egress-profile-health')}
-          {@render DetailPill('Proof', selectedProfile.diagnostics.proof_level.replaceAll('_', ' '))}
-          {@render DetailPill('Proxy', selectedProfile.effective.proxy_configured ? 'configured' : 'none')}
-          {@render DetailPill('Proxy auth', selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none')}
-          {@render DetailPill('TLS', selectedProfile.effective.tls_interception_enabled ? 'inspect' : 'metadata')}
-          {@render DetailPill('Bypass', String(selectedProfile.effective.bypass_rule_count))}
-          {@render DetailPill('Reachability', selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not probed')}
-        </div>
-        <AdminMessage
-          variant={selectedProfile.diagnostics.health === 'ready' ? 'info' : 'warning'}
-          title={`Diagnostics: ${selectedProfile.diagnostics.proof_level.replaceAll('_', ' ')}`}
-          message={selectedProfile.diagnostics.warnings.length > 0
-            ? selectedProfile.diagnostics.warnings.join(' ')
-            : selectedProfile.diagnostics.proof.profile_reachability_collected
-              ? (selectedProfile.diagnostics.proof.profile_reachability_healthy
-                  ? 'Profile reachability evidence is available for this egress endpoint.'
-                  : selectedProfile.diagnostics.proof.profile_reachability_failure ?? 'Profile reachability was probed and failed.')
-            : selectedProfile.diagnostics.proof.active_probe_collected
-              ? 'Active egress probe evidence is available for this profile.'
-              : 'No active probe has been collected yet; proof is based on sanitized configuration metadata.'}
-          compact={true}
-        />
-        <div class="grid min-w-0 gap-2 text-xs font-bold text-admin-ink/68 sm:grid-cols-2 lg:grid-cols-3" data-testid="egress-profile-diagnostics-proof">
-          <span>Profile resolved: {selectedProfile.diagnostics.proof.profile_resolved ? 'yes' : 'no'}</span>
-          <span>Runtime launch: {selectedProfile.diagnostics.proof.runtime_launch_observed ? 'observed' : 'not observed'}</span>
-          <span>Active probe: {selectedProfile.diagnostics.proof.active_probe_collected ? 'collected' : 'not collected'}</span>
-          <span>Profile reachability: {selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not collected'}</span>
-          <span>TLS expected: {selectedProfile.diagnostics.proof.tls_interception_expected ? 'yes' : 'no'}</span>
-          <span>Custom CA launch: {selectedProfile.diagnostics.proof.custom_ca_launch_config_expected ? 'expected' : 'not expected'}</span>
-          <span>Log sink: {selectedProfile.diagnostics.proof.sensitive_log_sink_declared ? 'declared' : 'not declared'}</span>
-        </div>
-      </div>
+    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+      Search
+      <input
+        class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="egress-profile-search"
+        placeholder="Name, state, proxy, TLS"
+        bind:value={search}
+      />
+    </label>
+
+    {#if rows.length === 0}
+      <AdminMessage variant="empty" message="No egress profiles match the current filter." compact={true} />
     {:else}
-      <AdminMessage variant="empty" message="Select an egress profile to inspect diagnostics and effective runtime configuration." compact={true} />
+      <div class="grid max-h-[min(360px,42vh)] min-w-0 gap-1 overflow-y-auto pr-1" aria-label="Visible egress profiles">
+        {#each rows as row (row.id)}
+          <button
+            class={`grid w-full min-w-0 cursor-pointer grid-cols-[4px_minmax(0,1fr)_auto] items-center gap-3 rounded-xl border p-2 text-left text-admin-ink/78 hover:border-admin-leaf/42 hover:bg-admin-field/84 ${rowClass(row.state, row.id === selectedProfileId)}`}
+            type="button"
+            data-testid="egress-profile-row"
+            data-profile-id={row.id}
+            aria-pressed={row.id === selectedProfileId}
+            onclick={() => selectProfile(row.id)}
+          >
+            <span class={`h-full min-h-12 rounded-full ${rowAccentClass(row.state, row.id === selectedProfileId)}`}></span>
+            <span class="grid min-w-0 gap-1">
+              <span class="flex min-w-0 items-center gap-2">
+                <strong class="min-w-0 truncate text-sm text-admin-ink" title={row.name}>{row.name}</strong>
+                {#if row.id === selectedProfileId}
+                  <span class="rounded-full bg-admin-leaf/14 px-2 py-0.5 text-[0.68rem] font-extrabold text-admin-leaf">selected</span>
+                {/if}
+              </span>
+              <span class="min-w-0 truncate text-xs text-admin-ink/52">
+                <span data-testid="egress-profile-row-health">{row.kind}</span> | {row.description || 'no description'} | updated {row.updatedAt}
+              </span>
+            </span>
+            <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">
+              <span class="rounded-lg bg-admin-field/72 px-2 py-1">{row.state}</span>
+              <span class="rounded-lg bg-admin-field/72 px-2 py-1">{row.kind}</span>
+            </span>
+          </button>
+        {/each}
+      </div>
     {/if}
   </section>
 </div>
 
-{#snippet ProfileFact(label: string, value: string)}
+{#snippet ProfileFact(label: string, value: string, testId?: string)}
   <span class="min-w-0 rounded-xl bg-admin-field/72 p-2 font-bold uppercase">
     {label}
-    <strong class="mt-1 block truncate font-mono text-admin-ink normal-case">{value}</strong>
-  </span>
-{/snippet}
-
-{#snippet DetailPill(label: string, value: string, testId?: string)}
-  <span class="min-w-0 rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]" data-testid={testId}>
-    {label}: {value}
+    <strong class="mt-1 block truncate font-mono text-admin-ink normal-case" data-testid={testId}>{value}</strong>
   </span>
 {/snippet}

--- a/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/EgressProfileCatalogPanel.svelte
@@ -25,6 +25,8 @@
     readonly onRunProfileReachabilityProbe?: (profileId: string) => Promise<EgressDiagnosticsResource | void> | EgressDiagnosticsResource | void;
   };
 
+  type EgressProfileEditorMode = 'create' | 'edit' | 'clone';
+
   let {
     profiles,
     loading = false,
@@ -38,14 +40,24 @@
   let search = $state('');
   let selectedProfileId = $state<string | null>(null);
   let editingProfileId = $state<string | null>(null);
+  let editorOpen = $state(false);
+  let editorMode = $state<EgressProfileEditorMode>('create');
   let form = $state(emptyEgressProfileForm());
   let mutating = $state(false);
   let feedback = $state<AdminMessageFeedback | null>(null);
   const rows = $derived(egressProfileRows(profiles, search));
   const selectedProfile = $derived(profiles.find((profile) => profile.id === selectedProfileId) ?? null);
+  const selectedRow = $derived(rows.find((row) => row.id === selectedProfileId) ?? null);
   const editing = $derived(Boolean(editingProfileId));
-  const canSave = $derived(Boolean(onCreateProfile && !editing) || Boolean(onUpdateProfile && editing));
+  const canSave = $derived(editorOpen && (Boolean(onCreateProfile && !editing) || Boolean(onUpdateProfile && editing)));
   const disabled = $derived(loading || mutating);
+  const editorTitle = $derived(
+    editorMode === 'edit'
+      ? 'Edit egress profile'
+      : editorMode === 'clone'
+        ? 'Clone egress profile'
+        : 'Create egress profile',
+  );
 
   $effect(() => {
     if (!rows.length) {
@@ -56,14 +68,25 @@
   });
 
   function selectProfile(profileId: string): void {
+    if (profileId !== selectedProfileId && editorOpen && editingProfileId && editingProfileId !== profileId) {
+      closeEditor();
+    }
     selectedProfileId = profileId;
     feedback = null;
   }
 
   function resetForm(): void {
     editingProfileId = null;
+    editorMode = 'create';
+    editorOpen = true;
     form = emptyEgressProfileForm();
     feedback = null;
+  }
+
+  function closeEditor(): void {
+    editorOpen = false;
+    editingProfileId = null;
+    form = emptyEgressProfileForm();
   }
 
   function editSelected(): void {
@@ -72,6 +95,8 @@
       return;
     }
     editingProfileId = profile.id;
+    editorMode = 'edit';
+    editorOpen = true;
     form = formFromEgressProfile(profile);
     feedback = null;
   }
@@ -82,6 +107,8 @@
       return;
     }
     editingProfileId = null;
+    editorMode = 'clone';
+    editorOpen = true;
     form = formFromEgressProfile(profile, { clone: true });
     feedback = {
       variant: 'info',
@@ -120,6 +147,8 @@
         message: saved?.name ? `${saved.name} is available in the egress catalog.` : 'Egress profile saved.',
       };
       editingProfileId = null;
+      editorOpen = false;
+      form = emptyEgressProfileForm();
       if (!saved?.id) {
         onRefresh();
       }
@@ -202,49 +231,125 @@
 </script>
 
 <div class="grid min-w-0 gap-3" data-testid="egress-profile-catalog">
-  <section class="grid gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile catalog controls">
-    <div class="flex min-w-0 flex-wrap items-start justify-between gap-3">
+  <section class="grid gap-3 rounded-[16px] border border-admin-leaf/25 bg-admin-leaf/10 p-3" aria-label="Selected egress profile">
+    <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
       <div class="min-w-0">
-        <p class="admin-eyebrow mb-1">Egress profiles</p>
-        <h3 class="m-0 text-base font-bold text-admin-ink">Approved outbound paths</h3>
+        <p class="admin-eyebrow mb-1">Selected egress profile</p>
+        <h3 class="m-0 truncate text-base font-bold text-admin-ink" data-testid="egress-profile-selected-name" title={selectedProfile?.name ?? ''}>
+          {selectedProfile?.name ?? 'No profile selected'}
+        </h3>
       </div>
+      <span class={`rounded-full border px-3 py-1 text-xs font-extrabold ${
+        !selectedProfile
+          ? 'border-[#90a6cc]/28 bg-admin-field/72 text-admin-ink/68'
+          : selectedProfile.state === 'ready'
+          ? 'border-admin-leaf/30 bg-admin-leaf/12 text-admin-leaf'
+          : 'border-admin-danger/32 bg-admin-danger/10 text-admin-danger'
+      }`}>
+        {selectedProfile?.state ?? 'select'}
+      </span>
+    </div>
+
+    {#if selectedProfile}
+      <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-3 xl:grid-cols-6">
+        {@render ProfileFact('Mode', selectedRow?.kind ?? 'direct')}
+        {@render ProfileFact('Proxy', selectedProfile.effective.proxy_configured ? 'configured' : 'none')}
+        {@render ProfileFact('Proxy auth', selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none')}
+        {@render ProfileFact('TLS', selectedProfile.effective.tls_interception_enabled ? 'intercept' : 'metadata')}
+        {@render ProfileFact('Bypass', String(selectedProfile.effective.bypass_rule_count))}
+        {@render ProfileFact('Updated', selectedProfile.updated_at)}
+      </div>
+      <p class="m-0 line-clamp-2 text-sm leading-normal text-admin-ink/64">
+        {selectedProfile.description ?? 'No description configured for this outbound path.'}
+      </p>
+    {:else}
+      <p class="m-0 text-sm leading-normal text-admin-ink/68">
+        Select an approved outbound path before editing, cloning, disabling, or probing an egress profile.
+      </p>
+    {/if}
+
+    <div class="flex flex-wrap gap-2">
+      <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-edit" disabled={!selectedProfile || disabled} onclick={editSelected}>
+        <Network size={15} aria-hidden="true" />
+        Edit
+      </button>
+      <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-clone" disabled={!selectedProfile || disabled} onclick={cloneSelected}>
+        <Copy size={15} aria-hidden="true" />
+        Clone
+      </button>
       <button
         class="admin-button-primary inline-flex items-center gap-2"
         type="button"
-        data-testid="egress-profile-refresh"
-        disabled={disabled}
-        onclick={onRefresh}
+        disabled={!selectedProfile || selectedProfile.state === 'disabled' || disabled || !onUpdateProfile}
+        data-testid="egress-profile-disable"
+        onclick={() => void disableSelected()}
       >
-        <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
-        Refresh
+        <ShieldOff size={15} aria-hidden="true" />
+        Disable
       </button>
-    </div>
-
-    {#if error}
-      <AdminMessage variant="warning" title="Egress catalog unavailable" message={error} compact={true} />
-    {/if}
-    {#if feedback}
-      <AdminMessage variant={feedback.variant} title={feedback.title} message={feedback.message} compact={true} onDismiss={() => { feedback = null; }} />
-    {/if}
-
-    <div class="grid min-w-0 gap-3 md:grid-cols-[minmax(220px,360px)_1fr] md:items-end">
-      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-        Search
-        <input
-          class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
-          data-testid="egress-profile-search"
-          placeholder="Name, state, proxy, TLS"
-          bind:value={search}
-        />
-      </label>
-      <p class="m-0 text-sm text-admin-ink/62" data-testid="egress-profile-count">
-        {rows.length} of {profiles.length} visible profiles
-      </p>
+      <button
+        class="admin-button-primary inline-flex items-center gap-2"
+        type="button"
+        disabled={!selectedProfile || disabled || !onRunProfileReachabilityProbe}
+        data-testid="egress-profile-reachability-probe"
+        onclick={() => void runReachabilityProbe()}
+      >
+        <RefreshCw class={mutating ? 'animate-spin' : ''} size={15} aria-hidden="true" />
+        Probe
+      </button>
     </div>
   </section>
 
-  <div class="grid min-w-0 gap-3 xl:grid-cols-[minmax(260px,390px)_minmax(0,1fr)]">
-    <section class="grid min-w-0 content-start gap-2 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profiles">
+  {#if error}
+    <AdminMessage variant="warning" title="Egress catalog unavailable" message={error} compact={true} />
+  {/if}
+  {#if feedback}
+    <AdminMessage variant={feedback.variant} title={feedback.title} message={feedback.message} compact={true} onDismiss={() => { feedback = null; }} />
+  {/if}
+
+  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile switcher">
+    <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
+      <div class="min-w-0">
+        <p class="admin-eyebrow mb-1">Profile switcher</p>
+        <p class="m-0 text-sm font-bold text-admin-ink/72" data-testid="egress-profile-count">
+          {rows.length} of {profiles.length} visible profiles
+        </p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <button
+          class="admin-button-primary inline-flex items-center gap-2"
+          type="button"
+          data-testid="egress-profile-new"
+          disabled={disabled}
+          onclick={resetForm}
+        >
+          <ShieldCheck size={15} aria-hidden="true" />
+          New profile
+        </button>
+        <button
+          class="admin-button-primary inline-flex items-center gap-2"
+          type="button"
+          data-testid="egress-profile-refresh"
+          disabled={disabled}
+          onclick={onRefresh}
+        >
+          <RefreshCw class={loading ? 'animate-spin' : ''} size={15} aria-hidden="true" />
+          Refresh
+        </button>
+      </div>
+    </div>
+
+    <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+      Search
+      <input
+        class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+        data-testid="egress-profile-search"
+        placeholder="Name, state, proxy, TLS"
+        bind:value={search}
+      />
+    </label>
+
+    <div class="grid max-h-[min(48vh,34rem)] min-h-0 min-w-0 content-start gap-2 overflow-y-auto pr-1" aria-label="Visible egress profiles">
       {#if rows.length === 0}
         <p class="m-0 text-sm text-admin-ink/62">No egress profiles match the current filter.</p>
       {:else}
@@ -268,11 +373,13 @@
               </span>
             </span>
             <span class="text-xs font-bold text-admin-ink/64" data-testid="egress-profile-row-health">
-              {row.health} | {row.proofLevel.replaceAll('_', ' ')}
+              {row.kind} | updated {row.updatedAt}
             </span>
             <span class="flex min-w-0 flex-wrap gap-1">
               {#each row.badges as badge}
-                <span class="rounded-lg bg-admin-night/58 px-2 py-0.5 text-[11px] font-bold text-[#c1d0e8]">{badge}</span>
+                {#if !badge.startsWith('health ') && !badge.endsWith('proof')}
+                  <span class="rounded-lg bg-admin-night/58 px-2 py-0.5 text-[11px] font-bold text-[#c1d0e8]">{badge}</span>
+                {/if}
               {/each}
             </span>
             {#if row.description}
@@ -281,182 +388,168 @@
           </button>
         {/each}
       {/if}
-    </section>
+    </div>
+  </section>
 
-    <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile details and editor">
+  {#if editorOpen}
+    <form class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile editor" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
       <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
         <div class="min-w-0">
-          <p class="admin-eyebrow mb-1">Profile detail</p>
-          <h3 class="m-0 text-base font-bold text-admin-ink" data-testid="egress-profile-selected-name">
-            {selectedProfile?.name ?? 'No profile selected'}
-          </h3>
+          <p class="admin-eyebrow mb-1">Profile editor</p>
+          <h4 class="m-0 text-sm font-bold text-admin-ink">{editorTitle}</h4>
         </div>
-        <div class="flex min-w-0 flex-wrap gap-2">
-          <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-edit" disabled={!selectedProfile || disabled} onclick={editSelected}>
-            <Network size={15} aria-hidden="true" />
-            Edit
-          </button>
-          <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-clone" disabled={!selectedProfile || disabled} onclick={cloneSelected}>
-            <Copy size={15} aria-hidden="true" />
-            Clone
-          </button>
-          <button
-            class="admin-button-primary inline-flex items-center gap-2"
-            type="button"
-            disabled={!selectedProfile || selectedProfile.state === 'disabled' || disabled || !onUpdateProfile}
-            data-testid="egress-profile-disable"
-            onclick={() => void disableSelected()}
-          >
-            <ShieldOff size={15} aria-hidden="true" />
-            Disable
-          </button>
-          <button
-            class="admin-button-primary inline-flex items-center gap-2"
-            type="button"
-            disabled={!selectedProfile || disabled || !onRunProfileReachabilityProbe}
-            data-testid="egress-profile-reachability-probe"
-            onclick={() => void runReachabilityProbe()}
-          >
-            <RefreshCw class={mutating ? 'animate-spin' : ''} size={15} aria-hidden="true" />
-            Probe
-          </button>
-        </div>
+        <button class="admin-button-ghost" type="button" disabled={disabled} onclick={closeEditor}>
+          Cancel
+        </button>
       </div>
 
-      {#if selectedProfile}
-        <div class="grid min-w-0 gap-2 rounded-xl border border-admin-ink/10 bg-admin-field/62 p-3">
-          <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">State: {selectedProfile.state}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]" data-testid="egress-profile-health">Health: {selectedProfile.diagnostics.health}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">Proxy: {selectedProfile.effective.proxy_configured ? 'configured' : 'none'}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">Proxy auth: {selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none'}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">TLS: {selectedProfile.effective.tls_interception_enabled ? 'inspect' : 'metadata'}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">Bypass: {selectedProfile.effective.bypass_rule_count}</span>
-            <span class="rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]">Reachability: {selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not probed'}</span>
-          </div>
-          <AdminMessage
-            variant={selectedProfile.diagnostics.health === 'ready' ? 'info' : 'warning'}
-            title={`Diagnostics: ${selectedProfile.diagnostics.proof_level.replaceAll('_', ' ')}`}
-            message={selectedProfile.diagnostics.warnings.length > 0
-              ? selectedProfile.diagnostics.warnings.join(' ')
-              : selectedProfile.diagnostics.proof.profile_reachability_collected
-                ? (selectedProfile.diagnostics.proof.profile_reachability_healthy
-                    ? 'Profile reachability evidence is available for this egress endpoint.'
-                    : selectedProfile.diagnostics.proof.profile_reachability_failure ?? 'Profile reachability was probed and failed.')
-              : selectedProfile.diagnostics.proof.active_probe_collected
-                ? 'Active egress probe evidence is available for this profile.'
-                : 'No active probe has been collected yet; proof is based on sanitized configuration metadata.'}
-            compact={true}
-          />
-          <div class="grid min-w-0 gap-2 text-xs font-bold text-admin-ink/68 sm:grid-cols-2 lg:grid-cols-3" data-testid="egress-profile-diagnostics-proof">
-            <span>Profile resolved: {selectedProfile.diagnostics.proof.profile_resolved ? 'yes' : 'no'}</span>
-            <span>Runtime launch: {selectedProfile.diagnostics.proof.runtime_launch_observed ? 'observed' : 'not observed'}</span>
-            <span>Active probe: {selectedProfile.diagnostics.proof.active_probe_collected ? 'collected' : 'not collected'}</span>
-            <span>Profile reachability: {selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not collected'}</span>
-            <span>TLS expected: {selectedProfile.diagnostics.proof.tls_interception_expected ? 'yes' : 'no'}</span>
-            <span>Custom CA launch: {selectedProfile.diagnostics.proof.custom_ca_launch_config_expected ? 'expected' : 'not expected'}</span>
-            <span>Log sink: {selectedProfile.diagnostics.proof.sensitive_log_sink_declared ? 'declared' : 'not declared'}</span>
-          </div>
-        </div>
-      {/if}
-
-      <form class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-field/62 p-3" onsubmit={(event) => { event.preventDefault(); void saveProfile(); }}>
-        <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
-          <h4 class="m-0 text-sm font-bold text-admin-ink">{editing ? 'Edit egress profile' : 'Create egress profile'}</h4>
-          <button class="admin-button-primary inline-flex items-center gap-2" type="button" data-testid="egress-profile-new" disabled={disabled} onclick={resetForm}>
-            <ShieldCheck size={15} aria-hidden="true" />
-            New profile
-          </button>
-        </div>
-
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Name
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-name" bind:value={form.name} disabled={disabled} />
-          </label>
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            State
-            <select class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.state} disabled={disabled}>
-              <option value="ready">ready</option>
-              <option value="disabled">disabled</option>
-            </select>
-          </label>
-        </div>
-
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
         <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-          Description
-          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-description" bind:value={form.description} disabled={disabled} />
+          Name
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-name" bind:value={form.name} disabled={disabled} />
         </label>
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          State
+          <select class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.state} disabled={disabled}>
+            <option value="ready">ready</option>
+            <option value="disabled">disabled</option>
+          </select>
+        </label>
+      </div>
 
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Labels
-            <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-labels" placeholder="region=eu" bind:value={form.labels} disabled={disabled}></textarea>
-          </label>
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Bypass rules
-            <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-bypass-rules" placeholder="localhost&#10;*.local" bind:value={form.bypassRules} disabled={disabled}></textarea>
-          </label>
+      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+        Description
+        <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-description" bind:value={form.description} disabled={disabled} />
+      </label>
+
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Labels
+          <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-labels" placeholder="region=eu" bind:value={form.labels} disabled={disabled}></textarea>
+        </label>
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Bypass rules
+          <textarea class="min-h-24 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field p-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-bypass-rules" placeholder="localhost&#10;*.local" bind:value={form.bypassRules} disabled={disabled}></textarea>
+        </label>
+      </div>
+
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Proxy URL
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-url" placeholder="http://bpane-egress-observer:3128" bind:value={form.proxyUrl} disabled={disabled} />
+        </label>
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Proxy auth binding ID
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-credential-binding-id" placeholder="credential binding UUID" bind:value={form.proxyCredentialBindingId} disabled={disabled} />
+        </label>
+      </div>
+
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Observation mode
+          <select class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-observation-mode" bind:value={form.observationMode} disabled={disabled}>
+            <option value="metadata_only">metadata_only</option>
+            <option value="tls_intercept">tls_intercept</option>
+          </select>
+        </label>
+      </div>
+
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Custom CA ref
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-custom-ca-ref" placeholder="file:///workspace/dev/egress-ca.pem" bind:value={form.customCaRef} disabled={disabled} />
+        </label>
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Custom CA name
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.customCaName} disabled={disabled} />
+        </label>
+      </div>
+
+      <div class="grid min-w-0 gap-3 md:grid-cols-2">
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Log-sink ref
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-log-sink-ref" placeholder="siem://browserpane/local-egress" bind:value={form.sensitiveLogSinkRef} disabled={disabled} />
+        </label>
+        <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+          Log-sink name
+          <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.sensitiveLogSinkName} disabled={disabled} />
+        </label>
+      </div>
+
+      <button
+        class="admin-button-primary inline-flex w-fit items-center gap-2"
+        type="submit"
+        data-testid="egress-profile-save"
+        disabled={disabled || !canSave}
+      >
+        {#if mutating}
+          <RefreshCw class="animate-spin" size={15} aria-hidden="true" />
+          Saving
+        {:else}
+          <ShieldCheck size={15} aria-hidden="true" />
+          {editing ? 'Save profile' : 'Create profile'}
+        {/if}
+      </button>
+    </form>
+  {/if}
+
+  <section class="grid min-w-0 gap-3 rounded-[16px] border border-admin-ink/10 bg-admin-panel/62 p-3" aria-label="Egress profile detail view">
+    <div class="min-w-0">
+      <p class="admin-eyebrow mb-1">Profile detail</p>
+      <h3 class="m-0 text-base font-bold text-admin-ink">Diagnostics and effective configuration</h3>
+    </div>
+
+    {#if selectedProfile}
+      <div class="grid min-w-0 gap-2 rounded-xl border border-admin-ink/10 bg-admin-field/62 p-3">
+        <div class="grid min-w-0 gap-2 sm:grid-cols-2 lg:grid-cols-4">
+          {@render DetailPill('State', selectedProfile.state)}
+          {@render DetailPill('Health', selectedProfile.diagnostics.health, 'egress-profile-health')}
+          {@render DetailPill('Proof', selectedProfile.diagnostics.proof_level.replaceAll('_', ' '))}
+          {@render DetailPill('Proxy', selectedProfile.effective.proxy_configured ? 'configured' : 'none')}
+          {@render DetailPill('Proxy auth', selectedProfile.effective.proxy_auth_configured ? 'binding' : 'none')}
+          {@render DetailPill('TLS', selectedProfile.effective.tls_interception_enabled ? 'inspect' : 'metadata')}
+          {@render DetailPill('Bypass', String(selectedProfile.effective.bypass_rule_count))}
+          {@render DetailPill('Reachability', selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not probed')}
         </div>
-
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Proxy URL
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-url" placeholder="http://bpane-egress-observer:3128" bind:value={form.proxyUrl} disabled={disabled} />
-          </label>
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Proxy auth binding ID
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-proxy-credential-binding-id" placeholder="credential binding UUID" bind:value={form.proxyCredentialBindingId} disabled={disabled} />
-          </label>
+        <AdminMessage
+          variant={selectedProfile.diagnostics.health === 'ready' ? 'info' : 'warning'}
+          title={`Diagnostics: ${selectedProfile.diagnostics.proof_level.replaceAll('_', ' ')}`}
+          message={selectedProfile.diagnostics.warnings.length > 0
+            ? selectedProfile.diagnostics.warnings.join(' ')
+            : selectedProfile.diagnostics.proof.profile_reachability_collected
+              ? (selectedProfile.diagnostics.proof.profile_reachability_healthy
+                  ? 'Profile reachability evidence is available for this egress endpoint.'
+                  : selectedProfile.diagnostics.proof.profile_reachability_failure ?? 'Profile reachability was probed and failed.')
+            : selectedProfile.diagnostics.proof.active_probe_collected
+              ? 'Active egress probe evidence is available for this profile.'
+              : 'No active probe has been collected yet; proof is based on sanitized configuration metadata.'}
+          compact={true}
+        />
+        <div class="grid min-w-0 gap-2 text-xs font-bold text-admin-ink/68 sm:grid-cols-2 lg:grid-cols-3" data-testid="egress-profile-diagnostics-proof">
+          <span>Profile resolved: {selectedProfile.diagnostics.proof.profile_resolved ? 'yes' : 'no'}</span>
+          <span>Runtime launch: {selectedProfile.diagnostics.proof.runtime_launch_observed ? 'observed' : 'not observed'}</span>
+          <span>Active probe: {selectedProfile.diagnostics.proof.active_probe_collected ? 'collected' : 'not collected'}</span>
+          <span>Profile reachability: {selectedProfile.diagnostics.proof.profile_reachability_collected ? (selectedProfile.diagnostics.proof.profile_reachability_healthy ? 'healthy' : 'failed') : 'not collected'}</span>
+          <span>TLS expected: {selectedProfile.diagnostics.proof.tls_interception_expected ? 'yes' : 'no'}</span>
+          <span>Custom CA launch: {selectedProfile.diagnostics.proof.custom_ca_launch_config_expected ? 'expected' : 'not expected'}</span>
+          <span>Log sink: {selectedProfile.diagnostics.proof.sensitive_log_sink_declared ? 'declared' : 'not declared'}</span>
         </div>
-
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Observation mode
-            <select class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-observation-mode" bind:value={form.observationMode} disabled={disabled}>
-              <option value="metadata_only">metadata_only</option>
-              <option value="tls_intercept">tls_intercept</option>
-            </select>
-          </label>
-        </div>
-
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Custom CA ref
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-custom-ca-ref" placeholder="file:///workspace/dev/egress-ca.pem" bind:value={form.customCaRef} disabled={disabled} />
-          </label>
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Custom CA name
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.customCaName} disabled={disabled} />
-          </label>
-        </div>
-
-        <div class="grid min-w-0 gap-3 md:grid-cols-2">
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Log-sink ref
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" data-testid="egress-profile-log-sink-ref" placeholder="siem://browserpane/local-egress" bind:value={form.sensitiveLogSinkRef} disabled={disabled} />
-          </label>
-          <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
-            Log-sink name
-            <input class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-panel/78 px-3 text-admin-ink outline-none focus:border-admin-leaf/45" bind:value={form.sensitiveLogSinkName} disabled={disabled} />
-          </label>
-        </div>
-
-        <button
-          class="admin-button-primary inline-flex w-fit items-center gap-2"
-          type="submit"
-          data-testid="egress-profile-save"
-          disabled={disabled || !canSave}
-        >
-          {#if mutating}
-            <RefreshCw class="animate-spin" size={15} aria-hidden="true" />
-            Saving
-          {:else}
-            <ShieldCheck size={15} aria-hidden="true" />
-            {editing ? 'Save profile' : 'Create profile'}
-          {/if}
-        </button>
-      </form>
-    </section>
-  </div>
+      </div>
+    {:else}
+      <AdminMessage variant="empty" message="Select an egress profile to inspect diagnostics and effective runtime configuration." compact={true} />
+    {/if}
+  </section>
 </div>
+
+{#snippet ProfileFact(label: string, value: string)}
+  <span class="min-w-0 rounded-xl bg-admin-field/72 p-2 font-bold uppercase">
+    {label}
+    <strong class="mt-1 block truncate font-mono text-admin-ink normal-case">{value}</strong>
+  </span>
+{/snippet}
+
+{#snippet DetailPill(label: string, value: string, testId?: string)}
+  <span class="min-w-0 rounded-lg bg-admin-night/58 px-2 py-1 text-xs font-bold text-[#c1d0e8]" data-testid={testId}>
+    {label}: {value}
+  </span>
+{/snippet}

--- a/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
@@ -226,7 +226,6 @@ async function createProfileThroughUi(page, options, profile) {
   );
   await page.locator(`[data-testid="egress-profile-row"]`).filter({ hasText: profile.name }).first().click();
   await page.getByTestId('egress-profile-health').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
-  await page.getByTestId('egress-profile-diagnostics-proof').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   return await fetchProfileByName(page, options, profile.name);
 }
 

--- a/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
@@ -45,15 +45,57 @@ async function run() {
       timeout: options.connectTimeoutMs,
     });
 
-    const proxyCredentialBinding = await createProxyCredentialBinding(accessToken, options, runLabel);
+    const authProxyCredentialBinding = await createProxyCredentialBinding(accessToken, options, {
+      name: `smoke-proxy-auth-${runLabel}`,
+      namespace: 'admin-egress-smoke',
+      allowedOrigins: ['http://bpane-egress-auth-observer:3130'],
+      password: 'proxy-pass',
+      runLabel,
+    });
+    const rejectedProxyCredentialBinding = await createProxyCredentialBinding(accessToken, options, {
+      name: `smoke-proxy-auth-rejected-${runLabel}`,
+      namespace: 'admin-egress-smoke',
+      allowedOrigins: ['http://bpane-egress-auth-observer:3130'],
+      password: 'wrong-pass',
+      runLabel,
+    });
     const proxyProfile = await createProfileThroughUi(page, options, {
       name: `smoke-proxy-${runLabel}`,
-      description: 'Admin smoke metadata-only proxy profile with secret-backed proxy auth',
+      description: 'Admin smoke metadata-only proxy profile',
       labels: 'suite=admin-egress\nmode=proxy',
       proxyUrl: 'http://bpane-egress-observer:3128',
-      proxyCredentialBindingId: proxyCredentialBinding.id,
       bypassRules: 'localhost\n*.local',
       mode: 'metadata_only',
+    });
+    const authProxyProfile = await createProfileThroughUi(page, options, {
+      name: `smoke-auth-proxy-${runLabel}`,
+      description: 'Admin smoke authenticated proxy profile with secret-backed proxy auth',
+      labels: 'suite=admin-egress\nmode=proxy-auth',
+      proxyUrl: 'http://bpane-egress-auth-observer:3130',
+      proxyCredentialBindingId: authProxyCredentialBinding.id,
+      bypassRules: 'localhost\n*.local',
+      mode: 'metadata_only',
+    });
+    const rejectedAuthProfile = await createEgressProfile(accessToken, options, {
+      name: `smoke-auth-rejected-${runLabel}`,
+      description: 'Admin smoke authenticated proxy profile with rejected credentials',
+      labels: { suite: 'admin-egress', mode: 'proxy-auth-rejected' },
+      proxy: {
+        url: 'http://bpane-egress-auth-observer:3130',
+        credential_binding_id: rejectedProxyCredentialBinding.id,
+      },
+      bypass_rules: ['localhost', '*.local'],
+      traffic_observation: { mode: 'metadata_only' },
+    });
+    const missingAuthProfile = await createEgressProfile(accessToken, options, {
+      name: `smoke-auth-missing-${runLabel}`,
+      description: 'Admin smoke authenticated proxy profile without credentials',
+      labels: { suite: 'admin-egress', mode: 'proxy-auth-missing' },
+      proxy: {
+        url: 'http://bpane-egress-auth-observer:3130',
+      },
+      bypass_rules: ['localhost', '*.local'],
+      traffic_observation: { mode: 'metadata_only' },
     });
     const tlsProfile = await createProfileThroughUi(page, options, {
       name: `smoke-tls-${runLabel}`,
@@ -69,12 +111,16 @@ async function run() {
     });
 
     await probeProfileReachabilityThroughUi(page, options, accessToken, proxyProfile);
+    await probeProfileReachabilityThroughUi(page, options, accessToken, authProxyProfile);
+    await probeProfileReachabilityFailure(accessToken, options, rejectedAuthProfile, /proxy authentication/i);
+    await probeProfileReachabilityFailure(accessToken, options, missingAuthProfile, /proxy authentication/i);
     await probeProfileReachabilityThroughUi(page, options, accessToken, tlsProfile);
 
     const clonedProfile = await cloneAndDisableProfile(page, options, accessToken, tlsProfile);
     await verifyDisabledProfileIsNotHealthyLaunchChoice(page, options, clonedProfile.id);
     sessionIds = await verifySessionEffectiveEgress(accessToken, options, {
       proxyProfile,
+      authProxyProfile,
       tlsProfile,
       observerSince,
       runLabel,
@@ -82,7 +128,11 @@ async function run() {
 
     console.log(JSON.stringify({
       proxyProfileId: proxyProfile.id,
-      proxyCredentialBindingId: proxyCredentialBinding.id,
+      authProxyProfileId: authProxyProfile.id,
+      authProxyCredentialBindingId: authProxyCredentialBinding.id,
+      rejectedAuthProfileId: rejectedAuthProfile.id,
+      rejectedProxyCredentialBindingId: rejectedProxyCredentialBinding.id,
+      missingAuthProfileId: missingAuthProfile.id,
       tlsProfileId: tlsProfile.id,
       disabledProfileId: clonedProfile.id,
       sessionIds,
@@ -98,6 +148,26 @@ async function run() {
     }
     await context.close();
     await browser.close();
+  }
+}
+
+async function probeProfileReachabilityFailure(accessToken, options, profile, expectedFailure) {
+  const diagnostics = await fetchJson(`${apiOrigin(options)}/api/v1/egress-profiles/${profile.id}/diagnostics/probe`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ timeout_ms: 10000 }),
+  });
+  const failure = diagnostics?.proof?.profile_reachability_failure ?? '';
+  if (
+    diagnostics?.proof?.profile_reachability_collected !== true
+    || diagnostics?.proof?.profile_reachability_healthy !== false
+    || !expectedFailure.test(failure)
+  ) {
+    throw new Error(`Expected profile reachability diagnostics to fail for ${profile.name}, got ${JSON.stringify(diagnostics)}`);
+  }
+  const serialized = JSON.stringify(diagnostics);
+  if (serialized.includes('wrong-pass') || serialized.includes('proxy-pass')) {
+    throw new Error(`Proxy-auth diagnostics leaked a credential value for ${profile.name}: ${serialized}`);
   }
 }
 
@@ -204,7 +274,7 @@ async function verifyDisabledProfileIsNotHealthyLaunchChoice(page, options, prof
 }
 
 async function verifySessionEffectiveEgress(accessToken, options, context) {
-  const { proxyProfile, tlsProfile, observerSince, runLabel } = context;
+  const { proxyProfile, authProxyProfile, tlsProfile, observerSince, runLabel } = context;
   const verifiedSessionIds = [];
   const noEgress = await createSession(accessToken, options, {});
   verifiedSessionIds.push(noEgress.id);
@@ -231,15 +301,15 @@ async function verifySessionEffectiveEgress(accessToken, options, context) {
   if (proxy.effective_egress?.profile_id !== proxyProfile.id || proxy.effective_egress?.tls_interception_enabled) {
     throw new Error(`Expected proxy session effective egress for ${proxyProfile.id}, got ${JSON.stringify(proxy.effective_egress)}`);
   }
-  if (proxy.effective_egress?.proxy_auth_configured !== true) {
-    throw new Error(`Expected proxy session to report configured proxy auth, got ${JSON.stringify(proxy.effective_egress)}`);
+  if (proxy.effective_egress?.proxy_auth_configured !== false) {
+    throw new Error(`Expected proxy session to report no configured proxy auth, got ${JSON.stringify(proxy.effective_egress)}`);
   }
   const proxyDiagnostics = await launchAndFetchEgressDiagnostics(accessToken, options, proxy.id);
   if (proxyDiagnostics.health !== 'ready' || proxyDiagnostics.proof_level !== 'runtime_launch_metadata') {
     throw new Error(`Expected proxy runtime diagnostics to be ready with launch metadata, got ${JSON.stringify(proxyDiagnostics)}`);
   }
-  if (proxyDiagnostics.proxy_auth_configured !== true) {
-    throw new Error(`Expected proxy diagnostics to report configured proxy auth, got ${JSON.stringify(proxyDiagnostics)}`);
+  if (proxyDiagnostics.proxy_auth_configured !== false) {
+    throw new Error(`Expected proxy diagnostics to report no configured proxy auth, got ${JSON.stringify(proxyDiagnostics)}`);
   }
   const proxyProbe = await runSessionEgressProbe(accessToken, options, proxy.id, runLabel).catch(() => null);
   await assertObserverCorrelation({
@@ -249,10 +319,33 @@ async function verifySessionEffectiveEgress(accessToken, options, context) {
     observerSince,
     expectedMode: 'metadata_only',
     expectedHost: probeObserved(proxyProbe) ? 'example.com' : null,
+    expectedProxyAuth: false,
+  });
+  await deleteSession(accessToken, options, proxy.id);
+
+  const authProxy = await createSession(accessToken, options, {
+    network_identity: { egress_profile_id: authProxyProfile.id },
+  });
+  verifiedSessionIds.push(authProxy.id);
+  if (authProxy.effective_egress?.profile_id !== authProxyProfile.id || authProxy.effective_egress?.proxy_auth_configured !== true) {
+    throw new Error(`Expected auth proxy session effective egress for ${authProxyProfile.id}, got ${JSON.stringify(authProxy.effective_egress)}`);
+  }
+  const authProxyDiagnostics = await launchAndFetchEgressDiagnostics(accessToken, options, authProxy.id);
+  if (authProxyDiagnostics.health !== 'ready' || authProxyDiagnostics.proof_level !== 'runtime_launch_metadata') {
+    throw new Error(`Expected auth proxy runtime diagnostics to be ready with launch metadata, got ${JSON.stringify(authProxyDiagnostics)}`);
+  }
+  const authProxyProbe = await runSessionEgressProbeUntilObserved(accessToken, options, authProxy.id, runLabel);
+  await assertObserverCorrelation({
+    sessionId: authProxy.id,
+    profileId: authProxyProfile.id,
+    observerContainer: 'bpane-egress-auth-observer',
+    observerSince,
+    expectedMode: 'metadata_only',
+    expectedHost: 'example.com',
     expectedProxyAuth: true,
   });
-  await assertSecretBackedProxyAuthRuntime(proxy.id);
-  await deleteSession(accessToken, options, proxy.id);
+  await assertSecretBackedProxyAuthRuntime(authProxy.id);
+  await deleteSession(accessToken, options, authProxy.id);
 
   const tls = await createSession(accessToken, options, {
     network_identity: { egress_profile_id: tlsProfile.id },
@@ -283,25 +376,34 @@ async function verifySessionEffectiveEgress(accessToken, options, context) {
   return verifiedSessionIds;
 }
 
-async function createProxyCredentialBinding(accessToken, options, runLabel) {
+async function createProxyCredentialBinding(accessToken, options, request) {
   return await fetchJson(`${apiOrigin(options)}/api/v1/credential-bindings`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      name: `smoke-proxy-auth-${runLabel}`,
+      name: request.name,
       provider: 'vault_kv_v2',
-      namespace: 'admin-egress-smoke',
-      allowed_origins: ['http://bpane-egress-observer:3128'],
+      namespace: request.namespace,
+      allowed_origins: request.allowedOrigins,
       injection_mode: 'form_fill',
       secret_payload: {
         username: 'proxy-user',
-        password: 'proxy-pass',
+        password: request.password,
       },
       labels: {
         suite: 'admin-egress',
         purpose: 'egress-proxy-auth',
+        run_id: String(request.runLabel),
       },
     }),
+  });
+}
+
+async function createEgressProfile(accessToken, options, profile) {
+  return await fetchJson(`${apiOrigin(options)}/api/v1/egress-profiles`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(profile),
   });
 }
 
@@ -327,8 +429,31 @@ async function runSessionEgressProbe(accessToken, options, sessionId, runLabel) 
   });
 }
 
+async function runSessionEgressProbeUntilObserved(accessToken, options, sessionId, runLabel) {
+  const lastProbe = { value: null };
+  return await poll(
+    `authenticated proxy browser egress probe ${sessionId}`,
+    async () => {
+      lastProbe.value = await runSessionEgressProbe(accessToken, options, sessionId, runLabel).catch((error) => ({
+        error: error.message,
+      }));
+      return lastProbe.value;
+    },
+    probeObserved,
+    Math.max(options.connectTimeoutMs, 90000),
+    1000,
+  ).catch(() => {
+    throw new Error(`Expected authenticated proxy browser probe to collect active egress proof, got ${JSON.stringify(lastProbe.value)}`);
+  });
+}
+
 function probeObserved(probe) {
-  return probe?.proof?.active_probe_collected === true && probe?.proof?.active_probe_healthy === true;
+  return (
+    probe?.health === 'ready'
+    && probe?.proof_level === 'active_probe'
+    && probe?.proof?.active_probe_collected === true
+    && !probe?.proof?.last_failure_reason
+  );
 }
 
 async function assertObserverCorrelation({

--- a/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-egress-profiles-smoke.mjs
@@ -67,6 +67,7 @@ async function run() {
       bypassRules: 'localhost\n*.local',
       mode: 'metadata_only',
     });
+    await verifyProfileEditThroughUi(page, options, proxyProfile);
     const authProxyProfile = await createProfileThroughUi(page, options, {
       name: `smoke-auth-proxy-${runLabel}`,
       description: 'Admin smoke authenticated proxy profile with secret-backed proxy auth',
@@ -227,6 +228,30 @@ async function createProfileThroughUi(page, options, profile) {
   await page.locator(`[data-testid="egress-profile-row"]`).filter({ hasText: profile.name }).first().click();
   await page.getByTestId('egress-profile-health').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   return await fetchProfileByName(page, options, profile.name);
+}
+
+async function verifyProfileEditThroughUi(page, options, profile) {
+  await page.getByTestId('egress-profile-search').fill(profile.name);
+  await page.locator(`[data-testid="egress-profile-row"][data-profile-id="${profile.id}"]`).click();
+  await page.getByTestId('egress-profile-edit').click();
+  const nameInput = page.getByTestId('egress-profile-name');
+  await nameInput.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  const value = await nameInput.inputValue();
+  if (value !== profile.name) {
+    throw new Error(`Expected egress profile edit form to load ${profile.name}, got ${value}`);
+  }
+  await page.waitForFunction(
+    () => document.activeElement?.getAttribute('data-testid') === 'egress-profile-name',
+    null,
+    { timeout: options.connectTimeoutMs },
+  );
+  const inViewport = await nameInput.evaluate((input) => {
+    const rect = input.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= window.innerHeight;
+  });
+  if (!inViewport) {
+    throw new Error('Expected egress profile edit form to be scrolled into view.');
+  }
 }
 
 async function cloneAndDisableProfile(page, options, accessToken, sourceProfile) {

--- a/deploy/examples/egress-observer/Dockerfile
+++ b/deploy/examples/egress-observer/Dockerfile
@@ -1,15 +1,19 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates squid \
+    && apt-get install -y --no-install-recommends apache2-utils ca-certificates squid \
     && rm -rf /var/lib/apt/lists/*
 
 COPY squid.conf /etc/squid/squid.conf
+COPY squid-auth.conf /etc/squid/squid-auth.conf
 
 RUN mkdir -p /var/log/squid /var/spool/squid /run/squid \
+    && htpasswd -bc /etc/squid/proxy-auth.htpasswd proxy-user proxy-pass \
+    && chown proxy:proxy /etc/squid/proxy-auth.htpasswd \
+    && chmod 640 /etc/squid/proxy-auth.htpasswd \
     && chown -R proxy:proxy /var/log/squid /var/spool/squid /run/squid
 
 USER proxy
-EXPOSE 3128
+EXPOSE 3128 3130
 
 CMD ["squid", "-N", "-f", "/etc/squid/squid.conf"]

--- a/deploy/examples/egress-observer/README.md
+++ b/deploy/examples/egress-observer/README.md
@@ -7,7 +7,11 @@ correlation metadata; the proxy records destinations, status, bytes, and timing.
 
 The example uses Squid as a plain forward proxy. HTTPS traffic is not
 man-in-the-middle inspected, so proxy logs normally contain `CONNECT host:443`
-for TLS traffic rather than request paths or response bodies.
+for TLS traffic rather than request paths or response bodies. The same compose
+file also starts an auth-enforcing Squid proxy at
+`bpane-egress-auth-observer:3130` with local test credentials
+`proxy-user / proxy-pass` so proxy-auth success and rejection paths can be
+validated without a production proxy.
 
 For local full HTTPS inspection, also start the mitmproxy-based TLS observer in
 `compose.tls.yml`. It listens as `bpane-egress-tls-observer:3129` and mints
@@ -26,6 +30,13 @@ Docker network:
 docker compose -f deploy/compose.yml up --build
 docker compose -f deploy/examples/egress-observer/compose.yml up --build
 ```
+
+The compose file starts:
+
+- `bpane-egress-observer:3128` for metadata-only proxy observation without
+  authentication.
+- `bpane-egress-auth-observer:3130` for metadata-only proxy observation with
+  Basic proxy authentication.
 
 If your main compose project uses a non-default network name, pass it
 explicitly:
@@ -73,6 +84,28 @@ share the same network.
   --bypass-rule "*.local"
 ```
 
+To validate proxy authentication, create a credential binding through the admin
+app or `/api/v1/credential-bindings` with a JSON payload containing
+`username=proxy-user` and `password=proxy-pass`, then point an egress profile at
+the auth observer:
+
+```bash
+./scripts/bpane egress-profile create local-auth-egress-observer \
+  --description "Local authenticated Squid access-log observer" \
+  --label observer=local-squid-auth \
+  --proxy-url http://bpane-egress-auth-observer:3130 \
+  --proxy-credential-binding-id <credential-binding-id> \
+  --bypass-rule localhost \
+  --bypass-rule 127.0.0.1 \
+  --bypass-rule "*.local"
+```
+
+Running `./scripts/bpane egress-profile diagnostics probe
+<egress-profile-id>` performs a real proxy request. A valid binding reports a
+healthy profile reachability probe. A missing binding, unavailable credential
+provider, malformed secret payload, or rejected proxy credential reports a
+sanitized failure reason without returning the secret value.
+
 For the TLS-intercept observer, include the CA and sensitive-log metadata:
 
 ```bash
@@ -107,6 +140,7 @@ Squid writes access logs to container stdout:
 
 ```bash
 docker compose -f deploy/examples/egress-observer/compose.yml logs -f egress-proxy
+docker compose -f deploy/examples/egress-observer/compose.yml logs -f egress-auth-proxy
 ```
 
 The TLS observer writes mitmproxy flow logs to container stdout:
@@ -142,7 +176,9 @@ log to join control-plane events with proxy access logs.
 If a profile references `proxy.credential_binding_id`, BrowserPane resolves the
 secret at runtime launch and configures Chromium proxy authentication from a
 session-local auth file. The credential value is not written to proxy URLs,
-Docker labels, or gateway startup logs.
+Docker labels, API diagnostics, CLI output, or gateway startup logs. Profile
+reachability probes resolve the same binding and send proxy credentials only to
+the configured proxy.
 
 ## Production Pattern
 
@@ -158,3 +194,8 @@ pipeline is:
 3. The egress proxy logs outbound traffic.
 4. A log shipper or SIEM collector tails proxy logs and joins them with the
    BrowserPane session/profile correlation metadata.
+
+For authenticated enterprise proxies, keep proxy-auth verification at the proxy
+boundary: the proxy owns authentication accept/reject logs, while BrowserPane
+exposes only sanitized binding/configuration state plus profile/session
+diagnostics.

--- a/deploy/examples/egress-observer/compose.yml
+++ b/deploy/examples/egress-observer/compose.yml
@@ -10,6 +10,18 @@ services:
         aliases:
           - bpane-egress-observer
 
+  egress-auth-proxy:
+    build:
+      context: .
+    container_name: bpane-egress-auth-observer
+    command: ["squid", "-N", "-f", "/etc/squid/squid-auth.conf"]
+    ports:
+      - "${BPANE_EGRESS_AUTH_OBSERVER_PORT:-3130}:3130"
+    networks:
+      bpane-internal:
+        aliases:
+          - bpane-egress-auth-observer
+
 networks:
   bpane-internal:
     external: true

--- a/deploy/examples/egress-observer/squid-auth.conf
+++ b/deploy/examples/egress-observer/squid-auth.conf
@@ -1,0 +1,31 @@
+visible_hostname bpane-egress-auth-observer
+http_port 3130
+
+# Keep the example focused on outbound observation, not object caching.
+cache deny all
+cache_store_log none
+pid_filename /tmp/squid-auth.pid
+
+# The default local BrowserPane compose network is deploy_bpane-internal.
+# Adjust this ACL if the main stack uses a different subnet.
+acl bpane_runtime_network src 172.28.0.0/16
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl CONNECT method CONNECT
+
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/proxy-auth.htpasswd
+auth_param basic realm BrowserPane Egress Auth Observer
+acl authenticated proxy_auth REQUIRED
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+http_access allow bpane_runtime_network authenticated
+http_access deny all
+
+# Access logs are the observer attachment point. Ship stdout with the log
+# collector used in your environment, or replace this with a file path mounted
+# into a sidecar collector.
+access_log stdio:/dev/stdout squid
+log_mime_hdrs off
+forwarded_for delete

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -540,7 +540,7 @@ paths:
     post:
       tags: [Egress Profiles]
       summary: Run an active egress profile reachability probe
-      description: Checks the configured proxy authority from the gateway side without starting a browser runtime and persists only sanitized health metadata.
+      description: Checks the configured proxy from the gateway side without starting a browser runtime. When proxy authentication is configured, the gateway resolves the credential binding for the probe, performs a real proxy request, and persists only sanitized success/failure metadata.
       operationId: runEgressProfileReachabilityProbe
       requestBody:
         required: false


### PR DESCRIPTION
## Summary

Closes #129.

This PR makes the egress/network identity feature production-shaped enough to stop expanding it directly after merge. It adds an auth-enforcing local Squid fixture, validates egress profile reachability through real proxy requests with credential bindings, and extends the admin smoke to cover valid, rejected, and missing proxy-auth cases. It also fixes active browser egress diagnostics against Docker-backed CDP endpoints by using a Chromium-safe Host header for CDP HTTP and WebSocket calls.

The final branch update also brings the admin Operations Overlay egress tab in line with the Sessions pattern: a simple profile selection list, a selected-profile metadata panel with contextual actions, and a visible/focused editor when New, Edit, or Clone is used.

Example use case: an enterprise support operator must launch a BrowserPane session through an approved authenticated outbound proxy. The operator can create/select the egress profile without seeing the proxy secret, prove that the credential binding works before launch, run an active browser egress probe after launch, and correlate proxy-side logs back to the BrowserPane session/profile without leaking credentials.

## Validation

- cargo test --workspace
- cargo test -p bpane-gateway network_identity
- cargo test -p bpane-gateway egress_diagnostics
- cargo test -p bpane-gateway --test compose_api_surface compose_network_identity_api_surface -- --ignored --test-threads=1
- cd code/web/bpane-admin && npm test
- cd code/web/bpane-admin && npm run check
- cd code/web/bpane-admin && npm run build
- cd code/web/bpane-client && npm test
- cd code/web/bpane-client && npm run build
- cd code/web/bpane-client && node --check scripts/run-admin-egress-profiles-smoke.mjs
- cd code/web/bpane-client && npm run smoke:admin-egress-profiles -- --headless
- cd code/web/bpane-client && npm run smoke:admin-session-configurator -- --headless
- cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless
- docker compose -f deploy/examples/egress-observer/compose.yml config
- docker compose -f deploy/examples/egress-observer/compose.yml up -d --build
- curl proxy fixture boundary: no auth = 407, wrong auth = 407, valid auth = 200

## Plan Fit

#130 is already merged. #129 now closes the final direct egress/network-identity hardening slice. After this PR, the next work should shift to the enterprise control-plane sequence in BPANE_OPEN_ISSUES_INTEGRATION_PLAN.md: #27, #52, #28/#70, then #80/#79.
