### PR TITLE
Add first project resources and session quota admission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Current product shape:
   - WebTransport gateway and shared-session coordinator.
   - `transport.rs`: browser connection loop, per-client policy, relay behavior.
   - `session_hub.rs`: fan-out, late-join bootstrap, viewer cap, telemetry.
-  - `session_control.rs`: versioned session-control store and Postgres integration, including session templates, browser contexts, workflows, credential bindings, file workspaces, and approved extension metadata.
+  - `session_control.rs`: versioned session-control store and Postgres integration, including projects with admission quotas, session templates, browser contexts, workflows, credential bindings, file workspaces, and approved extension metadata.
   - `browser_contexts/retention.rs`: background cleanup for ready reusable browser contexts whose per-context retention window expired; runtime-backed cleanup skips active writers and removes docker profile volumes through the session manager. Browser context resources can also carry per-context profile storage limits; the API reports over-limit usage and blocks new reusable sessions from contexts whose inspected profile storage exceeds that limit. Inactive reusable contexts can be cloned into new owner-scoped reusable contexts, exported as zip archives, or imported from BrowserPane export archives into new reusable contexts; docker-backed runtimes copy, package, or restore profile volume data when present.
   - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
   - `credential_provider.rs`: credential binding secret-provider boundary. Local compose uses HashiCorp Vault dev mode and the current implementation targets Vault KV v2.

--- a/ARCH.md
+++ b/ARCH.md
@@ -276,9 +276,15 @@ service.
   - `GET /api/v1/session-templates` — list reusable owner-scoped session templates
   - `GET /api/v1/session-templates/{id}` — fetch one session template
   - `PUT /api/v1/session-templates/{id}` — replace a session template and increment its version
+  - `POST /api/v1/projects` — create an owner-scoped project with labels, state, quota metadata, and usage counters
+  - `GET /api/v1/projects` — list owner-scoped projects with sanitized usage summaries
+  - `GET /api/v1/projects/{id}` — fetch one project
+  - `PUT /api/v1/projects/{id}` — replace one project, including quota metadata and lifecycle state
+  - `GET /api/v1/projects/{id}/usage` — fetch current project usage counters
   - `POST /api/v1/egress-profiles` — create an owner-scoped egress profile with sanitized proxy, optional proxy-auth credential binding reference, bypass, custom CA, and traffic-observation metadata
   - `GET /api/v1/egress-profiles` — list owner-scoped egress profiles
   - `GET /api/v1/egress-profiles/{id}` — fetch one egress profile
+  - session resources can carry `project_id`, a project summary, and an admission decision; project-scoped session creation enforces active-session quotas and archived-project rejection before runtime launch
   - egress traffic observation is intentionally proxy-side: session resources and gateway startup logs expose safe correlation metadata, while the configured egress proxy or secure web gateway owns URL/status/bytes/timing logs. TLS-intercept mode is an explicit egress profile setting and requires proxy, custom CA, and sensitive-log sink references. Proxy authentication is secret-backed through owner-scoped credential bindings and is materialized only as a session-local runtime auth file.
   - `POST /api/v1/sessions/{id}/access-tokens` — mint a short-lived session-scoped connect ticket
   - `POST /api/v1/sessions/{id}/stop` — explicit safe-stop with blocker reporting
@@ -469,7 +475,7 @@ The default dev stack no longer uses a shared token file.
 - the admin console discovers the OIDC provider and performs Authorization Code + PKCE
 - local browser users authenticate against Keycloak on `http://localhost:8091`
 - the local demo user is `demo / demo-demo`
-- after login, the admin console lists owner-scoped `/api/v1/sessions`, session templates, egress profiles, and browser contexts; it lets the user join an existing session, start a new one with optional template, network-identity, egress-profile, and reusable-context bindings, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
+- after login, the admin console lists owner-scoped `/api/v1/sessions`, projects, session templates, egress profiles, and browser contexts; it lets the user join an existing session, start a new one with optional project, template, network-identity, egress-profile, and reusable-context bindings, inspect project/admission metadata on live rows and session detail views, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
 - docker-backed reusable browser contexts mount a context-scoped Chromium profile volume at the session profile path while keeping uploads, downloads, and session-file mounts in the session-scoped data volume; runtime admission allows only one active writer per reusable context
 - browser-context retention cleanup is metadata-driven per context and removes expired reusable profile data only when the runtime manager confirms there is no active writer
 - the console then mints a short-lived `session_connect_ticket` through `POST /api/v1/sessions/{id}/access-tokens`
@@ -538,11 +544,12 @@ The supported local operator CLI lives in
 `code/web/bpane-client/scripts/bpane-cli.mjs`, is exposed as the package binary
 `bpane`, and has a repo-level wrapper at `scripts/bpane`.
 
-- Commands cover profile inspection/init, egress-profile create/list/get,
-  session create/list/get/status with network-identity options, access-ticket
-  and automation-access minting, connection disconnect, stop, kill, and bounded
-  cleanup. Egress-profile create/update commands can attach a proxy-auth
-  credential binding with `--proxy-credential-binding-id`.
+- Commands cover profile inspection/init, project create/list/get/usage/update/archive,
+  egress-profile create/list/get, session create/list/get/status with project
+  and network-identity options, access-ticket and automation-access minting,
+  connection disconnect, stop, kill, and bounded cleanup. Egress-profile
+  create/update commands can attach a proxy-auth credential binding with
+  `--proxy-credential-binding-id`.
 - `deploy/examples/egress-observer` provides local Squid forward-proxy
   examples for metadata-only access-log observation, session/container IP
   correlation, and authenticated proxy validation, plus a mitmproxy
@@ -809,10 +816,12 @@ more custom code and therefore more surface area for bugs.
   workloads in production, this matters.
 
 - **Production operations are still limited.** The gateway now has a durable
-  owner-scoped control plane, docker-backed runtime assignments, and
-  profile-backed reconnect/release semantics. It is still not an HA production
-  control plane: backup/restore, zero-downtime upgrades, multi-node runtime
-  scheduling, and full enterprise governance remain future work.
+  owner-scoped control plane, project-scoped active-session admission,
+  docker-backed runtime assignments, and profile-backed reconnect/release
+  semantics. It is still not an HA production control plane: project queueing,
+  cross-resource project quotas, backup/restore, zero-downtime upgrades,
+  multi-node runtime scheduling, and full enterprise governance remain future
+  work.
 
 - **No end-to-end testing of the visual pipeline.** The protocol has unit tests
   and integration tests for framing. The tile compositor has unit tests. But

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current support and scope:
 - Shared sessions: collaborative by default, intended for small curated groups rather than broadcast-scale delivery.
 - Owner/viewer mode: optional exclusive-owner mode is supported in the gateway; restricted viewers are read-only.
 - Camera: disabled by default in the compose stack and requires browser H.264 encode support plus a mapped `v4l2loopback` device.
-- Control plane: owner-scoped v1 APIs now cover sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
+- Control plane: owner-scoped v1 APIs now cover projects, sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
 - Workflow execution: Git-backed workflow versions run through a gateway-managed `workflow-worker`; the current executor model is Playwright.
 - Workflow boundary: BrowserPane currently focuses on executing and supervising browser workflows. Broader scheduling, DAG orchestration, and cross-system coordination are expected to sit above BrowserPane rather than inside it.
 
@@ -94,8 +94,9 @@ At a high level, BrowserPane has five responsibilities:
 2. Capture and classify that surface efficiently.
 3. Transport state, input, and media between host and browser.
 4. Render the remote session in a regular web page.
-5. Coordinate durable control-plane resources for sessions, workflows,
-   recordings, files, credentials, extensions, and automation ownership.
+5. Coordinate durable control-plane resources for projects, sessions,
+   workflows, recordings, files, credentials, extensions, and automation
+   ownership.
 
 The default local runtime looks like this:
 
@@ -121,7 +122,7 @@ bpane-gateway also talks to:
 | Project | Responsibility |
 | --- | --- |
 | `code/apps/bpane-host` | Linux host agent. Captures the desktop surface, classifies tiles, drives ROI H.264 video, emits audio, injects input, and handles clipboard, file transfer, resize, and camera ingress plumbing. |
-| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for sessions, session templates, automation tasks, recordings, workflows, files, credentials, and extensions. |
+| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for projects, sessions, session templates, automation tasks, recordings, workflows, files, credentials, and extensions. |
 | `code/shared/bpane-protocol` | Shared binary wire contract. Defines channels, frame envelopes, typed protocol messages, and incremental frame decoding used by the Rust services and validated against the browser client. |
 | `code/web/bpane-client` | Real browser client. Renders tiles/video, decodes media, captures keyboard/mouse/clipboard input, and manages browser-side audio, camera, and file-transfer flows. |
 | `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes compatibility Streamable HTTP on `/mcp`, session-scoped Streamable HTTP on `/sessions/{id}/mcp`, compatibility SSE on `/sse`, session-scoped SSE on `/sessions/{id}/sse`, and integrates with gateway ownership APIs so automation can attach alongside interactive browser users through delegated session control. |

--- a/README.md
+++ b/README.md
@@ -298,6 +298,11 @@ Canonical contract:
 - `GET /api/v1/session-templates`
 - `GET /api/v1/session-templates/{id}`
 - `PUT /api/v1/session-templates/{id}`
+- `POST /api/v1/projects`
+- `GET /api/v1/projects`
+- `GET /api/v1/projects/{id}`
+- `PUT /api/v1/projects/{id}`
+- `GET /api/v1/projects/{id}/usage`
 - `POST /api/v1/egress-profiles`
 - `GET /api/v1/egress-profiles`
 - `GET /api/v1/egress-profiles/{id}`
@@ -311,7 +316,7 @@ full contract is in the OpenAPI file; the route lists below call out the
 operator-facing surfaces that are most relevant for local development.
 
 Session templates store reusable defaults for session creation, including owner
-mode, viewport, idle timeout, labels, integration context, network identity, and recording policy.
+mode, project id, viewport, idle timeout, labels, integration context, network identity, and recording policy.
 Creating a session with a UUID `template_id` merges those defaults before the
 session is persisted; explicit caller fields win over template defaults.
 The admin create-session configurator follows the same rule: selecting a
@@ -320,6 +325,14 @@ explicit override, and the API payload preview shows the exact fields that will
 be sent.
 `GET /api/v1/sessions` accepts catalog filters such as `template_id`, `state`,
 `runtime_state`, `label.<key>`, `integration.<key>`, `limit`, and `offset`.
+Project resources let operators group sessions under an owner-scoped tenant,
+case, customer, or environment boundary. A project carries labels, lifecycle
+state, optional quotas such as `max_active_sessions`, and sanitized usage
+counters. Creating a session with `project_id` records the admission decision on
+the session and enforces active-session quota and archived-project checks before
+runtime launch. Session resources and `/status` include the project summary and
+admission reason so the admin live view, inspector, CLI, and API clients all
+show whether a session was admitted under a project quota or left owner-scoped.
 Network identity metadata lets callers declare locale, language preferences,
 timezone, geolocation, browser identity, user-agent override, and an
 `egress_profile_id` on either a session template or an explicit session create
@@ -521,6 +534,7 @@ Common session operations:
 ./scripts/bpane session list --state stopped --label suite=smoke --limit 5
 ./scripts/bpane session list --template-id <template-id> --label team=support
 ./scripts/bpane session create --label purpose=manual-test
+./scripts/bpane session create --project-id <project-id> --label purpose=tenant-test
 ./scripts/bpane session create --browser-context-id <context-id> --label purpose=context-test
 ./scripts/bpane session create \
   --locale de-DE \
@@ -552,6 +566,23 @@ Common session-template operations:
 ./scripts/bpane session-template get <template-id>
 ./scripts/bpane session-template update <template-id> --name customer-debug-session --default-label purpose=debug
 ./scripts/bpane session create --template-id <template-id> --label case=INC-1234
+```
+
+Common project operations:
+
+```bash
+./scripts/bpane project create support-tenant \
+  --description "Support tenant quota" \
+  --label tenant=support \
+  --max-active-sessions 3 \
+  --max-active-workflow-runs 4 \
+  --max-retained-storage-bytes 1073741824
+./scripts/bpane project list
+./scripts/bpane project get <project-id>
+./scripts/bpane project usage <project-id>
+./scripts/bpane project update <project-id> --name support-tenant --max-active-sessions 5
+./scripts/bpane project archive <project-id>
+./scripts/bpane session-template create tenant-debug-session --project-id <project-id> --default-label purpose=debug
 ```
 
 Common egress-profile operations:
@@ -697,9 +728,10 @@ destructive cleanup.
 The operator CLI integration smoke is
 `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`. It logs in
 through the admin app, creates a session, initializes a CLI profile, exercises
-session access/status/disconnect/stop/kill/cleanup, and validates standalone MCP
-health, authorize, set-default, doctor, preflight, repair, revoke, and
-clear-default flows.
+project/session-template/browser-context/egress catalog operations,
+session access/status/diagnostics/disconnect/stop/kill/cleanup, and validates
+standalone MCP health, authorize, set-default, doctor, preflight, repair,
+revoke, and clear-default flows.
 
 Current runtime notes:
 

--- a/code/apps/bpane-gateway/migrations/20260528000100_projects_admission.sql
+++ b/code/apps/bpane-gateway/migrations/20260528000100_projects_admission.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS control_projects (
+    id UUID PRIMARY KEY,
+    owner_subject TEXT NOT NULL,
+    owner_issuer TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+    quotas JSONB NOT NULL DEFAULT '{}'::jsonb,
+    state TEXT NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (owner_subject, owner_issuer, name)
+);
+
+CREATE INDEX IF NOT EXISTS control_projects_owner_idx
+    ON control_projects (owner_subject, owner_issuer, created_at DESC);
+
+ALTER TABLE control_sessions
+    ADD COLUMN IF NOT EXISTS project_id UUID NULL REFERENCES control_projects(id);
+
+ALTER TABLE control_sessions
+    ADD COLUMN IF NOT EXISTS admission JSONB NOT NULL DEFAULT jsonb_build_object(
+        'state', 'allowed',
+        'reason_code', 'owner_scope_unbounded',
+        'message', 'No project was selected; owner-scoped admission is unbounded.',
+        'project_id', NULL,
+        'active_sessions', NULL,
+        'max_active_sessions', NULL,
+        'checked_at', to_jsonb(NOW())
+    );
+
+CREATE INDEX IF NOT EXISTS control_sessions_project_idx
+    ON control_sessions (project_id, state, created_at DESC);

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -42,14 +42,15 @@ use crate::session_control::{
     EgressProfileState, FailSessionRecordingRequest, PersistBrowserContextRequest,
     PersistCompletedSessionRecordingRequest, PersistEgressDiagnosticsProbeResult,
     PersistEgressProfileReachabilityProbeResult, PersistEgressProfileRequest,
-    PersistSessionFileBindingRequest, PersistSessionTemplateRequest, SessionBrowserContextMode,
-    SessionEffectiveEgress, SessionLifecycleState, SessionListResponse, SessionNetworkIdentity,
-    SessionOwnerMode, SessionRecordingFormat, SessionRecordingListResponse, SessionRecordingMode,
-    SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
+    PersistProjectRequest, PersistSessionFileBindingRequest, PersistSessionTemplateRequest,
+    ProjectAdmissionDecision, ProjectListResponse, ProjectResource, ProjectUsageResource,
+    SessionBrowserContextMode, SessionEffectiveEgress, SessionLifecycleState, SessionListResponse,
+    SessionNetworkIdentity, SessionOwnerMode, SessionRecordingFormat, SessionRecordingListResponse,
+    SessionRecordingMode, SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
     SessionRecordingTerminationReason, SessionResource, SessionStore, SessionStoreError,
     SessionTemplateDefaults, SessionTemplateListResponse, SessionTemplateResource,
-    SetAutomationDelegateRequest, StoredBrowserContext, StoredEgressProfile, StoredSession,
-    StoredSessionRecording,
+    SetAutomationDelegateRequest, StoredBrowserContext, StoredEgressProfile, StoredProject,
+    StoredSession, StoredSessionRecording,
 };
 use crate::session_files::{
     SessionFileBindingListResponse, SessionFileBindingResource, SessionFileListResponse,
@@ -95,6 +96,7 @@ mod errors;
 mod extensions;
 mod file_workspaces;
 mod http_helpers;
+mod projects;
 mod recordings;
 mod resources;
 mod router;

--- a/code/apps/bpane-gateway/src/api/admin_events/snapshots.rs
+++ b/code/apps/bpane-gateway/src/api/admin_events/snapshots.rs
@@ -500,6 +500,9 @@ mod tests {
         SessionResource {
             id: Uuid::nil(),
             state: SessionLifecycleState::Ready,
+            project_id: None,
+            project: None,
+            admission: crate::session_control::ProjectAdmissionDecision::owner_scope_unbounded(now),
             template_id: None,
             browser_context: crate::session_control::SessionBrowserContextResource {
                 mode: crate::session_control::SessionBrowserContextMode::Fresh,

--- a/code/apps/bpane-gateway/src/api/projects.rs
+++ b/code/apps/bpane-gateway/src/api/projects.rs
@@ -1,0 +1,157 @@
+use axum::routing::{get, post};
+
+use super::*;
+
+pub(super) fn project_routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route("/api/v1/projects", post(create_project).get(list_projects))
+        .route(
+            "/api/v1/projects/{project_id}",
+            get(get_project).put(update_project),
+        )
+        .route(
+            "/api/v1/projects/{project_id}/usage",
+            get(get_project_usage),
+        )
+}
+
+async fn list_projects(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ProjectListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let projects = state
+        .session_store
+        .list_projects_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let projects = project_resources(&state, &principal, projects).await?;
+    Ok(Json(ProjectListResponse { projects }))
+}
+
+async fn create_project(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertProjectRequest>,
+) -> Result<(StatusCode, Json<ProjectResource>), (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let project = state
+        .session_store
+        .create_project(&principal, persist_project_request(request))
+        .await
+        .map_err(map_session_store_error)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(project_resource(&state, &principal, &project).await?),
+    ))
+}
+
+async fn get_project(
+    headers: HeaderMap,
+    Path(project_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ProjectResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let project = load_project(&state, &principal, project_id).await?;
+    Ok(Json(project_resource(&state, &principal, &project).await?))
+}
+
+async fn update_project(
+    headers: HeaderMap,
+    Path(project_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertProjectRequest>,
+) -> Result<Json<ProjectResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let project = state
+        .session_store
+        .update_project_for_owner(&principal, project_id, persist_project_request(request))
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("project {project_id} not found"),
+                }),
+            )
+        })?;
+    Ok(Json(project_resource(&state, &principal, &project).await?))
+}
+
+async fn get_project_usage(
+    headers: HeaderMap,
+    Path(project_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ProjectUsageResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let project = load_project(&state, &principal, project_id).await?;
+    Ok(Json(
+        project_resource(&state, &principal, &project).await?.usage,
+    ))
+}
+
+fn persist_project_request(request: UpsertProjectRequest) -> PersistProjectRequest {
+    PersistProjectRequest {
+        name: request.name,
+        description: request.description,
+        labels: request.labels,
+        quotas: request.quotas,
+        state: request.state,
+    }
+}
+
+async fn load_project(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    project_id: Uuid,
+) -> Result<StoredProject, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .session_store
+        .get_project_for_owner(principal, project_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("project {project_id} not found"),
+                }),
+            )
+        })
+}
+
+async fn project_resources(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    projects: Vec<StoredProject>,
+) -> Result<Vec<ProjectResource>, (StatusCode, Json<ErrorResponse>)> {
+    let mut resources = Vec::with_capacity(projects.len());
+    for project in projects {
+        resources.push(project_resource(state, principal, &project).await?);
+    }
+    Ok(resources)
+}
+
+async fn project_resource(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    project: &StoredProject,
+) -> Result<ProjectResource, (StatusCode, Json<ErrorResponse>)> {
+    let active_sessions = state
+        .session_store
+        .count_active_sessions_for_project(principal, project.id)
+        .await
+        .map_err(map_session_store_error)?;
+    Ok(project.to_resource(active_sessions, Utc::now()))
+}

--- a/code/apps/bpane-gateway/src/api/resources.rs
+++ b/code/apps/bpane-gateway/src/api/resources.rs
@@ -3,9 +3,9 @@ use std::collections::HashSet;
 
 use crate::auth::AuthenticatedPrincipal;
 use crate::session_control::{
-    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionRuntimeResumeMode,
-    SessionRuntimeState, SessionStatusSummary, SessionStopBlocker, SessionStopBlockerKind,
-    SessionStopEligibility, SessionStoreError, StoredSession,
+    SessionConnectionCounts, SessionIdleStatus, SessionPresenceState, SessionProjectResource,
+    SessionRuntimeResumeMode, SessionRuntimeState, SessionStatusSummary, SessionStopBlocker,
+    SessionStopBlockerKind, SessionStopEligibility, SessionStoreError, StoredSession,
 };
 use crate::session_manager::SessionRuntimeAssignmentStatus;
 
@@ -79,6 +79,9 @@ pub(super) async fn session_status_summary(
 
 pub(super) fn session_status_from_snapshot(
     state: SessionLifecycleState,
+    project_id: Option<Uuid>,
+    project: Option<SessionProjectResource>,
+    admission: ProjectAdmissionDecision,
     summary: SessionStatusSummary,
     snapshot: SessionTelemetrySnapshot,
     network_identity: SessionNetworkIdentity,
@@ -90,6 +93,9 @@ pub(super) fn session_status_from_snapshot(
 ) -> SessionStatus {
     SessionStatus {
         state,
+        project_id,
+        project,
+        admission,
         summary,
         connections: session_connections_from_snapshot(&snapshot),
         browser_clients: snapshot.browser_clients,
@@ -362,10 +368,12 @@ pub(super) async fn session_resource(
     state_override: Option<SessionLifecycleState>,
 ) -> Result<SessionResource, SessionStoreError> {
     let status = session_status_summary(state, stored).await?;
+    let project = session_project_resource(state, stored).await?;
     let effective_egress = session_effective_egress(state, stored).await?;
     let egress_diagnostics = session_egress_diagnostics(state, stored).await?;
     Ok(stored.to_resource(
         &state.public_gateway_url,
+        project,
         state
             .session_manager
             .describe_session_runtime(stored.id)
@@ -375,6 +383,21 @@ pub(super) async fn session_resource(
         effective_egress,
         egress_diagnostics,
     ))
+}
+
+pub(super) async fn session_project_resource(
+    state: &ApiState,
+    stored: &StoredSession,
+) -> Result<Option<SessionProjectResource>, SessionStoreError> {
+    let Some(project_id) = stored.project_id else {
+        return Ok(None);
+    };
+    let owner = session_owner_principal(stored);
+    Ok(state
+        .session_store
+        .get_project_for_owner(&owner, project_id)
+        .await?
+        .map(|project| project.to_session_project_resource()))
 }
 
 pub(super) async fn session_effective_egress(
@@ -461,11 +484,15 @@ pub(super) async fn load_session_status(
         .await?;
     let latest_recording = latest_recording(&recordings);
     let playback = prepare_session_recording_playback(session.id, &recordings, Utc::now());
+    let project = session_project_resource(state, session).await?;
     let effective_egress = session_effective_egress(state, session).await?;
     let egress_diagnostics = session_egress_diagnostics(state, session).await?;
 
     Ok(session_status_from_snapshot(
         session.state,
+        session.project_id,
+        project,
+        session.admission.clone(),
         summary,
         snapshot,
         session.network_identity.clone(),

--- a/code/apps/bpane-gateway/src/api/router.rs
+++ b/code/apps/bpane-gateway/src/api/router.rs
@@ -18,6 +18,7 @@ pub(crate) fn build_api_router(state: Arc<ApiState>) -> Router {
         .merge(sessions::session_routes())
         .merge(browser_contexts::browser_context_routes())
         .merge(extensions::extension_routes())
+        .merge(projects::project_routes())
         .merge(egress_profiles::egress_profile_routes())
         .merge(credential_bindings::credential_binding_routes())
         .merge(file_workspaces::file_workspace_routes())

--- a/code/apps/bpane-gateway/src/api/session_bindings.rs
+++ b/code/apps/bpane-gateway/src/api/session_bindings.rs
@@ -167,6 +167,7 @@ fn merge_template_defaults(
     mut request: CreateSessionRequest,
     defaults: SessionTemplateDefaults,
 ) -> CreateSessionRequest {
+    request.project_id = request.project_id.or(defaults.project_id);
     request.owner_mode = request.owner_mode.or(defaults.owner_mode);
     if request.viewport.is_none() {
         request.viewport = defaults.viewport;

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -48,6 +48,7 @@ mod credential_bindings;
 mod extensions;
 mod file_workspaces;
 mod network_identity;
+mod projects;
 mod recordings;
 mod session_files;
 mod session_templates;

--- a/code/apps/bpane-gateway/src/api/tests/projects.rs
+++ b/code/apps/bpane-gateway/src/api/tests/projects.rs
@@ -1,0 +1,315 @@
+use super::*;
+
+#[tokio::test]
+async fn manages_projects_and_reports_usage() {
+    let (app, token) = test_router_with_docker_pool().await;
+
+    let invalid = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/projects")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "support",
+                        "quotas": { "max_active_sessions": 0 }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+    let created = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/projects")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "support",
+                        "description": "Support escalations",
+                        "labels": { "team": "support" },
+                        "quotas": {
+                            "max_active_sessions": 1,
+                            "max_active_workflow_runs": 2,
+                            "max_retained_storage_bytes": 1048576
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let project = response_json(created).await;
+    let project_id = project["id"].as_str().unwrap().to_string();
+    assert_eq!(project["name"], "support");
+    assert_eq!(project["state"], "active");
+    assert_eq!(project["usage"]["active_sessions"], 0);
+    assert_eq!(project["usage"]["max_active_sessions"], 1);
+
+    let list = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/projects")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK);
+    let listed = response_json(list).await;
+    assert_eq!(listed["projects"].as_array().unwrap().len(), 1);
+    assert_eq!(listed["projects"][0]["id"], project_id);
+
+    let updated = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/projects/{project_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "support-escalations",
+                        "description": "Support escalations",
+                        "labels": { "team": "support", "priority": "high" },
+                        "quotas": { "max_active_sessions": 1 },
+                        "state": "active"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.status(), StatusCode::OK);
+    let updated = response_json(updated).await;
+    assert_eq!(updated["name"], "support-escalations");
+    assert_eq!(updated["labels"]["priority"], "high");
+
+    let usage = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/projects/{project_id}/usage"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(usage.status(), StatusCode::OK);
+    let usage = response_json(usage).await;
+    assert_eq!(usage["project_id"], project_id);
+    assert_eq!(usage["active_sessions"], 0);
+}
+
+#[tokio::test]
+async fn applies_project_admission_to_sessions_and_template_defaults() {
+    let (app, token) = test_router_with_docker_pool().await;
+
+    let project = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "tenant-alpha",
+                            "quotas": { "max_active_sessions": 1 }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let project_id = project["id"].as_str().unwrap().to_string();
+
+    let template = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/session-templates")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "tenant-alpha-debug",
+                            "defaults": { "project_id": project_id }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let template_id = template["id"].as_str().unwrap().to_string();
+
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({ "template_id": template_id }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::CREATED);
+    let first = response_json(first).await;
+    let first_session_id = first["id"].as_str().unwrap().to_string();
+    assert_eq!(first["project_id"], project_id);
+    assert_eq!(first["project"]["id"], project_id);
+    assert_eq!(first["admission"]["state"], "allowed");
+    assert_eq!(first["admission"]["reason_code"], "project_quota_available");
+    assert_eq!(first["admission"]["active_sessions"], 1);
+
+    let status = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/sessions/{first_session_id}/status"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(status.status(), StatusCode::OK);
+    let status = response_json(status).await;
+    assert_eq!(status["project_id"], project_id);
+    assert_eq!(status["project"]["id"], project_id);
+    assert_eq!(status["admission"]["state"], "allowed");
+
+    let rejected = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "project_id": project_id }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::CONFLICT);
+    let rejected = response_json(rejected).await;
+    assert!(rejected["error"]
+        .as_str()
+        .unwrap()
+        .contains("active_session_quota_exceeded"));
+
+    let usage = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/v1/projects/{project_id}/usage"))
+                    .header("authorization", bearer(&token))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(usage["active_sessions"], 1);
+
+    let stopped = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/api/v1/sessions/{first_session_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(stopped.status(), StatusCode::OK);
+
+    let second = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "project_id": project_id }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.status(), StatusCode::CREATED);
+
+    let archived = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/projects/{project_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "tenant-alpha",
+                        "quotas": { "max_active_sessions": 2 },
+                        "state": "archived"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(archived.status(), StatusCode::OK);
+
+    let archived_rejected = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/sessions")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(json!({ "project_id": project_id }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(archived_rejected.status(), StatusCode::CONFLICT);
+    let archived_rejected = response_json(archived_rejected).await;
+    assert!(archived_rejected["error"]
+        .as_str()
+        .unwrap()
+        .contains("project_archived"));
+}

--- a/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
+++ b/code/apps/bpane-gateway/src/api/tests/sessions/contract.rs
@@ -45,6 +45,9 @@ fn session_status_maps_recorder_clients() {
         prepare_session_recording_playback(latest_recording.session_id, &[], chrono::Utc::now());
     let status = session_status_from_snapshot(
         SessionLifecycleState::Active,
+        None,
+        None,
+        crate::session_control::ProjectAdmissionDecision::owner_scope_unbounded(chrono::Utc::now()),
         SessionStatusSummary {
             runtime_state: SessionRuntimeState::Running,
             runtime_resume_mode: SessionRuntimeResumeMode::ExactLive,

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -23,10 +23,10 @@ use crate::session_access::{SessionAutomationAccessTokenManager, SessionConnectT
 use crate::session_control::{
     BrowserContextPersistenceMode, CreateSessionRequest, EgressCustomCaConfig,
     EgressDiagnosticsResource, EgressProfileState, EgressProxyConfig,
-    EgressTrafficObservationConfig, SessionConnectInfo, SessionEffectiveEgress,
-    SessionLifecycleState, SessionNetworkIdentity, SessionOwnerMode, SessionRecordingFormat,
-    SessionRecordingMode, SessionResource, SessionStatusSummary, SessionStore,
-    SessionTemplateDefaults,
+    EgressTrafficObservationConfig, ProjectAdmissionDecision, ProjectQuotas, ProjectState,
+    SessionConnectInfo, SessionEffectiveEgress, SessionLifecycleState, SessionNetworkIdentity,
+    SessionOwnerMode, SessionProjectResource, SessionRecordingFormat, SessionRecordingMode,
+    SessionResource, SessionStatusSummary, SessionStore, SessionTemplateDefaults,
 };
 use crate::session_files::SessionFileBindingMode;
 use crate::session_hub::{SessionConnectionTelemetryRole, SessionTelemetrySnapshot};
@@ -102,6 +102,9 @@ pub(super) const WORKFLOW_RUN_WORKSPACE_ID_HEADER: &str = "x-bpane-workflow-work
 #[derive(Serialize)]
 pub(super) struct SessionStatus {
     pub(super) state: SessionLifecycleState,
+    pub(super) project_id: Option<Uuid>,
+    pub(super) project: Option<SessionProjectResource>,
+    pub(super) admission: ProjectAdmissionDecision,
     #[serde(flatten)]
     pub(super) summary: SessionStatusSummary,
     pub(super) connections: Vec<SessionConnectionInfo>,
@@ -309,6 +312,23 @@ pub(super) struct UpsertSessionTemplateRequest {
     pub(super) labels: HashMap<String, String>,
     #[serde(default)]
     pub(super) defaults: SessionTemplateDefaults,
+}
+
+#[derive(Deserialize)]
+pub(super) struct UpsertProjectRequest {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+    #[serde(default)]
+    pub(super) labels: HashMap<String, String>,
+    #[serde(default)]
+    pub(super) quotas: ProjectQuotas,
+    #[serde(default = "default_project_state")]
+    pub(super) state: ProjectState,
+}
+
+fn default_project_state() -> ProjectState {
+    ProjectState::Active
 }
 
 #[derive(Deserialize)]

--- a/code/apps/bpane-gateway/src/recording/retention.rs
+++ b/code/apps/bpane-gateway/src/recording/retention.rs
@@ -134,6 +134,7 @@ mod tests {
             .create_session(
                 &owner(),
                 CreateSessionRequest {
+                    project_id: None,
                     template_id: None,
                     browser_context: None,
                     network_identity: None,

--- a/code/apps/bpane-gateway/src/recording_lifecycle/tests.rs
+++ b/code/apps/bpane-gateway/src/recording_lifecycle/tests.rs
@@ -52,6 +52,7 @@ async fn create_session_with_mode(
         .create_session(
             &test_principal(),
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/runtime_manager/tests.rs
+++ b/code/apps/bpane-gateway/src/runtime_manager/tests.rs
@@ -341,6 +341,8 @@ fn docker_runtime_maps_network_identity_to_launch_env() {
     let session = StoredSession {
         id: session_id,
         state: SessionLifecycleState::Ready,
+        project_id: None,
+        admission: crate::session_control::ProjectAdmissionDecision::owner_scope_unbounded(now),
         template_id: None,
         browser_context: SessionBrowserContextResource {
             mode: SessionBrowserContextMode::Fresh,
@@ -615,6 +617,7 @@ async fn docker_runtime_resolves_secret_backed_proxy_auth_for_launch() {
         .create_session(
             &principal,
             CreateSessionRequest {
+                project_id: None,
                 network_identity: Some(SessionNetworkIdentity {
                     egress_profile_id: Some(profile.id),
                     ..Default::default()
@@ -865,6 +868,7 @@ async fn docker_runtime_rejects_parallel_writer_for_reusable_browser_context() {
         .await
         .unwrap();
     let create_request = || CreateSessionRequest {
+        project_id: None,
         browser_context: Some(SessionBrowserContextRequest {
             mode: SessionBrowserContextMode::Reusable,
             context_id: Some(context.id),

--- a/code/apps/bpane-gateway/src/session_control/in_memory.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 mod automation_tasks;
 mod browser_contexts;
 mod egress_profiles;
+mod projects;
 mod recordings;
 mod runtime_assignments;
 mod session_files;

--- a/code/apps/bpane-gateway/src/session_control/in_memory/projects.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/projects.rs
@@ -1,0 +1,132 @@
+use super::*;
+
+impl InMemorySessionStore {
+    pub(in crate::session_control) async fn create_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistProjectRequest,
+    ) -> Result<StoredProject, SessionStoreError> {
+        let now = Utc::now();
+        let mut projects = self.projects.lock().await;
+        if projects.iter().any(|project| {
+            project.owner_subject == principal.subject
+                && project.owner_issuer == principal.issuer
+                && project.name == request.name
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "project {} already exists",
+                request.name
+            )));
+        }
+        let project = StoredProject {
+            id: Uuid::now_v7(),
+            owner_subject: principal.subject.clone(),
+            owner_issuer: principal.issuer.clone(),
+            name: request.name,
+            description: request.description,
+            labels: request.labels,
+            quotas: request.quotas,
+            state: request.state,
+            created_at: now,
+            updated_at: now,
+        };
+        projects.push(project.clone());
+        Ok(project)
+    }
+
+    pub(in crate::session_control) async fn list_projects_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredProject>, SessionStoreError> {
+        let mut projects = self
+            .projects
+            .lock()
+            .await
+            .iter()
+            .filter(|project| {
+                project.owner_subject == principal.subject
+                    && project.owner_issuer == principal.issuer
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        projects.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(projects)
+    }
+
+    pub(in crate::session_control) async fn get_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        Ok(self
+            .projects
+            .lock()
+            .await
+            .iter()
+            .find(|project| {
+                project.id == id
+                    && project.owner_subject == principal.subject
+                    && project.owner_issuer == principal.issuer
+            })
+            .cloned())
+    }
+
+    pub(in crate::session_control) async fn update_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistProjectRequest,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        let mut projects = self.projects.lock().await;
+        if projects.iter().any(|project| {
+            project.id != id
+                && project.owner_subject == principal.subject
+                && project.owner_issuer == principal.issuer
+                && project.name == request.name
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "project {} already exists",
+                request.name
+            )));
+        }
+        let Some(project) = projects.iter_mut().find(|project| {
+            project.id == id
+                && project.owner_subject == principal.subject
+                && project.owner_issuer == principal.issuer
+        }) else {
+            return Ok(None);
+        };
+
+        project.name = request.name;
+        project.description = request.description;
+        project.labels = request.labels;
+        project.quotas = request.quotas;
+        project.state = request.state;
+        project.updated_at = Utc::now();
+        Ok(Some(project.clone()))
+    }
+
+    pub(in crate::session_control) async fn count_active_sessions_for_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<u32, SessionStoreError> {
+        let count = self
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .filter(|session| {
+                session.project_id == Some(project_id)
+                    && session.owner.subject == principal.subject
+                    && session.owner.issuer == principal.issuer
+                    && session.state.is_runtime_candidate()
+            })
+            .count();
+        u32::try_from(count).map_err(|error| {
+            SessionStoreError::Backend(format!(
+                "active project session count exceeded u32 range: {error}"
+            ))
+        })
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/sessions.rs
@@ -37,10 +37,76 @@ impl InMemorySessionStore {
         }
 
         let now = Utc::now();
+        let admission = if let Some(project_id) = request.project_id {
+            let project = self
+                .projects
+                .lock()
+                .await
+                .iter()
+                .find(|project| {
+                    project.id == project_id
+                        && project.owner_subject == principal.subject
+                        && project.owner_issuer == principal.issuer
+                })
+                .cloned()
+                .ok_or_else(|| {
+                    SessionStoreError::NotFound(format!("project {project_id} not found"))
+                })?;
+            let active_project_sessions = sessions
+                .iter()
+                .filter(|session| {
+                    session.project_id == Some(project_id) && session.state.is_runtime_candidate()
+                })
+                .count() as u32;
+            if project.state == ProjectState::Archived {
+                let decision = ProjectAdmissionDecision::rejected(
+                    project_id,
+                    ProjectAdmissionReasonCode::ProjectArchived,
+                    format!("project {project_id} is archived"),
+                    active_project_sessions,
+                    project.quotas.max_active_sessions,
+                    now,
+                );
+                return Err(SessionStoreError::Conflict(format!(
+                    "project admission rejected: {}: {}",
+                    decision.reason_code.as_str(),
+                    decision.message
+                )));
+            }
+            if let Some(max_active_sessions) = project.quotas.max_active_sessions {
+                if active_project_sessions >= max_active_sessions {
+                    let decision = ProjectAdmissionDecision::rejected(
+                        project_id,
+                        ProjectAdmissionReasonCode::ActiveSessionQuotaExceeded,
+                        format!(
+                            "project {project_id} active session quota is exhausted ({active_project_sessions}/{max_active_sessions})"
+                        ),
+                        active_project_sessions,
+                        Some(max_active_sessions),
+                        now,
+                    );
+                    return Err(SessionStoreError::Conflict(format!(
+                        "project admission rejected: {}: {}",
+                        decision.reason_code.as_str(),
+                        decision.message
+                    )));
+                }
+            }
+            ProjectAdmissionDecision::project_quota_available(
+                project_id,
+                active_project_sessions.saturating_add(1),
+                project.quotas.max_active_sessions,
+                now,
+            )
+        } else {
+            ProjectAdmissionDecision::owner_scope_unbounded(now)
+        };
         let browser_context = request.browser_context.unwrap_or_default();
         let session = StoredSession {
             id: Uuid::now_v7(),
             state: SessionLifecycleState::Ready,
+            project_id: request.project_id,
+            admission,
             template_id: request.template_id,
             browser_context: SessionBrowserContextResource {
                 mode: browser_context.mode,

--- a/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub(in crate::session_control) struct InMemoryStoreState {
     pub(in crate::session_control) browser_contexts: Mutex<Vec<StoredBrowserContext>>,
+    pub(in crate::session_control) projects: Mutex<Vec<StoredProject>>,
     pub(in crate::session_control) sessions: Mutex<Vec<StoredSession>>,
     pub(in crate::session_control) session_templates: Mutex<Vec<StoredSessionTemplate>>,
     pub(in crate::session_control) egress_profiles: Mutex<Vec<StoredEgressProfile>>,
@@ -44,6 +45,7 @@ impl InMemoryStoreState {
     pub(super) fn new() -> Self {
         Self {
             browser_contexts: Mutex::new(Vec::new()),
+            projects: Mutex::new(Vec::new()),
             sessions: Mutex::new(Vec::new()),
             session_templates: Mutex::new(Vec::new()),
             egress_profiles: Mutex::new(Vec::new()),

--- a/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
@@ -7,6 +7,7 @@ mod db;
 mod egress_profiles;
 mod extensions;
 mod file_workspaces;
+mod projects;
 mod recordings;
 mod runtime_assignments;
 mod session_files;

--- a/code/apps/bpane-gateway/src/session_control/postgres/projects.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/projects.rs
@@ -1,0 +1,286 @@
+use super::*;
+
+const PROJECT_COLUMNS: &str = r#"
+    id,
+    owner_subject,
+    owner_issuer,
+    name,
+    description,
+    labels,
+    quotas,
+    state,
+    created_at,
+    updated_at
+"#;
+
+pub(super) struct ProjectRepository<'a> {
+    store: &'a PostgresSessionStore,
+}
+
+impl PostgresSessionStore {
+    fn project_repository(&self) -> ProjectRepository<'_> {
+        ProjectRepository { store: self }
+    }
+
+    pub(in crate::session_control) async fn create_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistProjectRequest,
+    ) -> Result<StoredProject, SessionStoreError> {
+        self.project_repository()
+            .create_project(principal, request)
+            .await
+    }
+
+    pub(in crate::session_control) async fn list_projects_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredProject>, SessionStoreError> {
+        self.project_repository()
+            .list_projects_for_owner(principal)
+            .await
+    }
+
+    pub(in crate::session_control) async fn get_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        self.project_repository()
+            .get_project_for_owner(principal, id)
+            .await
+    }
+
+    pub(in crate::session_control) async fn update_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistProjectRequest,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        self.project_repository()
+            .update_project_for_owner(principal, id, request)
+            .await
+    }
+
+    pub(in crate::session_control) async fn count_active_sessions_for_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<u32, SessionStoreError> {
+        self.project_repository()
+            .count_active_sessions_for_project(principal, project_id)
+            .await
+    }
+}
+
+impl ProjectRepository<'_> {
+    async fn create_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistProjectRequest,
+    ) -> Result<StoredProject, SessionStoreError> {
+        let now = Utc::now();
+        let quotas_value = serde_json::to_value(&request.quotas).map_err(|error| {
+            SessionStoreError::Backend(format!("failed to encode project quotas: {error}"))
+        })?;
+        let query = format!(
+            r#"
+            INSERT INTO control_projects (
+                id,
+                owner_subject,
+                owner_issuer,
+                name,
+                description,
+                labels,
+                quotas,
+                state,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9, $9)
+            RETURNING
+                {PROJECT_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_one(
+                &query,
+                &[
+                    &Uuid::now_v7(),
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &json_labels(&request.labels),
+                    &quotas_value,
+                    &request.state.as_str(),
+                    &now,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "project {} already exists",
+                        request.name
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to create project: {error}"))
+            })?;
+        row_to_stored_project(&row)
+    }
+
+    async fn list_projects_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredProject>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {PROJECT_COLUMNS}
+            FROM control_projects
+            WHERE owner_subject = $1
+              AND owner_issuer = $2
+            ORDER BY created_at DESC
+            "#
+        );
+        let rows = self
+            .store
+            .db
+            .client()
+            .await?
+            .query(&query, &[&principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to list projects: {error}"))
+            })?;
+        rows.iter().map(row_to_stored_project).collect()
+    }
+
+    async fn get_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {PROJECT_COLUMNS}
+            FROM control_projects
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(&query, &[&id, &principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to fetch project: {error}"))
+            })?;
+        row.as_ref().map(row_to_stored_project).transpose()
+    }
+
+    async fn update_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistProjectRequest,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        let quotas_value = serde_json::to_value(&request.quotas).map_err(|error| {
+            SessionStoreError::Backend(format!("failed to encode project quotas: {error}"))
+        })?;
+        let query = format!(
+            r#"
+            UPDATE control_projects
+            SET
+                name = $4,
+                description = $5,
+                labels = $6::jsonb,
+                quotas = $7::jsonb,
+                state = $8,
+                updated_at = NOW()
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            RETURNING
+                {PROJECT_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                &query,
+                &[
+                    &id,
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &json_labels(&request.labels),
+                    &quotas_value,
+                    &request.state.as_str(),
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "project {} already exists",
+                        request.name
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to update project: {error}"))
+            })?;
+        row.as_ref().map(row_to_stored_project).transpose()
+    }
+
+    async fn count_active_sessions_for_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<u32, SessionStoreError> {
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                r#"
+                SELECT COUNT(*)::BIGINT AS session_count
+                FROM control_sessions
+                WHERE owner_subject = $1
+                  AND owner_issuer = $2
+                  AND project_id = $3
+                  AND state IN ('pending', 'starting', 'ready', 'active', 'idle')
+                "#,
+                &[&principal.subject, &principal.issuer, &project_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to count project active sessions: {error}"
+                ))
+            })?;
+        let count = row
+            .as_ref()
+            .map(|row| row.get::<_, i64>("session_count"))
+            .unwrap_or(0);
+        u32::try_from(count).map_err(|error| {
+            SessionStoreError::Backend(format!(
+                "active project session count exceeded u32 range: {error}"
+            ))
+        })
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions.rs
@@ -13,6 +13,8 @@ const SESSION_COLUMNS: &str = r#"
     automation_owner_issuer,
     automation_owner_display_name,
     state,
+    project_id,
+    admission,
     template_id,
     browser_context_mode,
     browser_context_id,
@@ -187,5 +189,73 @@ impl SessionRepository<'_> {
             .as_ref()
             .map(|row| row.get::<_, i64>("session_count"))
             .unwrap_or(0))
+    }
+
+    async fn load_project_for_owner_in_transaction(
+        &self,
+        transaction: &Transaction<'_>,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        let query = r#"
+            SELECT
+                id,
+                owner_subject,
+                owner_issuer,
+                name,
+                description,
+                labels,
+                quotas,
+                state,
+                created_at,
+                updated_at
+            FROM control_projects
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            FOR UPDATE
+        "#;
+        let row = transaction
+            .query_opt(query, &[&project_id, &principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to load project for admission: {error}"))
+            })?;
+        row.as_ref().map(row_to_stored_project).transpose()
+    }
+
+    async fn count_active_sessions_for_project_in_transaction(
+        &self,
+        transaction: &Transaction<'_>,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<u32, SessionStoreError> {
+        let row = transaction
+            .query_opt(
+                r#"
+                SELECT COUNT(*)::BIGINT AS session_count
+                FROM control_sessions
+                WHERE owner_subject = $1
+                  AND owner_issuer = $2
+                  AND project_id = $3
+                  AND state IN ('pending', 'starting', 'ready', 'active', 'idle')
+                "#,
+                &[&principal.subject, &principal.issuer, &project_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to count project active sessions for admission: {error}"
+                ))
+            })?;
+        let count = row
+            .as_ref()
+            .map(|row| row.get::<_, i64>("session_count"))
+            .unwrap_or(0);
+        u32::try_from(count).map_err(|error| {
+            SessionStoreError::Backend(format!(
+                "active project session count exceeded u32 range: {error}"
+            ))
+        })
     }
 }

--- a/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/sessions/lifecycle.rs
@@ -23,6 +23,66 @@ impl SessionRepository<'_> {
 
         let viewport = request.viewport.unwrap_or_default();
         let now = Utc::now();
+        let admission = if let Some(project_id) = request.project_id {
+            let project = self
+                .load_project_for_owner_in_transaction(&transaction, principal, project_id)
+                .await?
+                .ok_or_else(|| {
+                    SessionStoreError::NotFound(format!("project {project_id} not found"))
+                })?;
+            let active_project_sessions = self
+                .count_active_sessions_for_project_in_transaction(
+                    &transaction,
+                    principal,
+                    project_id,
+                )
+                .await?;
+            if project.state == ProjectState::Archived {
+                let decision = ProjectAdmissionDecision::rejected(
+                    project_id,
+                    ProjectAdmissionReasonCode::ProjectArchived,
+                    format!("project {project_id} is archived"),
+                    active_project_sessions,
+                    project.quotas.max_active_sessions,
+                    now,
+                );
+                return Err(SessionStoreError::Conflict(format!(
+                    "project admission rejected: {}: {}",
+                    decision.reason_code.as_str(),
+                    decision.message
+                )));
+            }
+            if let Some(max_active_sessions) = project.quotas.max_active_sessions {
+                if active_project_sessions >= max_active_sessions {
+                    let decision = ProjectAdmissionDecision::rejected(
+                        project_id,
+                        ProjectAdmissionReasonCode::ActiveSessionQuotaExceeded,
+                        format!(
+                            "project {project_id} active session quota is exhausted ({active_project_sessions}/{max_active_sessions})"
+                        ),
+                        active_project_sessions,
+                        Some(max_active_sessions),
+                        now,
+                    );
+                    return Err(SessionStoreError::Conflict(format!(
+                        "project admission rejected: {}: {}",
+                        decision.reason_code.as_str(),
+                        decision.message
+                    )));
+                }
+            }
+            ProjectAdmissionDecision::project_quota_available(
+                project_id,
+                active_project_sessions.saturating_add(1),
+                project.quotas.max_active_sessions,
+                now,
+            )
+        } else {
+            ProjectAdmissionDecision::owner_scope_unbounded(now)
+        };
+        let admission_value = serde_json::to_value(&admission).map_err(|error| {
+            SessionStoreError::Backend(format!("failed to encode session admission: {error}"))
+        })?;
         let labels_value = json_labels(&request.labels);
         let extensions_value = json_applied_extensions(&request.extensions)?;
         let recording_value = json_recording_policy(&request.recording)?;
@@ -44,6 +104,8 @@ impl SessionRepository<'_> {
                 owner_issuer,
                 owner_display_name,
                 state,
+                project_id,
+                admission,
                 template_id,
                 browser_context_mode,
                 browser_context_id,
@@ -61,8 +123,8 @@ impl SessionRepository<'_> {
                 updated_at
             )
             VALUES (
-                $1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, $12, $13,
-                $14::jsonb, $15::jsonb, $16::jsonb, $17::jsonb, $18, $19, $19
+                $1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10, $11::jsonb, $12, $13, $14, $15,
+                $16::jsonb, $17::jsonb, $18::jsonb, $19::jsonb, $20, $21, $21
             )
             RETURNING
                 {SESSION_COLUMNS}
@@ -77,6 +139,8 @@ impl SessionRepository<'_> {
                     &principal.issuer,
                     &principal.display_name,
                     &SessionLifecycleState::Ready.as_str(),
+                    &request.project_id,
+                    &admission_value,
                     &request.template_id,
                     &browser_context.mode.as_str(),
                     &browser_context.context_id,

--- a/code/apps/bpane-gateway/src/session_control/rows.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows.rs
@@ -19,8 +19,8 @@ pub(super) use encoding::{
 pub(super) use resources::{
     row_to_stored_browser_context, row_to_stored_credential_binding, row_to_stored_egress_profile,
     row_to_stored_extension_definition, row_to_stored_extension_version,
-    row_to_stored_file_workspace, row_to_stored_file_workspace_file, row_to_stored_session_file,
-    row_to_stored_session_file_binding, row_to_stored_session_template,
+    row_to_stored_file_workspace, row_to_stored_file_workspace_file, row_to_stored_project,
+    row_to_stored_session_file, row_to_stored_session_file_binding, row_to_stored_session_template,
     row_to_stored_workflow_definition, row_to_stored_workflow_definition_version,
 };
 pub(super) use runtime_assignments::{

--- a/code/apps/bpane-gateway/src/session_control/rows/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/resources.rs
@@ -64,6 +64,48 @@ pub(in crate::session_control) fn row_to_stored_browser_context(
     })
 }
 
+pub(in crate::session_control) fn row_to_stored_project(
+    row: &Row,
+) -> Result<StoredProject, SessionStoreError> {
+    let state = row
+        .get::<_, String>("state")
+        .parse::<ProjectState>()
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
+    let labels_value: Value = row.get("labels");
+    let labels = labels_value
+        .as_object()
+        .context("project labels column must be a JSON object")
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+        .iter()
+        .map(|(key, value)| {
+            Ok((
+                key.clone(),
+                value
+                    .as_str()
+                    .context("project label values must be strings")
+                    .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+                    .to_string(),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, SessionStoreError>>()?;
+    let quotas = serde_json::from_value::<ProjectQuotas>(row.get("quotas")).map_err(|error| {
+        SessionStoreError::Backend(format!("failed to decode project quotas: {error}"))
+    })?;
+
+    Ok(StoredProject {
+        id: row.get("id"),
+        owner_subject: row.get("owner_subject"),
+        owner_issuer: row.get("owner_issuer"),
+        name: row.get("name"),
+        description: row.get("description"),
+        labels,
+        quotas,
+        state,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
 pub(in crate::session_control) fn row_to_stored_credential_binding(
     row: &Row,
 ) -> Result<StoredCredentialBinding, SessionStoreError> {

--- a/code/apps/bpane-gateway/src/session_control/rows/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/sessions.rs
@@ -48,6 +48,12 @@ pub(in crate::session_control) fn row_to_stored_session(
             "failed to decode session network identity: {error}"
         ))
     })?;
+    let admission = serde_json::from_value::<ProjectAdmissionDecision>(row.get("admission"))
+        .map_err(|error| {
+            SessionStoreError::Backend(format!(
+                "failed to decode session admission decision: {error}"
+            ))
+        })?;
 
     let width = row.get::<_, i32>("viewport_width");
     let height = row.get::<_, i32>("viewport_height");
@@ -57,6 +63,8 @@ pub(in crate::session_control) fn row_to_stored_session(
     Ok(StoredSession {
         id: row.get("id"),
         state,
+        project_id: row.get("project_id"),
+        admission,
         template_id: row.get("template_id"),
         browser_context: SessionBrowserContextResource {
             mode: browser_context_mode,

--- a/code/apps/bpane-gateway/src/session_control/store/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/store/resources.rs
@@ -1,6 +1,79 @@
 use super::*;
 
 impl SessionStore {
+    pub async fn create_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistProjectRequest,
+    ) -> Result<StoredProject, SessionStoreError> {
+        validate_project_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => store.create_project(principal, request).await,
+            SessionStoreBackend::Postgres(store) => store.create_project(principal, request).await,
+        }
+    }
+
+    pub async fn list_projects_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredProject>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => store.list_projects_for_owner(principal).await,
+            SessionStoreBackend::Postgres(store) => store.list_projects_for_owner(principal).await,
+        }
+    }
+
+    pub async fn get_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.get_project_for_owner(principal, id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.get_project_for_owner(principal, id).await
+            }
+        }
+    }
+
+    pub async fn update_project_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistProjectRequest,
+    ) -> Result<Option<StoredProject>, SessionStoreError> {
+        validate_project_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.update_project_for_owner(principal, id, request).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.update_project_for_owner(principal, id, request).await
+            }
+        }
+    }
+
+    pub async fn count_active_sessions_for_project(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        project_id: Uuid,
+    ) -> Result<u32, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .count_active_sessions_for_project(principal, project_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .count_active_sessions_for_project(principal, project_id)
+                    .await
+            }
+        }
+    }
+
     pub fn validate_browser_context_request(
         request: &PersistBrowserContextRequest,
     ) -> Result<(), SessionStoreError> {

--- a/code/apps/bpane-gateway/src/session_control/tests/automation_tasks.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/automation_tasks.rs
@@ -9,6 +9,7 @@ async fn in_memory_store_tracks_automation_task_lifecycle_logs_and_events() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/recordings.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/recordings.rs
@@ -9,6 +9,7 @@ async fn in_memory_store_creates_and_stops_recording_metadata() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -125,6 +126,7 @@ async fn in_memory_store_lists_and_clears_expired_recording_artifacts() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/runtime_assignments.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/runtime_assignments.rs
@@ -15,6 +15,7 @@ async fn in_memory_store_persists_runtime_assignments_and_can_clear_them() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -71,6 +72,7 @@ async fn in_memory_store_persists_recording_worker_assignments() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -141,6 +143,7 @@ async fn in_memory_store_persists_workflow_run_worker_assignments() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/session_files.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/session_files.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 
 fn create_session_request() -> CreateSessionRequest {
     CreateSessionRequest {
+        project_id: None,
         template_id: None,
         browser_context: None,
         network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/capacity.rs
@@ -9,6 +9,7 @@ async fn in_memory_store_limits_legacy_runtime_to_one_active_session() {
         .create_session(
             &alpha,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -30,6 +31,7 @@ async fn in_memory_store_limits_legacy_runtime_to_one_active_session() {
         .create_session(
             &alpha,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -71,6 +73,7 @@ async fn in_memory_store_respects_runtime_pool_capacity() {
             .create_session(
                 &alpha,
                 CreateSessionRequest {
+                    project_id: None,
                     template_id: None,
                     browser_context: None,
                     network_identity: None,
@@ -93,6 +96,7 @@ async fn in_memory_store_respects_runtime_pool_capacity() {
         .create_session(
             &alpha,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -133,6 +137,7 @@ async fn reconnect_prep_respects_runtime_pool_capacity() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -162,6 +167,7 @@ async fn reconnect_prep_respects_runtime_pool_capacity() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/delegation.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/delegation.rs
@@ -10,6 +10,7 @@ async fn in_memory_store_allows_delegated_client_to_load_session() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/lifecycle.rs
@@ -8,6 +8,7 @@ async fn in_memory_store_stops_unused_ready_sessions_and_idle_sessions() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -36,6 +37,7 @@ async fn in_memory_store_stops_unused_ready_sessions_and_idle_sessions() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -94,6 +96,7 @@ async fn in_memory_store_can_prepare_a_stopped_session_for_reconnect() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -136,6 +139,7 @@ async fn in_memory_store_can_prepare_a_released_session_for_reconnect() {
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,
@@ -179,6 +183,7 @@ async fn in_memory_store_can_restore_runtime_candidate_to_ready_after_runtime_lo
         .create_session(
             &owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/sessions/visibility.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/sessions/visibility.rs
@@ -10,6 +10,7 @@ async fn in_memory_store_scopes_sessions_to_owner() {
         .create_session(
             &alpha,
             CreateSessionRequest {
+                project_id: None,
                 template_id: Some("default".to_string()),
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/tests/validation.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/validation.rs
@@ -4,6 +4,7 @@ use serde_json::json;
 #[test]
 fn rejects_non_object_integration_context() {
     let error = validate_create_request(&CreateSessionRequest {
+        project_id: None,
         template_id: None,
         browser_context: None,
         network_identity: None,
@@ -24,6 +25,7 @@ fn rejects_non_object_integration_context() {
 #[test]
 fn rejects_zero_recording_retention() {
     let error = validate_create_request(&CreateSessionRequest {
+        project_id: None,
         template_id: None,
         browser_context: None,
         network_identity: None,
@@ -110,6 +112,7 @@ fn accepts_valid_session_template_defaults() {
         description: Some("Support debug sessions".to_string()),
         labels: HashMap::from([("team".to_string(), "support".to_string())]),
         defaults: SessionTemplateDefaults {
+            project_id: None,
             owner_mode: Some(SessionOwnerMode::Collaborative),
             viewport: Some(SessionViewport {
                 width: 1440,
@@ -132,6 +135,7 @@ fn accepts_valid_session_template_defaults() {
 #[test]
 fn validates_network_identity_and_egress_profile_shapes() {
     validate_create_request(&CreateSessionRequest {
+        project_id: None,
         network_identity: Some(SessionNetworkIdentity {
             locale: Some("de-DE".to_string()),
             languages: vec!["de-DE".to_string(), "en-US".to_string()],
@@ -176,6 +180,7 @@ fn validates_network_identity_and_egress_profile_shapes() {
         },
     ] {
         let error = validate_create_request(&CreateSessionRequest {
+            project_id: None,
             network_identity: Some(identity),
             ..CreateSessionRequest::default()
         })

--- a/code/apps/bpane-gateway/src/session_control/tests/workflows.rs
+++ b/code/apps/bpane-gateway/src/session_control/tests/workflows.rs
@@ -21,6 +21,7 @@ async fn create_workflow_fixture(
         .create_session(
             owner,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -262,6 +262,233 @@ pub struct SessionNetworkIdentity {
     pub egress_profile_id: Option<Uuid>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectState {
+    Active,
+    Archived,
+}
+
+impl ProjectState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Archived => "archived",
+        }
+    }
+}
+
+impl FromStr for ProjectState {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(Self::Active),
+            "archived" => Ok(Self::Archived),
+            _ => Err("unknown project state"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectQuotas {
+    #[serde(default)]
+    pub max_active_sessions: Option<u32>,
+    #[serde(default)]
+    pub max_active_workflow_runs: Option<u32>,
+    #[serde(default)]
+    pub max_retained_storage_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectAdmissionState {
+    Allowed,
+    Queued,
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectAdmissionReasonCode {
+    OwnerScopeUnbounded,
+    ProjectQuotaAvailable,
+    ActiveSessionQuotaExceeded,
+    ProjectArchived,
+}
+
+impl ProjectAdmissionReasonCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OwnerScopeUnbounded => "owner_scope_unbounded",
+            Self::ProjectQuotaAvailable => "project_quota_available",
+            Self::ActiveSessionQuotaExceeded => "active_session_quota_exceeded",
+            Self::ProjectArchived => "project_archived",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProjectAdmissionDecision {
+    pub state: ProjectAdmissionState,
+    pub reason_code: ProjectAdmissionReasonCode,
+    pub message: String,
+    #[serde(default)]
+    pub project_id: Option<Uuid>,
+    #[serde(default)]
+    pub active_sessions: Option<u32>,
+    #[serde(default)]
+    pub max_active_sessions: Option<u32>,
+    pub checked_at: DateTime<Utc>,
+}
+
+impl ProjectAdmissionDecision {
+    pub fn owner_scope_unbounded(checked_at: DateTime<Utc>) -> Self {
+        Self {
+            state: ProjectAdmissionState::Allowed,
+            reason_code: ProjectAdmissionReasonCode::OwnerScopeUnbounded,
+            message: "No project was selected; owner-scoped admission is unbounded.".to_string(),
+            project_id: None,
+            active_sessions: None,
+            max_active_sessions: None,
+            checked_at,
+        }
+    }
+
+    pub fn project_quota_available(
+        project_id: Uuid,
+        active_sessions: u32,
+        max_active_sessions: Option<u32>,
+        checked_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            state: ProjectAdmissionState::Allowed,
+            reason_code: ProjectAdmissionReasonCode::ProjectQuotaAvailable,
+            message: "Project admission allowed.".to_string(),
+            project_id: Some(project_id),
+            active_sessions: Some(active_sessions),
+            max_active_sessions,
+            checked_at,
+        }
+    }
+
+    pub fn rejected(
+        project_id: Uuid,
+        reason_code: ProjectAdmissionReasonCode,
+        message: String,
+        active_sessions: u32,
+        max_active_sessions: Option<u32>,
+        checked_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            state: ProjectAdmissionState::Rejected,
+            reason_code,
+            message,
+            project_id: Some(project_id),
+            active_sessions: Some(active_sessions),
+            max_active_sessions,
+            checked_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistProjectRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub quotas: ProjectQuotas,
+    pub state: ProjectState,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredProject {
+    pub id: Uuid,
+    pub owner_subject: String,
+    pub owner_issuer: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub quotas: ProjectQuotas,
+    pub state: ProjectState,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectUsageResource {
+    pub project_id: Uuid,
+    pub active_sessions: u32,
+    pub max_active_sessions: Option<u32>,
+    pub active_workflow_runs: u32,
+    pub max_active_workflow_runs: Option<u32>,
+    pub retained_storage_bytes: u64,
+    pub max_retained_storage_bytes: Option<u64>,
+    pub observed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ProjectResource {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub labels: HashMap<String, String>,
+    pub quotas: ProjectQuotas,
+    pub state: ProjectState,
+    pub usage: ProjectUsageResource,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SessionProjectResource {
+    pub id: Uuid,
+    pub name: String,
+    pub state: ProjectState,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectListResponse {
+    pub projects: Vec<ProjectResource>,
+}
+
+impl StoredProject {
+    pub fn usage(&self, active_sessions: u32, observed_at: DateTime<Utc>) -> ProjectUsageResource {
+        ProjectUsageResource {
+            project_id: self.id,
+            active_sessions,
+            max_active_sessions: self.quotas.max_active_sessions,
+            active_workflow_runs: 0,
+            max_active_workflow_runs: self.quotas.max_active_workflow_runs,
+            retained_storage_bytes: 0,
+            max_retained_storage_bytes: self.quotas.max_retained_storage_bytes,
+            observed_at,
+        }
+    }
+
+    pub fn to_resource(&self, active_sessions: u32, observed_at: DateTime<Utc>) -> ProjectResource {
+        ProjectResource {
+            id: self.id,
+            name: self.name.clone(),
+            description: self.description.clone(),
+            labels: self.labels.clone(),
+            quotas: self.quotas.clone(),
+            state: self.state,
+            usage: self.usage(active_sessions, observed_at),
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+
+    pub fn to_session_project_resource(&self) -> SessionProjectResource {
+        SessionProjectResource {
+            id: self.id,
+            name: self.name.clone(),
+            state: self.state,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EgressProxyConfig {
     pub url: String,
@@ -1038,6 +1265,9 @@ pub struct SessionStatusSummary {
 pub struct SessionResource {
     pub id: Uuid,
     pub state: SessionLifecycleState,
+    pub project_id: Option<Uuid>,
+    pub project: Option<SessionProjectResource>,
+    pub admission: ProjectAdmissionDecision,
     pub template_id: Option<String>,
     pub browser_context: SessionBrowserContextResource,
     pub network_identity: SessionNetworkIdentity,
@@ -1065,6 +1295,8 @@ pub struct SessionResource {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateSessionRequest {
     #[serde(default)]
+    pub project_id: Option<Uuid>,
+    #[serde(default)]
     pub template_id: Option<String>,
     #[serde(default)]
     pub browser_context: Option<SessionBrowserContextRequest>,
@@ -1090,6 +1322,8 @@ pub struct CreateSessionRequest {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct SessionTemplateDefaults {
+    #[serde(default)]
+    pub project_id: Option<Uuid>,
     #[serde(default)]
     pub owner_mode: Option<SessionOwnerMode>,
     #[serde(default)]
@@ -1178,6 +1412,8 @@ pub struct SessionListResponse {
 pub struct StoredSession {
     pub id: Uuid,
     pub state: SessionLifecycleState,
+    pub project_id: Option<Uuid>,
+    pub admission: ProjectAdmissionDecision,
     pub template_id: Option<String>,
     pub browser_context: SessionBrowserContextResource,
     pub network_identity: SessionNetworkIdentity,
@@ -1200,6 +1436,7 @@ impl StoredSession {
     pub fn to_resource(
         &self,
         public_gateway_url: &str,
+        project: Option<SessionProjectResource>,
         runtime: SessionRuntimeInfo,
         status: SessionStatusSummary,
         state_override: Option<SessionLifecycleState>,
@@ -1209,6 +1446,9 @@ impl StoredSession {
         SessionResource {
             id: self.id,
             state: state_override.unwrap_or(self.state),
+            project_id: self.project_id,
+            project,
+            admission: self.admission.clone(),
             template_id: self.template_id.clone(),
             browser_context: self.browser_context.clone(),
             network_identity: self.network_identity.clone(),

--- a/code/apps/bpane-gateway/src/session_control/validation/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/mod.rs
@@ -17,8 +17,8 @@ pub(super) use resources::{
     validate_browser_context_request, validate_credential_binding_request,
     validate_egress_profile_request, validate_extension_definition_request,
     validate_extension_version_request, validate_file_workspace_file_request,
-    validate_file_workspace_request, validate_session_file_binding_request,
-    validate_session_file_request,
+    validate_file_workspace_request, validate_project_request,
+    validate_session_file_binding_request, validate_session_file_request,
 };
 pub(super) use sessions::{
     validate_automation_delegate_request, validate_create_request,

--- a/code/apps/bpane-gateway/src/session_control/validation/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/resources.rs
@@ -58,6 +58,54 @@ pub(in crate::session_control) fn validate_browser_context_request(
     Ok(())
 }
 
+pub(in crate::session_control) fn validate_project_request(
+    request: &PersistProjectRequest,
+) -> Result<(), SessionStoreError> {
+    if request.name.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "project name must not be empty".to_string(),
+        ));
+    }
+    if let Some(description) = &request.description {
+        if description.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "project description must not be empty when provided".to_string(),
+            ));
+        }
+    }
+    for (key, value) in &request.labels {
+        if key.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "project label keys must not be empty".to_string(),
+            ));
+        }
+        if value.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "project label values must not be empty".to_string(),
+            ));
+        }
+    }
+    if request.quotas.max_active_sessions == Some(0) {
+        return Err(SessionStoreError::InvalidRequest(
+            "project quotas.max_active_sessions must be greater than zero when provided"
+                .to_string(),
+        ));
+    }
+    if request.quotas.max_active_workflow_runs == Some(0) {
+        return Err(SessionStoreError::InvalidRequest(
+            "project quotas.max_active_workflow_runs must be greater than zero when provided"
+                .to_string(),
+        ));
+    }
+    if request.quotas.max_retained_storage_bytes == Some(0) {
+        return Err(SessionStoreError::InvalidRequest(
+            "project quotas.max_retained_storage_bytes must be greater than zero when provided"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub(in crate::session_control) fn validate_credential_binding_request(
     request: &PersistCredentialBindingRequest,
 ) -> Result<(), SessionStoreError> {

--- a/code/apps/bpane-gateway/src/session_control/validation/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/sessions.rs
@@ -5,6 +5,11 @@ use super::*;
 pub(in crate::session_control) fn validate_create_request(
     request: &CreateSessionRequest,
 ) -> Result<(), SessionStoreError> {
+    if request.project_id == Some(Uuid::nil()) {
+        return Err(SessionStoreError::InvalidRequest(
+            "project_id must not be nil".to_string(),
+        ));
+    }
     if let Some(viewport) = &request.viewport {
         if viewport.width == 0 || viewport.height == 0 {
             return Err(SessionStoreError::InvalidRequest(
@@ -105,6 +110,7 @@ pub(in crate::session_control) fn validate_session_template_request(
 
 fn validate_template_defaults(defaults: &SessionTemplateDefaults) -> Result<(), SessionStoreError> {
     let request = CreateSessionRequest {
+        project_id: defaults.project_id,
         owner_mode: defaults.owner_mode,
         viewport: defaults.viewport.clone(),
         idle_timeout_sec: defaults.idle_timeout_sec,

--- a/code/apps/bpane-gateway/src/session_files/retention.rs
+++ b/code/apps/bpane-gateway/src/session_files/retention.rs
@@ -126,6 +126,7 @@ mod tests {
             .create_session(
                 &owner(),
                 CreateSessionRequest {
+                    project_id: None,
                     template_id: None,
                     browser_context: None,
                     network_identity: None,

--- a/code/apps/bpane-gateway/src/session_files/transfer_recorder.rs
+++ b/code/apps/bpane-gateway/src/session_files/transfer_recorder.rs
@@ -259,6 +259,7 @@ mod tests {
             .create_session(
                 &owner,
                 CreateSessionRequest {
+                    project_id: None,
                     recording: SessionRecordingPolicy::default(),
                     ..CreateSessionRequest::default()
                 },

--- a/code/apps/bpane-gateway/src/transport/tests/request.rs
+++ b/code/apps/bpane-gateway/src/transport/tests/request.rs
@@ -13,6 +13,7 @@ use crate::session_hub::BrowserClientRole;
 
 fn empty_request() -> CreateSessionRequest {
     CreateSessionRequest {
+        project_id: None,
         template_id: None,
         browser_context: None,
         network_identity: None,

--- a/code/apps/bpane-gateway/src/workflow/retention.rs
+++ b/code/apps/bpane-gateway/src/workflow/retention.rs
@@ -165,6 +165,7 @@ mod tests {
             .create_session(
                 &principal,
                 CreateSessionRequest {
+                    project_id: None,
                     template_id: None,
                     browser_context: None,
                     network_identity: None,

--- a/code/apps/bpane-gateway/src/workflow_lifecycle/tests.rs
+++ b/code/apps/bpane-gateway/src/workflow_lifecycle/tests.rs
@@ -68,6 +68,7 @@ async fn create_workflow_run(store: &SessionStore) -> crate::workflow::StoredWor
         .create_session(
             &principal,
             CreateSessionRequest {
+                project_id: None,
                 template_id: None,
                 browser_context: None,
                 network_identity: None,

--- a/code/apps/bpane-gateway/tests/compose_api_surface.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface.rs
@@ -3,7 +3,7 @@ mod suite;
 
 use suite::{
     automation_access_boundaries, browser_contexts, credentials_extensions, network_identity,
-    ownership_boundaries, recording_artifacts, session_churn, session_compatibility,
+    ownership_boundaries, projects, recording_artifacts, session_churn, session_compatibility,
     session_templates, sessions_recordings, support, workflow_run_controls, workflows_events,
     workspaces_automation,
 };
@@ -24,6 +24,15 @@ async fn compose_session_templates_catalog_api_surface() -> anyhow::Result<()> {
     let harness = support::ComposeHarness::connect().await?;
     harness.cleanup_active_sessions().await?;
     session_templates::run(&harness).await
+}
+
+#[tokio::test]
+#[ignore = "requires running local compose stack"]
+async fn compose_projects_api_surface() -> anyhow::Result<()> {
+    let _guard = support::suite_lock().lock().await;
+    let harness = support::ComposeHarness::connect().await?;
+    harness.cleanup_active_sessions().await?;
+    projects::run(&harness).await
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
@@ -3,6 +3,7 @@ pub mod browser_contexts;
 pub mod credentials_extensions;
 pub mod network_identity;
 pub mod ownership_boundaries;
+pub mod projects;
 pub mod recording_artifacts;
 pub mod session_churn;
 pub mod session_compatibility;

--- a/code/apps/bpane-gateway/tests/compose_api_surface/projects.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/projects.rs
@@ -1,0 +1,234 @@
+use anyhow::{anyhow, Result};
+use reqwest::StatusCode;
+use serde_json::json;
+
+use super::support::{json_array, json_id, label_map, ComposeHarness};
+
+pub async fn run(harness: &ComposeHarness) -> Result<()> {
+    let invalid = harness
+        .post_json_outcome(
+            "/api/v1/projects",
+            json!({
+                "name": "invalid-project",
+                "quotas": { "max_active_sessions": 0 }
+            }),
+        )
+        .await?;
+    if invalid.status != StatusCode::BAD_REQUEST {
+        return Err(anyhow!(
+            "invalid project create returned {} instead of 400: {}",
+            invalid.status,
+            invalid.body
+        ));
+    }
+
+    let project_name = harness.unique_name("compose-project");
+    let project = harness
+        .post_json(
+            "/api/v1/projects",
+            json!({
+                "name": project_name,
+                "description": "Compose e2e project",
+                "labels": label_map("projects"),
+                "quotas": {
+                    "max_active_sessions": 1,
+                    "max_active_workflow_runs": 2,
+                    "max_retained_storage_bytes": 1048576
+                }
+            }),
+        )
+        .await?;
+    let project_id = json_id(&project, "id")?;
+    if project["state"] != json!("active")
+        || project["usage"]["active_sessions"] != json!(0)
+        || project["usage"]["max_active_sessions"] != json!(1)
+    {
+        return Err(anyhow!(
+            "project create returned unexpected resource: {project}"
+        ));
+    }
+
+    let listed = harness.get_json("/api/v1/projects").await?;
+    let listed_projects = json_array(&listed, "projects")?;
+    if !listed_projects
+        .iter()
+        .any(|candidate| candidate.get("id") == Some(&json!(project_id)))
+    {
+        return Err(anyhow!("project list did not include {project_id}"));
+    }
+
+    let fetched = harness
+        .get_json(&format!("/api/v1/projects/{project_id}"))
+        .await?;
+    if fetched["id"] != json!(project_id) || fetched["labels"]["suite"] != json!("projects") {
+        return Err(anyhow!(
+            "project get returned unexpected resource: {fetched}"
+        ));
+    }
+
+    let template_name = harness.unique_name("compose-project-template");
+    let template = harness
+        .post_json(
+            "/api/v1/session-templates",
+            json!({
+                "name": template_name,
+                "defaults": {
+                    "project_id": project_id,
+                    "labels": {
+                        "team": "support"
+                    }
+                }
+            }),
+        )
+        .await?;
+    let template_id = json_id(&template, "id")?;
+    if template["defaults"]["project_id"] != json!(project_id) {
+        return Err(anyhow!(
+            "project template default was not persisted: {template}"
+        ));
+    }
+
+    let run_id = harness.unique_name("project-admission-e2e");
+    let first = harness
+        .post_json(
+            "/api/v1/sessions",
+            json!({
+                "template_id": template_id,
+                "labels": {
+                    "run_id": run_id
+                }
+            }),
+        )
+        .await?;
+    let first_session_id = json_id(&first, "id")?;
+    if first["project_id"] != json!(project_id)
+        || first["project"]["id"] != json!(project_id)
+        || first["admission"]["state"] != json!("allowed")
+        || first["admission"]["reason_code"] != json!("project_quota_available")
+        || first["admission"]["active_sessions"] != json!(1)
+    {
+        return Err(anyhow!(
+            "project-scoped session did not expose allowed admission: {first}"
+        ));
+    }
+
+    let status = harness
+        .get_json(&format!("/api/v1/sessions/{first_session_id}/status"))
+        .await?;
+    if status["project_id"] != json!(project_id) || status["admission"]["state"] != json!("allowed")
+    {
+        return Err(anyhow!(
+            "project-scoped session status did not expose admission: {status}"
+        ));
+    }
+
+    let rejected = harness
+        .post_json_outcome(
+            "/api/v1/sessions",
+            json!({
+                "project_id": project_id
+            }),
+        )
+        .await?;
+    if rejected.status != StatusCode::CONFLICT
+        || !rejected.body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("active_session_quota_exceeded")
+    {
+        return Err(anyhow!(
+            "project quota rejection returned unexpected result {}: {}",
+            rejected.status,
+            rejected.body
+        ));
+    }
+
+    let usage = harness
+        .get_json(&format!("/api/v1/projects/{project_id}/usage"))
+        .await?;
+    if usage["active_sessions"] != json!(1) {
+        return Err(anyhow!(
+            "project usage did not count the active session: {usage}"
+        ));
+    }
+
+    let stopped_first = harness
+        .delete_json(&format!("/api/v1/sessions/{first_session_id}"))
+        .await?;
+    if stopped_first["state"] != json!("stopped") {
+        return Err(anyhow!(
+            "first project-scoped session cleanup did not stop the session"
+        ));
+    }
+
+    let second = harness
+        .post_json(
+            "/api/v1/sessions",
+            json!({
+                "project_id": project_id,
+                "labels": {
+                    "run_id": run_id,
+                    "retry": "true"
+                }
+            }),
+        )
+        .await?;
+    let second_session_id = json_id(&second, "id")?;
+    if second["admission"]["state"] != json!("allowed") {
+        return Err(anyhow!(
+            "project admission did not recover after stopping first session: {second}"
+        ));
+    }
+
+    let archived = harness
+        .put_json(
+            &format!("/api/v1/projects/{project_id}"),
+            json!({
+                "name": project_name,
+                "description": "Compose e2e project archived",
+                "labels": label_map("projects"),
+                "quotas": {
+                    "max_active_sessions": 1,
+                    "max_active_workflow_runs": 2,
+                    "max_retained_storage_bytes": 1048576
+                },
+                "state": "archived"
+            }),
+        )
+        .await?;
+    if archived["state"] != json!("archived") {
+        return Err(anyhow!("project archive did not persist: {archived}"));
+    }
+
+    let archived_rejected = harness
+        .post_json_outcome(
+            "/api/v1/sessions",
+            json!({
+                "project_id": project_id
+            }),
+        )
+        .await?;
+    if archived_rejected.status != StatusCode::CONFLICT
+        || !archived_rejected.body["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("project_archived")
+    {
+        return Err(anyhow!(
+            "archived project rejection returned unexpected result {}: {}",
+            archived_rejected.status,
+            archived_rejected.body
+        ));
+    }
+
+    let stopped_second = harness
+        .delete_json(&format!("/api/v1/sessions/{second_session_id}"))
+        .await?;
+    if stopped_second["state"] != json!("stopped") {
+        return Err(anyhow!(
+            "second project-scoped session cleanup did not stop the session"
+        ));
+    }
+
+    Ok(())
+}

--- a/code/apps/bpane-gateway/tests/compose_api_surface/projects.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/projects.rs
@@ -60,7 +60,11 @@ pub async fn run(harness: &ComposeHarness) -> Result<()> {
     let fetched = harness
         .get_json(&format!("/api/v1/projects/{project_id}"))
         .await?;
-    if fetched["id"] != json!(project_id) || fetched["labels"]["suite"] != json!("projects") {
+    if fetched["id"] != json!(project_id)
+        || fetched["labels"]["suite"] != json!("bpane-gateway-compose-e2e")
+        || fetched["labels"]["scope"] != json!("projects")
+        || fetched["usage"]["max_active_sessions"] != json!(1)
+    {
         return Err(anyhow!(
             "project get returned unexpected resource: {fetched}"
         ));

--- a/code/web/bpane-admin/src/lib/api/control-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.test.ts
@@ -4,6 +4,21 @@ import { ControlClient, type FetchLike } from './control-client';
 const SESSION = {
   id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
   state: 'active',
+  project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+  project: {
+    id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    name: 'Support tenant',
+    state: 'active',
+  },
+  admission: {
+    state: 'allowed',
+    reason_code: 'project_quota_available',
+    message: 'Project admission allowed.',
+    project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    active_sessions: 1,
+    max_active_sessions: 2,
+    checked_at: '2026-05-04T19:00:00Z',
+  },
   template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   browser_context: {
     mode: 'reusable',
@@ -89,6 +104,31 @@ const BROWSER_CONTEXT = {
   deleted_at: null,
 };
 
+const PROJECT = {
+  id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+  name: 'Support tenant',
+  description: 'Support tenant project',
+  labels: { tenant: 'support' },
+  quotas: {
+    max_active_sessions: 2,
+    max_active_workflow_runs: 4,
+    max_retained_storage_bytes: 1073741824,
+  },
+  state: 'active',
+  usage: {
+    project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    active_sessions: 1,
+    max_active_sessions: 2,
+    active_workflow_runs: 1,
+    max_active_workflow_runs: 4,
+    retained_storage_bytes: 268435456,
+    max_retained_storage_bytes: 1073741824,
+    observed_at: '2026-05-04T18:50:00Z',
+  },
+  created_at: '2026-05-04T18:50:00Z',
+  updated_at: '2026-05-04T18:50:00Z',
+};
+
 const TEMPLATE = {
   id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   name: 'Support triage',
@@ -154,6 +194,8 @@ describe('ControlClient', () => {
 
     expect(response.sessions).toHaveLength(1);
     expect(response.sessions[0]?.id).toBe(SESSION.id);
+    expect(response.sessions[0]?.project?.name).toBe('Support tenant');
+    expect(response.sessions[0]?.admission?.reason_code).toBe('project_quota_available');
     expect(response.sessions[0]?.browser_context).toEqual(SESSION.browser_context);
     expect(response.sessions[0]?.network_identity?.locale).toBe('de-DE');
     expect(response.sessions[0]?.effective_egress?.profile_name).toBe('EU support egress');
@@ -166,6 +208,106 @@ describe('ControlClient', () => {
           authorization: 'Bearer owner-token',
         }),
       }),
+    );
+  });
+
+  it('manages project catalog resources with bearer auth', async () => {
+    const responses = [PROJECT, PROJECT, { ...PROJECT, name: 'Support tenant archived', state: 'archived' }, PROJECT.usage];
+    const fetchImpl = vi.fn<FetchLike>(async () => new Response(JSON.stringify(responses.shift()), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    const created = await client.createProject({
+      name: 'Support tenant',
+      description: 'Support tenant project',
+      labels: { tenant: 'support' },
+      quotas: {
+        max_active_sessions: 2,
+        max_active_workflow_runs: 4,
+        max_retained_storage_bytes: 1073741824,
+      },
+    });
+    await client.getProject('project/with space');
+    await client.updateProject('project/with space', {
+      name: 'Support tenant archived',
+      state: 'archived',
+    });
+    await client.getProjectUsage('project/with space');
+
+    expect(created).toMatchObject({
+      id: PROJECT.id,
+      name: 'Support tenant',
+      usage: {
+        active_sessions: 1,
+        max_active_sessions: 2,
+      },
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL('http://localhost:8932/api/v1/projects'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'Support tenant',
+          description: 'Support tenant project',
+          labels: { tenant: 'support' },
+          quotas: {
+            max_active_sessions: 2,
+            max_active_workflow_runs: 4,
+            max_retained_storage_bytes: 1073741824,
+          },
+          state: 'active',
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL('http://localhost:8932/api/v1/projects/project%2Fwith%20space'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      new URL('http://localhost:8932/api/v1/projects/project%2Fwith%20space'),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'Support tenant archived',
+          state: 'archived',
+          labels: {},
+          quotas: {},
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      4,
+      new URL('http://localhost:8932/api/v1/projects/project%2Fwith%20space/usage'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('lists project catalog resources with bearer auth', async () => {
+    const fetchImpl = jsonFetch({ projects: [PROJECT] });
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    const response = await client.listProjects();
+
+    expect(response.projects[0]).toMatchObject({
+      id: PROJECT.id,
+      name: 'Support tenant',
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL('http://localhost:8932/api/v1/projects'),
+      expect.objectContaining({ method: 'GET' }),
     );
   });
 
@@ -559,6 +701,7 @@ describe('ControlClient', () => {
     });
 
     await client.createSession({
+      project_id: PROJECT.id,
       template_id: TEMPLATE.id,
       browser_context: {
         mode: 'reusable',
@@ -579,6 +722,7 @@ describe('ControlClient', () => {
       expect.objectContaining({
         method: 'POST',
         body: JSON.stringify({
+          project_id: PROJECT.id,
           template_id: TEMPLATE.id,
           browser_context: {
             mode: 'reusable',

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -15,6 +15,7 @@ import type {
   CloneBrowserContextCommand,
   CreateBrowserContextCommand,
   CreateEgressProfileCommand,
+  CreateProjectCommand,
   ImportBrowserContextCommand,
   CreateSessionCommand,
   CreateFileWorkspaceCommand,
@@ -26,6 +27,9 @@ import type {
   FileWorkspaceFileResource,
   FileWorkspaceListResponse,
   FileWorkspaceResource,
+  ProjectListResponse,
+  ProjectResource,
+  ProjectUsageResource,
   SessionAccessTokenResponse,
   SessionFileBindingListResponse,
   SessionFileBindingResource,
@@ -77,6 +81,41 @@ export class ControlClient {
   async listSessions(filters: SessionListFilters = {}): Promise<SessionListResponse> {
     const payload = await this.#request('GET', buildSessionListPath(filters));
     return ControlSessionMapper.toSessionList(payload);
+  }
+
+  async listProjects(): Promise<ProjectListResponse> {
+    const payload = await this.#request('GET', '/api/v1/projects');
+    return ControlSessionMapper.toProjectList(payload);
+  }
+
+  async createProject(command: CreateProjectCommand): Promise<ProjectResource> {
+    const payload = await this.#request('POST', '/api/v1/projects', {
+      ...command,
+      labels: command.labels ?? {},
+      quotas: command.quotas ?? {},
+      state: command.state ?? 'active',
+    });
+    return ControlSessionMapper.toProjectResource(payload);
+  }
+
+  async getProject(projectId: string): Promise<ProjectResource> {
+    const payload = await this.#request('GET', `/api/v1/projects/${encodeURIComponent(projectId)}`);
+    return ControlSessionMapper.toProjectResource(payload);
+  }
+
+  async updateProject(projectId: string, command: CreateProjectCommand): Promise<ProjectResource> {
+    const payload = await this.#request('PUT', `/api/v1/projects/${encodeURIComponent(projectId)}`, {
+      ...command,
+      labels: command.labels ?? {},
+      quotas: command.quotas ?? {},
+      state: command.state ?? 'active',
+    });
+    return ControlSessionMapper.toProjectResource(payload);
+  }
+
+  async getProjectUsage(projectId: string): Promise<ProjectUsageResource> {
+    const payload = await this.#request('GET', `/api/v1/projects/${encodeURIComponent(projectId)}/usage`);
+    return ControlSessionMapper.toProjectUsage(payload);
   }
 
   async listSessionTemplates(): Promise<SessionTemplateListResponse> {

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -15,6 +15,14 @@ import type {
   EgressProxyConfig,
   EgressTrafficObservationConfig,
   EgressTrafficObservationMode,
+  ProjectAdmissionDecision,
+  ProjectAdmissionReasonCode,
+  ProjectAdmissionState,
+  ProjectListResponse,
+  ProjectQuotas,
+  ProjectResource,
+  ProjectState,
+  ProjectUsageResource,
   SessionAutomationDelegate,
   SessionBrowserContextMode,
   SessionBrowserContextResource,
@@ -25,6 +33,7 @@ import type {
   SessionAccessTokenResponse,
   SessionListResponse,
   SessionNetworkIdentity,
+  SessionProjectResource,
   SessionResource,
   SessionRuntimeInfo,
   SessionStatusSummary,
@@ -45,6 +54,45 @@ import {
 } from './control-wire';
 
 export class ControlSessionMapper {
+  static toProjectList(payload: unknown): ProjectListResponse {
+    const object = expectRecord(payload, 'project list response');
+    const projects = object.projects;
+    if (!Array.isArray(projects)) {
+      throw new Error('project list response must contain a projects array');
+    }
+    return {
+      projects: projects.map((project) => this.toProjectResource(project)),
+    };
+  }
+
+  static toProjectResource(payload: unknown): ProjectResource {
+    const object = expectRecord(payload, 'project resource');
+    const description = optionalString(object.description, 'project description');
+    return {
+      id: expectString(object.id, 'project id'),
+      name: expectString(object.name, 'project name'),
+      description: description ?? null,
+      labels: expectStringRecord(object.labels ?? {}, 'project labels'),
+      quotas: toProjectQuotas(object.quotas),
+      state: expectEnum(object.state, 'project state', PROJECT_STATES),
+      usage: toProjectUsage(object.usage),
+      created_at: expectString(object.created_at, 'project created_at'),
+      updated_at: expectString(object.updated_at, 'project updated_at'),
+    };
+  }
+
+  static toProjectUsage(payload: unknown): ProjectUsageResource {
+    return toProjectUsage(payload);
+  }
+
+  static toProjectAdmissionDecision(payload: unknown): ProjectAdmissionDecision | null {
+    return toProjectAdmissionDecision(payload);
+  }
+
+  static toSessionProjectResource(payload: unknown): SessionProjectResource | null {
+    return toSessionProjectResource(payload) ?? null;
+  }
+
   static toEgressProfileList(payload: unknown): EgressProfileListResponse {
     const object = expectRecord(payload, 'egress profile list response');
     const profiles = object.profiles;
@@ -168,6 +216,9 @@ export class ControlSessionMapper {
     return {
       id: expectString(object.id, 'session resource id'),
       state: expectString(object.state, 'session resource state'),
+      project_id: optionalString(object.project_id, 'session resource project_id') ?? null,
+      project: toSessionProjectResource(object.project) ?? null,
+      admission: toProjectAdmissionDecision(object.admission),
       template_id: templateId ?? null,
       browser_context: toSessionBrowserContextResource(object.browser_context),
       network_identity: toSessionNetworkIdentity(object.network_identity),
@@ -219,6 +270,14 @@ export class ControlSessionMapper {
 const BROWSER_CONTEXT_STATES = ['ready', 'deleted'] satisfies readonly BrowserContextState[];
 const BROWSER_CONTEXT_PERSISTENCE_MODES = ['reusable', 'ephemeral'] satisfies readonly BrowserContextPersistenceMode[];
 const SESSION_BROWSER_CONTEXT_MODES = ['fresh', 'ephemeral', 'reusable'] satisfies readonly SessionBrowserContextMode[];
+const PROJECT_STATES = ['active', 'archived'] satisfies readonly ProjectState[];
+const PROJECT_ADMISSION_STATES = ['allowed', 'queued', 'rejected'] satisfies readonly ProjectAdmissionState[];
+const PROJECT_ADMISSION_REASON_CODES = [
+  'owner_scope_unbounded',
+  'project_quota_available',
+  'active_session_quota_exceeded',
+  'project_archived',
+] satisfies readonly ProjectAdmissionReasonCode[];
 const EGRESS_PROFILE_STATES = ['ready', 'disabled'] satisfies readonly EgressProfileState[];
 const EGRESS_TRAFFIC_OBSERVATION_MODES = ['metadata_only', 'tls_intercept'] satisfies readonly EgressTrafficObservationMode[];
 const EGRESS_DIAGNOSTICS_HEALTHS = ['ready', 'unknown', 'attention', 'blocked', 'missing'] satisfies readonly EgressDiagnosticsHealth[];
@@ -248,6 +307,93 @@ function optionalRecord(value: unknown, label: string): Readonly<Record<string, 
     return value;
   }
   return expectRecord(value, label);
+}
+
+function toProjectQuotas(value: unknown): ProjectQuotas {
+  const object = value === undefined || value === null
+    ? {}
+    : expectRecord(value, 'project quotas');
+  return {
+    max_active_sessions: optionalNumber(
+      object.max_active_sessions,
+      'project quotas max_active_sessions',
+    ) ?? null,
+    max_active_workflow_runs: optionalNumber(
+      object.max_active_workflow_runs,
+      'project quotas max_active_workflow_runs',
+    ) ?? null,
+    max_retained_storage_bytes: optionalNumber(
+      object.max_retained_storage_bytes,
+      'project quotas max_retained_storage_bytes',
+    ) ?? null,
+  };
+}
+
+function toProjectUsage(value: unknown): ProjectUsageResource {
+  const object = expectRecord(value, 'project usage');
+  return {
+    project_id: expectString(object.project_id, 'project usage project_id'),
+    active_sessions: expectNumber(object.active_sessions, 'project usage active_sessions'),
+    max_active_sessions: optionalNumber(
+      object.max_active_sessions,
+      'project usage max_active_sessions',
+    ) ?? null,
+    active_workflow_runs: expectNumber(
+      object.active_workflow_runs,
+      'project usage active_workflow_runs',
+    ),
+    max_active_workflow_runs: optionalNumber(
+      object.max_active_workflow_runs,
+      'project usage max_active_workflow_runs',
+    ) ?? null,
+    retained_storage_bytes: expectNumber(
+      object.retained_storage_bytes,
+      'project usage retained_storage_bytes',
+    ),
+    max_retained_storage_bytes: optionalNumber(
+      object.max_retained_storage_bytes,
+      'project usage max_retained_storage_bytes',
+    ) ?? null,
+    observed_at: expectString(object.observed_at, 'project usage observed_at'),
+  };
+}
+
+function toSessionProjectResource(value: unknown): SessionProjectResource | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  const object = expectRecord(value, 'session project');
+  return {
+    id: expectString(object.id, 'session project id'),
+    name: expectString(object.name, 'session project name'),
+    state: expectEnum(object.state, 'session project state', PROJECT_STATES),
+  };
+}
+
+function toProjectAdmissionDecision(value: unknown): ProjectAdmissionDecision | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const object = expectRecord(value, 'project admission decision');
+  return {
+    state: expectEnum(object.state, 'project admission state', PROJECT_ADMISSION_STATES),
+    reason_code: expectEnum(
+      object.reason_code,
+      'project admission reason_code',
+      PROJECT_ADMISSION_REASON_CODES,
+    ),
+    message: expectString(object.message, 'project admission message'),
+    project_id: optionalString(object.project_id, 'project admission project_id') ?? null,
+    active_sessions: optionalNumber(
+      object.active_sessions,
+      'project admission active_sessions',
+    ) ?? null,
+    max_active_sessions: optionalNumber(
+      object.max_active_sessions,
+      'project admission max_active_sessions',
+    ) ?? null,
+    checked_at: expectString(object.checked_at, 'project admission checked_at'),
+  };
 }
 
 function toStringArray(value: unknown, label: string): readonly string[] {
@@ -600,7 +746,9 @@ function toOptionalViewport(value: unknown, label: string): SessionViewport | nu
 function toSessionTemplateDefaults(value: unknown): SessionTemplateDefaults {
   const object = expectRecord(value, 'session template defaults');
   const ownerMode = optionalString(object.owner_mode, 'session template defaults owner_mode');
+  const projectId = optionalString(object.project_id, 'session template defaults project_id');
   return {
+    project_id: projectId ?? null,
     ...(ownerMode !== undefined ? { owner_mode: ownerMode } : {}),
     viewport: toOptionalViewport(object.viewport, 'session template defaults viewport') ?? null,
     idle_timeout_sec: optionalNumber(

--- a/code/web/bpane-admin/src/lib/api/control-session-status-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-status-mapper.ts
@@ -21,6 +21,9 @@ export class ControlSessionStatusMapper {
     const object = expectRecord(payload, 'session status');
     return {
       state: expectString(object.state, 'session status state'),
+      project_id: optionalString(object.project_id, 'session status project_id') ?? null,
+      project: ControlSessionMapper.toSessionProjectResource(object.project),
+      admission: ControlSessionMapper.toProjectAdmissionDecision(object.admission),
       runtime_state: expectString(object.runtime_state, 'session status runtime_state'),
       runtime_resume_mode: expectString(object.runtime_resume_mode, 'session status runtime_resume_mode'),
       presence_state: expectString(object.presence_state, 'session status presence_state'),

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -121,6 +121,73 @@ export type SessionEffectiveEgress = {
   readonly sensitive_log_sink_configured: boolean;
 };
 
+export type ProjectState = 'active' | 'archived';
+
+export type ProjectQuotas = {
+  readonly max_active_sessions?: number | null;
+  readonly max_active_workflow_runs?: number | null;
+  readonly max_retained_storage_bytes?: number | null;
+};
+
+export type ProjectUsageResource = {
+  readonly project_id: string;
+  readonly active_sessions: number;
+  readonly max_active_sessions?: number | null;
+  readonly active_workflow_runs: number;
+  readonly max_active_workflow_runs?: number | null;
+  readonly retained_storage_bytes: number;
+  readonly max_retained_storage_bytes?: number | null;
+  readonly observed_at: string;
+};
+
+export type ProjectResource = {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly quotas: ProjectQuotas;
+  readonly state: ProjectState;
+  readonly usage: ProjectUsageResource;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type SessionProjectResource = {
+  readonly id: string;
+  readonly name: string;
+  readonly state: ProjectState;
+};
+
+export type ProjectAdmissionState = 'allowed' | 'queued' | 'rejected';
+
+export type ProjectAdmissionReasonCode =
+  | 'owner_scope_unbounded'
+  | 'project_quota_available'
+  | 'active_session_quota_exceeded'
+  | 'project_archived';
+
+export type ProjectAdmissionDecision = {
+  readonly state: ProjectAdmissionState;
+  readonly reason_code: ProjectAdmissionReasonCode;
+  readonly message: string;
+  readonly project_id?: string | null;
+  readonly active_sessions?: number | null;
+  readonly max_active_sessions?: number | null;
+  readonly checked_at: string;
+};
+
+export type ProjectListResponse = {
+  readonly projects: readonly ProjectResource[];
+};
+
+export type CreateProjectCommand = {
+  readonly name: string;
+  readonly description?: string | null;
+  readonly labels?: Readonly<Record<string, string>>;
+  readonly quotas?: ProjectQuotas;
+  readonly state?: ProjectState;
+};
+
 export type EgressProfileResource = {
   readonly id: string;
   readonly name: string;
@@ -267,6 +334,9 @@ export type SessionStatusSummary = {
 export type SessionResource = {
   readonly id: string;
   readonly state: string;
+  readonly project_id?: string | null;
+  readonly project?: SessionProjectResource | null;
+  readonly admission?: ProjectAdmissionDecision | null;
   readonly template_id?: string | null;
   readonly browser_context: SessionBrowserContextResource;
   readonly network_identity?: SessionNetworkIdentity;
@@ -302,6 +372,7 @@ export type SessionListFilters = {
 };
 
 export type SessionTemplateDefaults = {
+  readonly project_id?: string | null;
   readonly owner_mode?: string | null;
   readonly viewport?: SessionViewport | null;
   readonly idle_timeout_sec?: number | null;
@@ -327,6 +398,7 @@ export type SessionTemplateListResponse = {
 };
 
 export type CreateSessionCommand = {
+  readonly project_id?: string | null;
   readonly template_id?: string | null;
   readonly browser_context?: SessionBrowserContextCommand;
   readonly network_identity?: SessionNetworkIdentity;

--- a/code/web/bpane-admin/src/lib/api/session-status-types.ts
+++ b/code/web/bpane-admin/src/lib/api/session-status-types.ts
@@ -2,8 +2,10 @@ import type { SessionRecordingPlaybackResource } from './recording-types';
 import type {
   SessionConnectionCounts,
   EgressDiagnosticsResource,
+  ProjectAdmissionDecision,
   SessionEffectiveEgress,
   SessionNetworkIdentity,
+  SessionProjectResource,
   SessionStopEligibility,
 } from './control-types';
 
@@ -50,6 +52,9 @@ export type SessionTelemetry = {
 
 export type SessionStatus = {
   readonly state: string;
+  readonly project_id?: string | null;
+  readonly project?: SessionProjectResource | null;
+  readonly admission?: ProjectAdmissionDecision | null;
   readonly runtime_state: string;
   readonly runtime_resume_mode: string;
   readonly presence_state: string;

--- a/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionListRoute.svelte
@@ -8,6 +8,7 @@
     CreateBrowserContextCommand,
     CreateSessionCommand,
     EgressProfileResource,
+    ProjectResource,
     SessionResource,
     SessionTemplateResource,
   } from '../api/control-types';
@@ -23,14 +24,17 @@
 
   let { controlClient }: AdminSessionListRouteProps = $props();
   let sessions = $state<readonly SessionResource[]>([]);
+  let projects = $state<readonly ProjectResource[]>([]);
   let sessionTemplates = $state<readonly SessionTemplateResource[]>([]);
   let browserContexts = $state<readonly BrowserContextResource[]>([]);
   let egressProfiles = $state<readonly EgressProfileResource[]>([]);
   let loading = $state(false);
+  let projectsLoading = $state(false);
   let templatesLoading = $state(false);
   let browserContextsLoading = $state(false);
   let egressProfilesLoading = $state(false);
   let error = $state<string | null>(null);
+  let projectError = $state<string | null>(null);
   let templateError = $state<string | null>(null);
   let browserContextError = $state<string | null>(null);
   let egressProfileError = $state<string | null>(null);
@@ -52,11 +56,24 @@
   const filteredSessions = $derived(filterSessions(viewModel.sessions, search));
 
   onMount(() => {
+    void loadProjects();
     void loadSessionTemplates();
     void loadBrowserContexts();
     void loadEgressProfiles();
     void loadSessions(false);
   });
+
+  async function loadProjects(): Promise<void> {
+    projectsLoading = true;
+    projectError = null;
+    try {
+      projects = (await controlClient.listProjects()).projects;
+    } catch (loadError) {
+      projectError = errorMessage(loadError);
+    } finally {
+      projectsLoading = false;
+    }
+  }
 
   async function loadSessionTemplates(): Promise<void> {
     templatesLoading = true;
@@ -184,6 +201,8 @@
       session.presence,
       session.template,
       session.browserContext,
+      session.project,
+      session.admission,
       session.networkIdentity,
       session.egress,
       session.mcpDelegation,
@@ -302,12 +321,15 @@
 
   <SessionCreateConfigurator
     {sessionTemplates}
+    {projects}
     {browserContexts}
     {egressProfiles}
     {templatesLoading}
+    {projectsLoading}
     {browserContextsLoading}
     {egressProfilesLoading}
     {templateError}
+    {projectError}
     {browserContextError}
     {egressProfileError}
     loading={loading}
@@ -358,7 +380,7 @@
           <span class="grid min-w-0 gap-1">
             <strong class="truncate font-mono text-sm" title={session.id}>{session.id}</strong>
             <span class="truncate text-xs text-admin-ink/58">
-              <span data-testid="session-inspector-row-template">{session.template}</span> | <span data-testid="session-inspector-row-browser-context">{session.browserContext}</span> | <span data-testid="session-inspector-row-network-identity">{session.networkIdentity}</span> | <span data-testid="session-inspector-row-egress">{session.egress}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
+              <span data-testid="session-inspector-row-project">{session.project}</span> | <span data-testid="session-inspector-row-admission">{session.admission}</span> | <span data-testid="session-inspector-row-template">{session.template}</span> | <span data-testid="session-inspector-row-browser-context">{session.browserContext}</span> | <span data-testid="session-inspector-row-network-identity">{session.networkIdentity}</span> | <span data-testid="session-inspector-row-egress">{session.egress}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
             </span>
           </span>
           <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -17,6 +17,7 @@
     EgressDiagnosticsResource,
     EgressProfileResource,
     ImportBrowserContextCommand,
+    ProjectResource,
     SessionResource,
     SessionTemplateResource,
   } from '../api/control-types';
@@ -59,18 +60,21 @@
   let liveConnection = $state<LiveBrowserSessionConnection | null>(null);
   let sessions = $state<readonly SessionResource[]>([]);
   let sessionTemplates = $state<readonly SessionTemplateResource[]>([]);
+  let projects = $state<readonly ProjectResource[]>([]);
   let browserContexts = $state<readonly BrowserContextResource[]>([]);
   let egressProfiles = $state<readonly EgressProfileResource[]>([]);
   let selectedSession = $state<SessionResource | null>(null);
   let sessionsLoading = $state(false);
   let sessionsError = $state<string | null>(null);
   let templatesLoading = $state(false);
+  let projectsLoading = $state(false);
   let browserContextsLoading = $state(false);
   let egressProfilesLoading = $state(false);
   let cloningBrowserContextId = $state<string | null>(null);
   let exportingBrowserContextId = $state<string | null>(null);
   let importingBrowserContext = $state(false);
   let templateError = $state<string | null>(null);
+  let projectError = $state<string | null>(null);
   let browserContextError = $state<string | null>(null);
   let egressProfileError = $state<string | null>(null);
   let globalMessage = $state<AdminMessageFeedback | null>(null);
@@ -140,11 +144,31 @@
       },
     });
     void loadSessions();
+    void loadProjects();
     void loadSessionTemplates();
     void loadBrowserContexts();
     void loadEgressProfiles();
     return () => { subscription.close(); disconnectBrowser(false); };
   });
+  async function loadProjects(showFeedback = false): Promise<void> {
+    projectsLoading = true;
+    projectError = null;
+    try {
+      projects = (await controlClient.listProjects()).projects;
+      if (showFeedback) {
+        showGlobalMessage(
+          'success',
+          'Projects refreshed',
+          `${projects.length} project${projects.length === 1 ? '' : 's'} refreshed.`,
+        );
+      }
+    } catch (error) {
+      projectError = errorMessage(error);
+      showGlobalMessage('warning', 'Project catalog unavailable', projectError);
+    } finally {
+      projectsLoading = false;
+    }
+  }
   async function loadSessionTemplates(showFeedback = false): Promise<void> {
     templatesLoading = true;
     templateError = null;
@@ -297,6 +321,7 @@
       upsertSession(created);
       setSessionList((await controlClient.listSessions()).sessions, 'local');
       showGlobalMessage('success', 'Session created', `Created session ${shortAdminId(created.id)}.`);
+      void loadProjects(false);
       void loadBrowserContexts(false);
       requestBrowserConnect();
     } catch (error) {
@@ -605,6 +630,7 @@
     {#snippet admin()}
     <AdminWorkspaceTabs
       {controlClient} {workflowClient} {selectedSession} {sessionTemplates} {templatesLoading} {templateError} {mcpBridge} {liveConnection}
+      {projects} {projectsLoading} {projectError}
       {sessions} {browserContexts} {browserContextsLoading} {browserContextError}
       {egressProfiles} {egressProfilesLoading} {egressProfileError}
       cloningContextId={cloningBrowserContextId}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -22,6 +22,7 @@
     EgressDiagnosticsResource,
     EgressProfileResource,
     ImportBrowserContextCommand,
+    ProjectResource,
     SessionResource,
     SessionTemplateResource,
   } from '../api/control-types';
@@ -57,16 +58,19 @@
     readonly workflowClient: WorkflowClient;
     readonly selectedSession: SessionResource | null;
     readonly sessions?: readonly SessionResource[];
+    readonly projects?: readonly ProjectResource[];
     readonly sessionTemplates?: readonly SessionTemplateResource[];
     readonly browserContexts?: readonly BrowserContextResource[];
     readonly egressProfiles?: readonly EgressProfileResource[];
     readonly templatesLoading?: boolean;
+    readonly projectsLoading?: boolean;
     readonly browserContextsLoading?: boolean;
     readonly egressProfilesLoading?: boolean;
     readonly cloningContextId?: string | null;
     readonly exportingContextId?: string | null;
     readonly importingBrowserContext?: boolean;
     readonly templateError?: string | null;
+    readonly projectError?: string | null;
     readonly browserContextError?: string | null;
     readonly egressProfileError?: string | null;
     readonly mcpBridge: McpBridgeConfig | null;
@@ -188,13 +192,16 @@
         {#if activePanel.id === 'sessions'}
         <SessionListPanel
           viewModel={props.sessionListViewModel}
+          projects={props.projects ?? []}
           sessionTemplates={props.sessionTemplates ?? []}
           browserContexts={props.browserContexts ?? []}
           egressProfiles={props.egressProfiles ?? []}
           templatesLoading={props.templatesLoading ?? false}
+          projectsLoading={props.projectsLoading ?? false}
           browserContextsLoading={props.browserContextsLoading ?? false}
           egressProfilesLoading={props.egressProfilesLoading ?? false}
           templateError={props.templateError ?? null}
+          projectError={props.projectError ?? null}
           browserContextError={props.browserContextError ?? null}
           egressProfileError={props.egressProfileError ?? null}
           connected={props.browserConnected}

--- a/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionCreateConfigurator.svelte
@@ -5,6 +5,7 @@
     CreateBrowserContextCommand,
     CreateSessionCommand,
     EgressProfileResource,
+    ProjectResource,
     SessionTemplateResource,
   } from '../api/control-types';
   import {
@@ -18,6 +19,8 @@
     isLocalProxyEgressPreset,
     isLocalTlsInterceptorEgressPreset,
     networkIdentitySummary,
+    projectOptionLabel,
+    projectUsageSummary,
     sessionBrowserContextSummary,
     sessionTemplateDefaultsSummary,
     validateBrowserContextCreateForm,
@@ -29,12 +32,15 @@
     readonly onCreateSession: (command: CreateSessionCommand) => void;
     readonly onCreateBrowserContext?: (command: CreateBrowserContextCommand) => Promise<BrowserContextResource | void>;
     readonly sessionTemplates?: readonly SessionTemplateResource[];
+    readonly projects?: readonly ProjectResource[];
     readonly browserContexts?: readonly BrowserContextResource[];
     readonly egressProfiles?: readonly EgressProfileResource[];
     readonly templatesLoading?: boolean;
+    readonly projectsLoading?: boolean;
     readonly browserContextsLoading?: boolean;
     readonly egressProfilesLoading?: boolean;
     readonly templateError?: string | null;
+    readonly projectError?: string | null;
     readonly browserContextError?: string | null;
     readonly egressProfileError?: string | null;
     readonly loading?: boolean;
@@ -52,12 +58,15 @@
     onCreateSession,
     onCreateBrowserContext,
     sessionTemplates = [],
+    projects = [],
     browserContexts = [],
     egressProfiles = [],
     templatesLoading = false,
+    projectsLoading = false,
     browserContextsLoading = false,
     egressProfilesLoading = false,
     templateError = null,
+    projectError = null,
     browserContextError = null,
     egressProfileError = null,
     loading = false,
@@ -72,6 +81,7 @@
   }: SessionCreateConfiguratorProps = $props();
 
   const defaults = defaultSessionCreateFormState();
+  let projectId = $state(defaults.projectId);
   let templateId = $state(defaults.templateId);
   let ownerMode = $state(defaults.ownerMode);
   let idleTimeoutSec = $state(defaults.idleTimeoutSec);
@@ -113,6 +123,7 @@
     || browserContextMaxProfileMb.trim(),
   ));
   const validation = $derived(validateSessionCreateForm({
+    projectId,
     templateId,
     ownerMode,
     idleTimeoutSec,
@@ -130,7 +141,9 @@
     browserContextId,
     browserContexts,
     egressProfiles,
+    projects,
   }));
+  const selectedProject = $derived(projects.find((project) => project.id === projectId) ?? null);
   const selectedTemplate = $derived(sessionTemplates.find((template) => template.id === templateId) ?? null);
   const selectedTemplateSummary = $derived(sessionTemplateDefaultsSummary(selectedTemplate));
   const selectedBrowserContextSummary = $derived(sessionBrowserContextSummary(
@@ -163,6 +176,17 @@
   $effect(() => {
     if (payloadInitiallyOpen) {
       payloadOpenInternal = true;
+    }
+  });
+
+  $effect(() => {
+    if (
+      projectId
+      && !projectsLoading
+      && projects.length > 0
+      && !projects.some((project) => project.id === projectId)
+    ) {
+      projectId = '';
     }
   });
 
@@ -293,6 +317,23 @@
   >
     <div class={fieldGridClass}>
       <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
+        Project
+        <select
+          class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
+          data-testid="session-create-project"
+          bind:value={projectId}
+          disabled={loading || disabled || projectsLoading}
+        >
+          <option value="">Owner scope</option>
+          {#each projects as project}
+            <option value={project.id} disabled={project.state === 'archived'}>
+              {projectOptionLabel(project)}
+            </option>
+          {/each}
+        </select>
+      </label>
+
+      <label class="grid min-w-0 gap-1 text-sm font-bold text-admin-ink/72">
         Template
         <select
           class="min-h-11 min-w-0 rounded-xl border border-[#90a6cc]/20 bg-admin-field px-3 text-admin-ink outline-none focus:border-admin-leaf/45"
@@ -350,6 +391,38 @@
         </select>
       </label>
     </div>
+
+    {#if projectsLoading || projectError || selectedProject}
+      <section
+        class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-field/68 p-3 text-sm text-admin-ink/72"
+        aria-label="Project scope"
+        data-testid="session-create-project-summary"
+      >
+        {#if projectsLoading}
+          <span class="text-xs font-bold text-[#c1d0e8]">Loading projects...</span>
+        {:else if projectError}
+          <AdminMessage
+            variant="warning"
+            title="Project catalog unavailable"
+            message={projectError}
+            compact={true}
+          />
+        {:else if selectedProject}
+          <div class="flex min-w-0 flex-wrap items-start justify-between gap-2">
+            <span class="min-w-0">
+              <strong class="block truncate text-admin-ink">{selectedProject.name}</strong>
+              <span class="block truncate text-xs text-admin-ink/58">{selectedProject.id}</span>
+            </span>
+            <span class="rounded-lg bg-admin-leaf/12 px-2 py-1 text-xs font-bold text-admin-leaf">
+              {selectedProject.state}
+            </span>
+          </div>
+          <p class="m-0 text-xs leading-normal text-admin-ink/62 [overflow-wrap:anywhere]">
+            {projectUsageSummary(selectedProject)}
+          </p>
+        {/if}
+      </section>
+    {/if}
 
     <section
       class="grid min-w-0 gap-3 rounded-xl border border-admin-ink/10 bg-admin-field/68 p-3 text-sm text-admin-ink/72"

--- a/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionListPanel.svelte
@@ -5,6 +5,7 @@
     CreateBrowserContextCommand,
     CreateSessionCommand,
     EgressProfileResource,
+    ProjectResource,
     SessionTemplateResource,
   } from '../api/control-types';
   import AdminMessage from './AdminMessage.svelte';
@@ -14,13 +15,16 @@
 
   type SessionListPanelProps = {
     readonly viewModel: SessionListPanelViewModel;
+    readonly projects?: readonly ProjectResource[];
     readonly sessionTemplates?: readonly SessionTemplateResource[];
     readonly browserContexts?: readonly BrowserContextResource[];
     readonly egressProfiles?: readonly EgressProfileResource[];
     readonly templatesLoading?: boolean;
+    readonly projectsLoading?: boolean;
     readonly browserContextsLoading?: boolean;
     readonly egressProfilesLoading?: boolean;
     readonly templateError?: string | null;
+    readonly projectError?: string | null;
     readonly browserContextError?: string | null;
     readonly egressProfileError?: string | null;
     readonly connected: boolean;
@@ -35,13 +39,16 @@
 
   let {
     viewModel,
+    projects = [],
     sessionTemplates = [],
     browserContexts = [],
     egressProfiles = [],
     templatesLoading = false,
+    projectsLoading = false,
     browserContextsLoading = false,
     egressProfilesLoading = false,
     templateError = null,
+    projectError = null,
     browserContextError = null,
     egressProfileError = null,
     connected,
@@ -77,6 +84,8 @@
     {#if viewModel.selectedSession}
       <div class="grid min-w-0 grid-cols-2 gap-2 text-xs text-admin-ink/70 sm:grid-cols-3">
         {@render Fact('State', viewModel.selectedSession.lifecycle, 'session-selected-state')}
+        {@render Fact('Project', viewModel.selectedSession.project, 'session-selected-project')}
+        {@render Fact('Admission', viewModel.selectedSession.admission, 'session-selected-admission')}
         {@render Fact('Template', viewModel.selectedSession.template, 'session-selected-template')}
         {@render Fact('Context', viewModel.selectedSession.browserContext, 'session-selected-browser-context')}
         {@render Fact('Network', viewModel.selectedSession.networkIdentity, 'session-selected-network-identity')}
@@ -133,12 +142,15 @@
 
   <SessionCreateConfigurator
     {sessionTemplates}
+    {projects}
     {browserContexts}
     {egressProfiles}
     {templatesLoading}
+    {projectsLoading}
     {browserContextsLoading}
     {egressProfilesLoading}
     {templateError}
+    {projectError}
     {browserContextError}
     {egressProfileError}
     loading={viewModel.loading}

--- a/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/SessionTable.svelte
@@ -37,7 +37,7 @@
           {/if}
         </span>
         <span class="min-w-0 truncate text-xs text-admin-ink/52">
-          <span data-testid="session-row-template">{session.template}</span> | <span data-testid="session-row-browser-context">{session.browserContext}</span> | <span data-testid="session-row-network-identity">{session.networkIdentity}</span> | <span data-testid="session-row-egress">{session.egress}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
+          <span data-testid="session-row-project">{session.project}</span> | <span data-testid="session-row-admission">{session.admission}</span> | <span data-testid="session-row-template">{session.template}</span> | <span data-testid="session-row-browser-context">{session.browserContext}</span> | <span data-testid="session-row-network-identity">{session.networkIdentity}</span> | <span data-testid="session-row-egress">{session.egress}</span> | {session.mcpDelegation} | {session.labels} | updated {session.updatedAt}
         </span>
       </span>
       <span class="grid justify-items-end gap-1 text-xs text-[#c1d0e8]">

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.test.ts
@@ -8,6 +8,8 @@ import {
   isLocalTlsInterceptorEgressPreset,
   networkIdentitySummary,
   parseSessionCreateLabels,
+  projectOptionLabel,
+  projectUsageSummary,
   sessionBrowserContextSummary,
   sessionTemplateDefaultsSummary,
   validateBrowserContextCreateForm,
@@ -94,6 +96,31 @@ const EGRESS_PROFILE = {
   },
   created_at: '2026-05-04T18:45:00Z',
   updated_at: '2026-05-04T18:45:00Z',
+} as const;
+
+const PROJECT = {
+  id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+  name: 'Support tenant',
+  description: 'Support tenant project',
+  labels: { tenant: 'support' },
+  quotas: {
+    max_active_sessions: 2,
+    max_active_workflow_runs: 4,
+    max_retained_storage_bytes: 1073741824,
+  },
+  state: 'active',
+  usage: {
+    project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    active_sessions: 1,
+    max_active_sessions: 2,
+    active_workflow_runs: 1,
+    max_active_workflow_runs: 4,
+    retained_storage_bytes: 268435456,
+    max_retained_storage_bytes: 1073741824,
+    observed_at: '2026-05-04T18:50:00Z',
+  },
+  created_at: '2026-05-04T18:50:00Z',
+  updated_at: '2026-05-04T18:50:00Z',
 } as const;
 
 describe('session create configurator', () => {
@@ -213,6 +240,57 @@ describe('session create configurator', () => {
     });
     expect(validation.preview).toContain('"template_id"');
     expect(validation.preview).not.toContain('"owner_mode"');
+  });
+
+  it('adds selected project admission scope to the create-session payload', () => {
+    const validation = validateSessionCreateForm({
+      projectId: PROJECT.id,
+      templateId: '',
+      ownerMode: 'collaborative',
+      idleTimeoutSec: '',
+      labels: '',
+      projects: [PROJECT],
+    });
+
+    expect(validation.errors).toEqual([]);
+    expect(validation.command).toEqual({
+      project_id: PROJECT.id,
+      owner_mode: 'collaborative',
+    });
+    expect(validation.preview).toContain('"project_id"');
+    expect(projectOptionLabel(PROJECT)).toBe('Support tenant (active, sessions=1/2, workflows=1/4)');
+    expect(projectUsageSummary(PROJECT)).toBe(
+      'state=active | sessions=1/2 | workflow_runs=1/4 | storage=268435456/1073741824 | labels=tenant=support',
+    );
+  });
+
+  it('rejects unavailable or archived project selections', () => {
+    const archivedProject = {
+      ...PROJECT,
+      state: 'archived',
+    } as const;
+
+    const missing = validateSessionCreateForm({
+      projectId: '019df811-91a5-7b00-9fe5-93403ea57f20',
+      templateId: '',
+      ownerMode: 'collaborative',
+      idleTimeoutSec: '',
+      labels: '',
+      projects: [PROJECT],
+    });
+    const archived = validateSessionCreateForm({
+      projectId: archivedProject.id,
+      templateId: '',
+      ownerMode: 'collaborative',
+      idleTimeoutSec: '',
+      labels: '',
+      projects: [archivedProject],
+    });
+
+    expect(missing.command).toBeNull();
+    expect(missing.errors).toContain('Selected project is not available.');
+    expect(archived.command).toBeNull();
+    expect(archived.errors).toContain('Selected project is archived.');
   });
 
   it('adds reusable browser context bindings to the create-session payload', () => {
@@ -357,6 +435,7 @@ describe('session create configurator', () => {
       labels: {},
       defaults: {
         owner_mode: 'collaborative',
+        project_id: PROJECT.id,
         viewport: { width: 1440, height: 900 },
         idle_timeout_sec: 1800,
         labels: { team: 'support' },
@@ -373,7 +452,7 @@ describe('session create configurator', () => {
       created_at: '2026-05-04T18:00:00Z',
       updated_at: '2026-05-04T18:00:00Z',
     })).toBe(
-      'owner=collaborative | idle=1800s | viewport=1440x900 | labels=team=support | integration=ticket | recording=manual | locale=de-DE | languages=de-DE | timezone=Europe/Berlin | egress=019df7be...4a73',
+      'owner=collaborative | project=019df811...7f19 | idle=1800s | viewport=1440x900 | labels=team=support | integration=ticket | recording=manual | locale=de-DE | languages=de-DE | timezone=Europe/Berlin | egress=019df7be...4a73',
     );
     expect(networkIdentitySummary({
       locale: 'de-DE',

--- a/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-create-configurator.ts
@@ -3,6 +3,7 @@ import type {
   CreateBrowserContextCommand,
   CreateSessionCommand,
   EgressProfileResource,
+  ProjectResource,
   SessionBrowserContextCommand,
   SessionBrowserContextMode,
   SessionNetworkIdentity,
@@ -52,6 +53,7 @@ const BROWSER_CONTEXT_MODE_VALUES = new Set<string>(
 );
 
 export type SessionCreateFormState = {
+  readonly projectId?: string;
   readonly templateId: string;
   readonly ownerMode: string;
   readonly idleTimeoutSec: string;
@@ -69,6 +71,7 @@ export type SessionCreateFormState = {
   readonly browserContextId?: string;
   readonly browserContexts?: readonly BrowserContextResource[];
   readonly egressProfiles?: readonly EgressProfileResource[];
+  readonly projects?: readonly ProjectResource[];
 };
 
 export type SessionCreateValidation = {
@@ -78,6 +81,7 @@ export type SessionCreateValidation = {
 };
 
 type MutableCreateSessionCommand = {
+  project_id?: string;
   template_id?: string;
   browser_context?: SessionBrowserContextCommand;
   network_identity?: SessionNetworkIdentity;
@@ -100,6 +104,7 @@ export type BrowserContextCreateValidation = {
 
 export function defaultSessionCreateFormState(): SessionCreateFormState {
   return {
+    projectId: '',
     templateId: '',
     ownerMode: DEFAULT_SESSION_CREATE_OWNER_MODE,
     idleTimeoutSec: '',
@@ -123,6 +128,17 @@ export function validateSessionCreateForm(
 ): SessionCreateValidation {
   const errors: string[] = [];
   const command: MutableCreateSessionCommand = {};
+  const projectId = (state.projectId ?? '').trim();
+  if (projectId) {
+    const project = state.projects?.find((entry) => entry.id === projectId) ?? null;
+    if (state.projects && state.projects.length > 0 && !project) {
+      errors.push('Selected project is not available.');
+    } else if (project?.state === 'archived') {
+      errors.push('Selected project is archived.');
+    } else {
+      command.project_id = projectId;
+    }
+  }
   const templateId = state.templateId.trim();
   if (templateId) {
     command.template_id = templateId;
@@ -395,6 +411,9 @@ export function sessionTemplateDefaultsSummary(
   if (defaults.owner_mode) {
     facts.push(`owner=${defaults.owner_mode}`);
   }
+  if (defaults.project_id) {
+    facts.push(`project=${shortId(defaults.project_id)}`);
+  }
   if (defaults.idle_timeout_sec) {
     facts.push(`idle=${defaults.idle_timeout_sec}s`);
   }
@@ -463,6 +482,34 @@ export function egressProfileOptionLabel(profile: EgressProfileResource): string
     profile.effective.bypass_rule_count > 0 ? `${profile.effective.bypass_rule_count} bypass` : null,
   ].filter(Boolean);
   return `${profile.name} (${signals.join(', ')})`;
+}
+
+export function projectOptionLabel(project: ProjectResource): string {
+  const signals = [
+    project.state,
+    `sessions=${usageFraction(project.usage.active_sessions, project.usage.max_active_sessions)}`,
+    project.usage.max_active_workflow_runs !== null && project.usage.max_active_workflow_runs !== undefined
+      ? `workflows=${usageFraction(project.usage.active_workflow_runs, project.usage.max_active_workflow_runs)}`
+      : null,
+  ].filter(Boolean);
+  return `${project.name} (${signals.join(', ')})`;
+}
+
+export function projectUsageSummary(project: ProjectResource | null | undefined): string {
+  if (!project) {
+    return 'No project selected; the session remains owner-scoped.';
+  }
+  const facts = [
+    `state=${project.state}`,
+    `sessions=${usageFraction(project.usage.active_sessions, project.usage.max_active_sessions)}`,
+    `workflow_runs=${usageFraction(project.usage.active_workflow_runs, project.usage.max_active_workflow_runs)}`,
+    `storage=${usageFraction(project.usage.retained_storage_bytes, project.usage.max_retained_storage_bytes)}`,
+  ];
+  const labels = Object.entries(project.labels).sort(([left], [right]) => left.localeCompare(right));
+  if (labels.length > 0) {
+    facts.push(`labels=${labels.map(([key, value]) => `${key}=${value}`).join(',')}`);
+  }
+  return facts.join(' | ');
 }
 
 export function egressProfileKind(profile: EgressProfileResource): 'tls_interceptor' | 'proxy' | 'other' {
@@ -575,6 +622,10 @@ function formatBytes(value: number): string {
     return `${kib}KiB`;
   }
   return `${value}B`;
+}
+
+function usageFraction(value: number, max: number | null | undefined): string {
+  return max === null || max === undefined ? `${value}/unlimited` : `${value}/${max}`;
 }
 
 function formatDuration(seconds: number): string {

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.test.ts
@@ -43,6 +43,21 @@ const EGRESS_DIAGNOSTICS: EgressDiagnosticsResource = {
 const SESSION: SessionResource = {
   id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f6',
   state: 'active',
+  project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+  project: {
+    id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    name: 'Support tenant',
+    state: 'active',
+  },
+  admission: {
+    state: 'allowed',
+    reason_code: 'project_quota_available',
+    message: 'Project admission allowed.',
+    project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    active_sessions: 1,
+    max_active_sessions: 2,
+    checked_at: '2026-05-04T19:00:00Z',
+  },
   template_id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   browser_context: {
     mode: 'reusable',
@@ -136,6 +151,21 @@ const TEMPLATE = {
 
 const STATUS: SessionStatus = {
   state: 'active',
+  project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+  project: {
+    id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    name: 'Support tenant',
+    state: 'active',
+  },
+  admission: {
+    state: 'allowed',
+    reason_code: 'project_quota_available',
+    message: 'Project admission allowed.',
+    project_id: '019df811-91a5-7b00-9fe5-93403ea57f19',
+    active_sessions: 1,
+    max_active_sessions: 2,
+    checked_at: '2026-05-04T19:00:00Z',
+  },
   runtime_state: 'running',
   runtime_resume_mode: 'exact_live',
   presence_state: 'connected',
@@ -217,6 +247,9 @@ describe('SessionViewModelBuilder', () => {
       runtime: 'running',
       presence: 'connected',
       clients: 1,
+      project: 'Support tenant (019df811...7f19)',
+      projectId: SESSION.project_id,
+      admission: 'allowed | project_quota_available 1/2',
       template: 'Support triage (019df5c8...21c0)',
       templateId: TEMPLATE.id,
       browserContext: 'Support profile (019df7be...4a72)',
@@ -263,6 +296,16 @@ describe('SessionViewModelBuilder', () => {
       label: 'mcp owner',
       value: 'yes',
       testId: 'session-mcp-owner',
+    });
+    expect(viewModel.facts).toContainEqual({
+      label: 'project',
+      value: 'Support tenant (019df811...7f19)',
+      testId: 'session-project',
+    });
+    expect(viewModel.facts).toContainEqual({
+      label: 'admission',
+      value: 'allowed | project_quota_available 1/2',
+      testId: 'session-admission',
     });
     expect(viewModel.facts).toContainEqual({
       label: 'template',

--- a/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/session-view-model.ts
@@ -19,6 +19,9 @@ export type SessionListItemViewModel = {
   readonly updatedAt: string;
   readonly template: string;
   readonly templateId: string | null;
+  readonly project: string;
+  readonly projectId: string | null;
+  readonly admission: string;
   readonly browserContext: string;
   readonly browserContextId: string | null;
   readonly networkIdentity: string;
@@ -132,6 +135,16 @@ export class SessionViewModelBuilder {
       facts: [
         { label: 'state', value: session.state, testId: 'session-state' },
         {
+          label: 'project',
+          value: projectLabel(session),
+          testId: 'session-project',
+        },
+        {
+          label: 'admission',
+          value: admissionLabel(status?.admission ?? session.admission),
+          testId: 'session-admission',
+        },
+        {
           label: 'template',
           value: templateLabel(session, templateLookup),
           testId: 'session-template',
@@ -210,6 +223,9 @@ function toListItem(
     updatedAt: session.updated_at,
     template: templateLabel(session, templates),
     templateId: session.template_id ?? null,
+    project: projectLabel(session),
+    projectId: session.project_id ?? null,
+    admission: admissionLabel(session.admission),
     browserContext: browserContextLabel(session, browserContexts),
     browserContextId: session.browser_context?.context_id ?? null,
     networkIdentity: networkIdentityLabel(session.network_identity),
@@ -243,6 +259,7 @@ function statusFacts(status: SessionStatus | null): SessionFactViewModel[] {
   }
   return [
     { label: 'status state', value: status.state },
+    { label: 'status admission', value: admissionLabel(status.admission), testId: 'session-status-admission' },
     { label: 'resolution', value: `${status.resolution[0]}x${status.resolution[1]}` },
     { label: 'mcp owner', value: yesNo(status.mcp_owner), testId: 'session-mcp-owner' },
     { label: 'exclusive owner', value: yesNo(status.exclusive_browser_owner) },
@@ -392,6 +409,28 @@ function templateLabel(
   }
   const template = templates.get(templateId);
   return template ? `${template.name} (${shortId(template.id)})` : `Template ${shortId(templateId)}`;
+}
+
+function projectLabel(session: SessionResource): string {
+  if (session.project) {
+    const stateSuffix = session.project.state === 'active' ? '' : `, ${session.project.state}`;
+    return `${session.project.name} (${shortId(session.project.id)}${stateSuffix})`;
+  }
+  if (session.project_id) {
+    return `Project ${shortId(session.project_id)}`;
+  }
+  return 'No project';
+}
+
+function admissionLabel(admission: SessionResource['admission'] | SessionStatus['admission']): string {
+  if (!admission) {
+    return 'No admission decision';
+  }
+  const usage = admission.active_sessions !== null
+    && admission.active_sessions !== undefined
+    ? ` ${admission.active_sessions}/${admission.max_active_sessions ?? 'unlimited'}`
+    : '';
+  return `${admission.state} | ${admission.reason_code}${usage}`;
 }
 
 function browserContextLabel(

--- a/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
+++ b/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
@@ -453,6 +453,8 @@ describe('bpane operator CLI', () => {
         'create',
         '--label',
         'suite=cli',
+        '--project-id',
+        '0198dff7-457e-7000-8000-000000000025',
         '--template-id',
         'desktop',
         '--browser-context-id',
@@ -502,6 +504,7 @@ describe('bpane operator CLI', () => {
     expect(calls[0].url).toBe('http://localhost:8080/api/v1/sessions');
     expect(calls[0].init.method).toBe('POST');
     expect(JSON.parse(calls[0].init.body)).toEqual({
+      project_id: '0198dff7-457e-7000-8000-000000000025',
       template_id: 'desktop',
       browser_context: {
         mode: 'reusable',
@@ -809,9 +812,11 @@ describe('bpane operator CLI', () => {
         'session-template',
         'create',
         'customer-debug-session',
-        '--description',
-        'Support debug session',
-        '--label',
+      '--description',
+      'Support debug session',
+      '--project-id',
+      'project-1',
+      '--label',
         'team=support',
         '--default-label',
         'purpose=debug',
@@ -852,6 +857,7 @@ describe('bpane operator CLI', () => {
       description: 'Support debug session',
       labels: { team: 'support' },
       defaults: {
+        project_id: 'project-1',
         owner_mode: 'collaborative',
         viewport: { width: 1440, height: 900 },
         idle_timeout_sec: 1800,
@@ -866,6 +872,185 @@ describe('bpane operator CLI', () => {
         recording: { mode: 'manual', format: 'webm', retention_sec: 86400 },
       },
     });
+  });
+
+  it('manages projects through the CLI', async () => {
+    const createProjectIo = createIo();
+    const { calls, fetchImpl } = createFetch(
+      jsonResponse({ id: 'project-1', name: 'support-tenant' }, 201),
+      jsonResponse({ projects: [{ id: 'project-1' }] }),
+      jsonResponse({ id: 'project-1', name: 'support-tenant' }),
+      jsonResponse({
+        id: 'project-1',
+        name: 'support-tenant',
+        description: 'Existing project',
+        labels: { tenant: 'support' },
+        quotas: {
+          max_active_sessions: 2,
+          max_active_workflow_runs: 4,
+          max_retained_storage_bytes: 1073741824,
+        },
+        state: 'active',
+      }),
+      jsonResponse({ id: 'project-1', name: 'support-tenant-v2', state: 'active' }),
+      jsonResponse({
+        project_id: 'project-1',
+        active_sessions: 1,
+        max_active_sessions: 3,
+        active_workflow_runs: 0,
+        max_active_workflow_runs: 4,
+        retained_storage_bytes: 0,
+        max_retained_storage_bytes: 1073741824,
+      }),
+      jsonResponse({
+        id: 'project-1',
+        name: 'support-tenant-v2',
+        labels: { tenant: 'support', managed: 'true' },
+        quotas: { max_active_sessions: 3 },
+        state: 'active',
+      }),
+      jsonResponse({ id: 'project-1', name: 'support-tenant-v2', state: 'archived' }),
+    );
+
+    const createCode = await runBpaneCli(
+      [
+        'project',
+        'create',
+        'support-tenant',
+        '--description',
+        'Support tenant',
+        '--label',
+        'tenant=support',
+        '--max-active-sessions',
+        '2',
+        '--max-active-workflow-runs',
+        '4',
+        '--max-retained-storage-bytes',
+        '1073741824',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      createProjectIo.io,
+      fetchImpl,
+    );
+    expect(createCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(createProjectIo)).toEqual({ id: 'project-1', name: 'support-tenant' });
+    expect(calls[0].url).toBe('http://localhost:8080/api/v1/projects');
+    expect(calls[0].init.method).toBe('POST');
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      name: 'support-tenant',
+      description: 'Support tenant',
+      labels: { tenant: 'support' },
+      quotas: {
+        max_active_sessions: 2,
+        max_active_workflow_runs: 4,
+        max_retained_storage_bytes: 1073741824,
+      },
+    });
+
+    const listIo = createIo();
+    const listCode = await runBpaneCli(
+      ['project', 'list'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      listIo.io,
+      fetchImpl,
+    );
+    expect(listCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(listIo)).toEqual({ projects: [{ id: 'project-1' }] });
+
+    const getIo = createIo();
+    const getCode = await runBpaneCli(
+      ['project', 'get', 'project/with space'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      getIo.io,
+      fetchImpl,
+    );
+    expect(getCode).toBe(EXIT_CODES.ok);
+    expect(calls[2].url).toBe('http://localhost:8080/api/v1/projects/project%2Fwith%20space');
+
+    const updateIo = createIo();
+    const updateCode = await runBpaneCli(
+      [
+        'project',
+        'update',
+        'project-1',
+        '--name',
+        'support-tenant-v2',
+        '--label',
+        'managed=true',
+        '--max-active-sessions',
+        '3',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      updateIo.io,
+      fetchImpl,
+    );
+    expect(updateCode).toBe(EXIT_CODES.ok);
+    expect(calls[3].url).toBe('http://localhost:8080/api/v1/projects/project-1');
+    expect(calls[4].url).toBe('http://localhost:8080/api/v1/projects/project-1');
+    expect(calls[4].init.method).toBe('PUT');
+    expect(JSON.parse(calls[4].init.body)).toEqual({
+      name: 'support-tenant-v2',
+      description: 'Existing project',
+      labels: { tenant: 'support', managed: 'true' },
+      quotas: {
+        max_active_sessions: 3,
+        max_active_workflow_runs: 4,
+        max_retained_storage_bytes: 1073741824,
+      },
+      state: 'active',
+    });
+
+    const usageIo = createIo();
+    const usageCode = await runBpaneCli(
+      ['project', 'usage', 'project-1'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      usageIo.io,
+      fetchImpl,
+    );
+    expect(usageCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(usageIo).active_sessions).toBe(1);
+    expect(calls[5].url).toBe('http://localhost:8080/api/v1/projects/project-1/usage');
+
+    const archiveIo = createIo();
+    const archiveCode = await runBpaneCli(
+      ['project', 'archive', 'project-1'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      archiveIo.io,
+      fetchImpl,
+    );
+    expect(archiveCode).toBe(EXIT_CODES.ok);
+    expect(calls[7].init.method).toBe('PUT');
+    expect(JSON.parse(calls[7].init.body)).toEqual({
+      name: 'support-tenant-v2',
+      labels: { tenant: 'support', managed: 'true' },
+      quotas: { max_active_sessions: 3 },
+      state: 'archived',
+    });
+  });
+
+  it('validates project CLI input before fetching', async () => {
+    const missingNameIo = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({ ok: true }));
+
+    const missingNameCode = await runBpaneCli(
+      ['project', 'create'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      missingNameIo.io,
+      fetchImpl,
+    );
+    expect(missingNameCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(missingNameIo).error).toContain('Project create requires');
+
+    const invalidQuotaIo = createIo();
+    const invalidQuotaCode = await runBpaneCli(
+      ['project', 'create', 'support-tenant', '--max-active-sessions', '0'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      invalidQuotaIo.io,
+      fetchImpl,
+    );
+    expect(invalidQuotaCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(invalidQuotaIo).error).toContain('--max-active-sessions');
+    expect(calls).toHaveLength(0);
   });
 
   it('validates session-template CLI input before fetching', async () => {

--- a/code/web/bpane-client/scripts/bpane-cli.mjs
+++ b/code/web/bpane-client/scripts/bpane-cli.mjs
@@ -52,12 +52,16 @@ const KNOWN_OPTIONS = new Set([
   'mcp-display-name',
   'mcp-issuer',
   'max-profile-storage-bytes',
+  'max-active-sessions',
+  'max-active-workflow-runs',
+  'max-retained-storage-bytes',
   'name',
   'older-than-sec',
   'offset',
   'output',
   'owner-mode',
   'profile',
+  'project-id',
   'probe-public-ip-url',
   'probe-timeout-ms',
   'probe-tls-url',
@@ -113,13 +117,19 @@ function usageText() {
     '  bpane session-template list [options]',
     '  bpane session-template get <template-id> [options]',
     '  bpane session-template update <template-id> [options]',
-  '  bpane egress-profile create [profile-name] [options]',
-  '  bpane egress-profile list [options]',
-  '  bpane egress-profile get <profile-id> [options]',
-  '  bpane egress-profile diagnostics <profile-id> [options]',
-  '  bpane egress-profile diagnostics probe <profile-id> [options]',
-  '  bpane egress-profile update <profile-id> [options]',
-  '  bpane egress-profile disable <profile-id> [options]',
+    '  bpane project create [project-name] [options]',
+    '  bpane project list [options]',
+    '  bpane project get <project-id> [options]',
+    '  bpane project update <project-id> [options]',
+    '  bpane project usage <project-id> [options]',
+    '  bpane project archive <project-id> [options]',
+    '  bpane egress-profile create [profile-name] [options]',
+    '  bpane egress-profile list [options]',
+    '  bpane egress-profile get <profile-id> [options]',
+    '  bpane egress-profile diagnostics <profile-id> [options]',
+    '  bpane egress-profile diagnostics probe <profile-id> [options]',
+    '  bpane egress-profile update <profile-id> [options]',
+    '  bpane egress-profile disable <profile-id> [options]',
     '  bpane browser-context create [context-name] [options]',
     '  bpane browser-context clone <source-context-id> <target-context-name> [options]',
     '  bpane browser-context export <context-id> --output <path> [options]',
@@ -156,6 +166,7 @@ function usageText() {
     '  --state <state>           Repeatable cleanup state filter. Default: stopped.',
     '  --runtime-state <state>   Repeatable session runtime-state filter.',
     '  --template-id <id>        Session template id for create/list filters.',
+    '  --project-id <id>         Project id for session create/template defaults.',
     '  --browser-context-id <id> Browser context id for reusable session creation.',
     '  --browser-context-mode <mode> Browser context mode: fresh, ephemeral, reusable.',
     '  --locale <tag>            Session locale, for example de-DE.',
@@ -178,8 +189,11 @@ function usageText() {
     '  --probe-public-ip-url <url>  Public-IP endpoint for session egress probe.',
     '  --probe-tls-url <url>        HTTPS endpoint for TLS issuer probe.',
     '  --probe-timeout-ms <ms>      Session egress probe timeout. Requires an already-ready runtime.',
-    '  --name <name>             Session template name for create/update.',
-    '  --description <text>      Session template description for create/update.',
+    '  --name <name>             Resource name for create/update commands.',
+    '  --description <text>      Resource description for create/update commands.',
+    '  --max-active-sessions <count> Project active-session quota.',
+    '  --max-active-workflow-runs <count> Project active workflow-run quota.',
+    '  --max-retained-storage-bytes <bytes> Project retained-storage quota.',
     '  --persistence-mode <mode> Browser context persistence mode. Default: reusable.',
     '  --retention-sec <sec>     Browser context retention window in seconds.',
   '  --max-profile-storage-bytes <bytes> Browser context profile storage limit in bytes.',
@@ -507,6 +521,14 @@ function requiredTemplateId(positionals, commandLabel) {
   return templateId;
 }
 
+function requiredProjectId(positionals, commandLabel) {
+  const projectId = positionals[2];
+  if (!projectId || positionals.length > 3) {
+    throw new CliError('USAGE', `Usage: bpane ${commandLabel} <project-id>`, EXIT_CODES.usage);
+  }
+  return projectId;
+}
+
 function requiredBrowserContextId(positionals, commandLabel) {
   const contextId = positionals[2];
   if (!contextId || positionals.length > 3) {
@@ -803,6 +825,10 @@ function buildCreateSessionRequest(options) {
   }
 
   const body = {};
+  const projectId = getOption(options, 'project-id');
+  if (projectId) {
+    body.project_id = projectId;
+  }
   const templateId = getOption(options, 'template-id');
   if (templateId) {
     body.template_id = templateId;
@@ -876,6 +902,10 @@ function buildCreateSessionRequest(options) {
 
 function buildSessionTemplateDefaults(options) {
   const defaults = {};
+  const projectId = getOption(options, 'project-id');
+  if (projectId) {
+    defaults.project_id = projectId;
+  }
   const ownerMode = getOption(options, 'owner-mode');
   if (ownerMode) {
     defaults.owner_mode = ownerMode;
@@ -945,7 +975,7 @@ function mergeSessionTemplateDefaults(existingDefaults, overrideDefaults) {
   const overrides = isObjectRecord(overrideDefaults) ? overrideDefaults : {};
   const merged = { ...existing };
 
-  for (const key of ['owner_mode', 'viewport', 'idle_timeout_sec', 'recording']) {
+  for (const key of ['project_id', 'owner_mode', 'viewport', 'idle_timeout_sec', 'recording']) {
     if (Object.prototype.hasOwnProperty.call(overrides, key)) {
       merged[key] = overrides[key];
     }
@@ -1037,6 +1067,96 @@ function buildSessionTemplateUpdateRequest(existingTemplate, options) {
     body.description = description;
   } else if (existingTemplate?.description != null) {
     body.description = existingTemplate.description;
+  }
+  return body;
+}
+
+function buildProjectQuotas(options, existingQuotas = null) {
+  const quotas = isObjectRecord(existingQuotas) ? { ...existingQuotas } : {};
+  const maxActiveSessions = parseIntegerOption(options, 'max-active-sessions');
+  if (maxActiveSessions !== null) {
+    quotas.max_active_sessions = maxActiveSessions;
+  }
+  const maxActiveWorkflowRuns = parseIntegerOption(options, 'max-active-workflow-runs');
+  if (maxActiveWorkflowRuns !== null) {
+    quotas.max_active_workflow_runs = maxActiveWorkflowRuns;
+  }
+  const maxRetainedStorageBytes = parseIntegerOption(options, 'max-retained-storage-bytes');
+  if (maxRetainedStorageBytes !== null) {
+    quotas.max_retained_storage_bytes = maxRetainedStorageBytes;
+  }
+  return quotas;
+}
+
+function buildProjectRequest(options, fallbackName = null) {
+  const rawBody = parseJsonOption(options, 'body-json');
+  if (rawBody !== null) {
+    return rawBody;
+  }
+
+  const name = getOption(options, 'name') ?? fallbackName;
+  if (!name) {
+    throw new CliError(
+      'USAGE',
+      'Project create requires --name or a positional project name.',
+      EXIT_CODES.usage,
+    );
+  }
+  const body = { name };
+  const description = getOption(options, 'description');
+  if (description !== null) {
+    body.description = description;
+  }
+  const labels = parseKeyValueOptions(options, 'label');
+  if (Object.keys(labels).length) {
+    body.labels = labels;
+  }
+  const quotas = buildProjectQuotas(options);
+  if (Object.keys(quotas).length) {
+    body.quotas = quotas;
+  }
+  const state = getOption(options, 'state');
+  if (state) {
+    body.state = state;
+  }
+  return body;
+}
+
+function buildProjectUpdateRequest(existingProject, options, forcedState = null) {
+  const rawBody = parseJsonOption(options, 'body-json');
+  if (rawBody !== null) {
+    return rawBody;
+  }
+
+  const name = getOption(options, 'name') ?? existingProject?.name;
+  if (!name) {
+    throw new CliError(
+      'USAGE',
+      'Project update requires --name when the existing project response has no name.',
+      EXIT_CODES.usage,
+    );
+  }
+  const body = { name };
+  const description = getOption(options, 'description');
+  if (description !== null) {
+    body.description = description;
+  } else if (existingProject?.description != null) {
+    body.description = existingProject.description;
+  }
+  const labels = {
+    ...(isObjectRecord(existingProject?.labels) ? existingProject.labels : {}),
+    ...parseKeyValueOptions(options, 'label'),
+  };
+  if (Object.keys(labels).length) {
+    body.labels = labels;
+  }
+  const quotas = buildProjectQuotas(options, existingProject?.quotas ?? null);
+  if (Object.keys(quotas).length) {
+    body.quotas = quotas;
+  }
+  const state = forcedState ?? getOption(options, 'state') ?? existingProject?.state;
+  if (state) {
+    body.state = state;
   }
   return body;
 }
@@ -1975,6 +2095,47 @@ async function handleSessionTemplateCommand(config, positionals, options) {
   );
 }
 
+async function handleProjectCommand(config, positionals, options) {
+  const action = positionals[1];
+  if (action === 'create' && positionals.length <= 3) {
+    return await requestGateway(config, '/api/v1/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildProjectRequest(options, positionals[2] ?? null)),
+    });
+  }
+  if (action === 'list' && positionals.length === 2) {
+    return await requestGateway(config, '/api/v1/projects');
+  }
+  if (action === 'get') {
+    const projectId = requiredProjectId(positionals, 'project get');
+    return await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}`);
+  }
+  if (action === 'usage') {
+    const projectId = requiredProjectId(positionals, 'project usage');
+    return await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}/usage`);
+  }
+  if (action === 'update') {
+    const projectId = requiredProjectId(positionals, 'project update');
+    const existingProject = await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}`);
+    return await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildProjectUpdateRequest(existingProject, options)),
+    });
+  }
+  if (action === 'archive') {
+    const projectId = requiredProjectId(positionals, 'project archive');
+    const existingProject = await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}`);
+    return await requestGateway(config, `/api/v1/projects/${encodeURIComponent(projectId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildProjectUpdateRequest(existingProject, options, 'archived')),
+    });
+  }
+  throw new CliError('USAGE', `Unknown project command: ${action ?? ''}`.trim(), EXIT_CODES.usage);
+}
+
 async function handleEgressProfileCommand(config, positionals, options) {
   const action = positionals[1];
   if (action === 'create' && positionals.length <= 3) {
@@ -2353,6 +2514,9 @@ export async function runBpaneCli(argv, env = process.env, io = process, fetchIm
     } else if (scope === 'session-template') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleSessionTemplateCommand(config, positionals, options);
+    } else if (scope === 'project') {
+      const config = await buildConfig(options, env, fetchImpl);
+      result = await handleProjectCommand(config, positionals, options);
     } else if (scope === 'egress-profile') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleEgressProfileCommand(config, positionals, options);

--- a/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-configurator-smoke.mjs
@@ -28,6 +28,7 @@ async function run() {
   const context = await browser.newContext({ viewport: { width: 1440, height: 980 } });
   const page = await context.newPage();
   let sessionId = '';
+  let project = null;
   let template = null;
   let browserContext = null;
   let egressProfile = null;
@@ -36,10 +37,11 @@ async function run() {
     log(`Opening ${options.pageUrl}`);
     await ensureAdminLoggedIn(page, options);
     await cleanupAdminBeforeRun(page, options, log);
+    project = await createProject(page, options);
     egressProfile = await createEgressProfile(page, options);
     template = await createSessionTemplate(page, options, egressProfile);
 
-    browserContext = await verifyCompactPayloadToggle(page, options, template);
+    browserContext = await verifyCompactPayloadToggle(page, options, template, project);
 
     await page.goto(adminRouteUrl(options, 'sessions'), { waitUntil: 'domcontentloaded' });
     await page.getByTestId('session-create-configurator').waitFor({
@@ -48,31 +50,37 @@ async function run() {
     });
 
     await verifyClientValidation(page);
-    await configureTemplatedSession(page, options, template, browserContext, egressProfile);
-    await verifyPayloadPreview(page, template, browserContext, egressProfile);
+    await configureTemplatedSession(page, options, template, project, browserContext, egressProfile);
+    await verifyPayloadPreview(page, template, project, browserContext, egressProfile);
     await page.getByTestId('session-inspector-new').click();
     sessionId = await waitForSessionDetailUrl(page, options);
 
     const session = await fetchSession(page, options, sessionId);
-    verifyCreatedSession(session, sessionId, template, browserContext, egressProfile);
-    await verifyDetailUi(page, options, sessionId, template, browserContext, egressProfile);
-    await verifyInspectorTemplateFilter(page, options, sessionId, template, browserContext, egressProfile);
-    await emitSummary(page, options, session, template, log);
+    verifyCreatedSession(session, sessionId, template, project, browserContext, egressProfile);
+    await verifyDetailUi(page, options, sessionId, template, project, browserContext, egressProfile);
+    await verifyInspectorTemplateFilter(page, options, sessionId, template, project, browserContext, egressProfile);
+    await emitSummary(page, options, session, template, project, log);
   } finally {
     await cleanupCreatedSession(page, options, sessionId, log);
     await cleanupCreatedBrowserContext(page, options, browserContext?.id ?? '', log);
+    await cleanupCreatedProject(page, options, project, log);
     await context.close();
     await browser.close();
   }
 }
 
-async function verifyCompactPayloadToggle(page, options, template) {
+async function verifyCompactPayloadToggle(page, options, template, project) {
   await page.goto(options.pageUrl, { waitUntil: 'domcontentloaded' });
   await openAdminTab(page, 'sessions');
   const browserContext = await createBrowserContextThroughUi(page, options);
+  await selectProject(page, project, options);
   await selectSessionTemplate(page, template, options);
   await selectBrowserContext(page, browserContext, options);
   await assertNoHorizontalOverflow(page, 'session-create-configurator', 'live session create configurator');
+  const projectSummary = await page.getByTestId('session-create-project-summary').textContent();
+  if (!projectSummary?.includes(project.name) || !projectSummary.includes('sessions=0/1')) {
+    throw new Error(`Expected live configurator project summary for ${project.name}, got ${projectSummary}`);
+  }
   const templateSummary = await page.getByTestId('session-create-template-summary').textContent();
   if (!templateSummary?.includes(template.name) || !templateSummary.includes('team=support') || !templateSummary.includes('locale=de-DE')) {
     throw new Error(`Expected live configurator template summary for ${template.name}, got ${templateSummary}`);
@@ -85,8 +93,8 @@ async function verifyCompactPayloadToggle(page, options, template) {
   });
   const previewText = await page.getByTestId('session-create-preview').textContent();
   const preview = JSON.parse(previewText ?? '{}');
-  if (preview.template_id !== template.id) {
-    throw new Error(`Expected live configurator preview to include template_id ${template.id}, got ${previewText}`);
+  if (preview.project_id !== project.id || preview.template_id !== template.id) {
+    throw new Error(`Expected live configurator preview to include project/template ids ${project.id}/${template.id}, got ${previewText}`);
   }
   if (preview.browser_context?.mode !== 'reusable' || preview.browser_context?.context_id !== browserContext.id) {
     throw new Error(`Expected live configurator preview to include reusable browser context ${browserContext.id}, got ${previewText}`);
@@ -158,7 +166,8 @@ async function assertNoHorizontalOverflow(page, testId, label) {
   }
 }
 
-async function configureTemplatedSession(page, options, template, browserContext, egressProfile) {
+async function configureTemplatedSession(page, options, template, project, browserContext, egressProfile) {
+  await selectProject(page, project, options);
   await selectSessionTemplate(page, template, options);
   await selectBrowserContext(page, browserContext, options);
   await page.getByTestId('session-create-locale').fill('de-DE');
@@ -175,12 +184,13 @@ async function configureTemplatedSession(page, options, template, browserContext
   await page.getByTestId('session-create-labels').fill('case=1234\npurpose=import-repro');
 }
 
-async function verifyPayloadPreview(page, template, browserContext, egressProfile) {
+async function verifyPayloadPreview(page, template, project, browserContext, egressProfile) {
   const previewText = await page.getByTestId('session-create-preview').textContent();
   const preview = JSON.parse(previewText ?? '{}');
   const expectedLabels = { case: '1234', purpose: 'import-repro' };
   if (
-    preview.template_id !== template.id
+    preview.project_id !== project.id
+    || preview.template_id !== template.id
     || Object.hasOwn(preview, 'owner_mode')
     || Object.hasOwn(preview, 'idle_timeout_sec')
     || preview.browser_context?.mode !== 'reusable'
@@ -195,7 +205,7 @@ async function verifyPayloadPreview(page, template, browserContext, egressProfil
   }
 }
 
-async function verifyDetailUi(page, options, sessionId, template, browserContext, egressProfile) {
+async function verifyDetailUi(page, options, sessionId, template, project, browserContext, egressProfile) {
   await page.getByTestId('session-inspector-detail').waitFor({
     state: 'visible',
     timeout: options.connectTimeoutMs,
@@ -207,6 +217,14 @@ async function verifyDetailUi(page, options, sessionId, template, browserContext
   await page.getByTestId('session-owner-mode').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   const ownerMode = await page.getByTestId('session-owner-mode').textContent();
   const idleTimeout = await page.getByTestId('session-idle-timeout').textContent();
+  const detailProject = await poll(
+    'session detail project name',
+    async () => await page.getByTestId('session-project').textContent(),
+    (value) => value?.includes(project.name) === true,
+    options.connectTimeoutMs,
+    100,
+  );
+  const detailAdmission = await page.getByTestId('session-admission').textContent();
   const detailTemplate = await poll(
     'session detail template name',
     async () => await page.getByTestId('session-template').textContent(),
@@ -228,6 +246,8 @@ async function verifyDetailUi(page, options, sessionId, template, browserContext
   if (
     ownerMode !== 'collaborative'
     || idleTimeout !== '1200'
+    || !detailProject?.includes(project.name)
+    || !detailAdmission?.includes('project_quota_available')
     || !detailTemplate?.includes(template.name)
     || !detailBrowserContext?.includes(browserContext.name)
     || !network?.includes('de-DE')
@@ -237,12 +257,12 @@ async function verifyDetailUi(page, options, sessionId, template, browserContext
     || !labels.includes('team=support')
     || !integration?.includes('source=admin-smoke-template')
   ) {
-    throw new Error(`Unexpected configured session detail facts: ${ownerMode} / ${idleTimeout} / ${detailTemplate} / ${detailBrowserContext} / ${network} / ${egress} / ${labels} / ${integration}`);
+    throw new Error(`Unexpected configured session detail facts: ${ownerMode} / ${idleTimeout} / ${detailProject} / ${detailAdmission} / ${detailTemplate} / ${detailBrowserContext} / ${network} / ${egress} / ${labels} / ${integration}`);
   }
   await page.getByTestId('session-file-bindings').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
 }
 
-async function verifyInspectorTemplateFilter(page, options, sessionId, template, browserContext, egressProfile) {
+async function verifyInspectorTemplateFilter(page, options, sessionId, template, project, browserContext, egressProfile) {
   await page.goto(adminRouteUrl(options, 'sessions'), { waitUntil: 'domcontentloaded' });
   await page.getByTestId('session-inspector-list').waitFor({
     state: 'visible',
@@ -252,6 +272,8 @@ async function verifyInspectorTemplateFilter(page, options, sessionId, template,
   const row = page.locator(`[data-testid="session-inspector-row"][data-session-id="${sessionId}"]`);
   await row.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   const rowTemplate = await row.getByTestId('session-inspector-row-template').textContent();
+  const rowProject = await row.getByTestId('session-inspector-row-project').textContent();
+  const rowAdmission = await row.getByTestId('session-inspector-row-admission').textContent();
   const rowBrowserContext = await poll(
     'session inspector row browser context name',
     async () => await row.getByTestId('session-inspector-row-browser-context').textContent(),
@@ -262,6 +284,12 @@ async function verifyInspectorTemplateFilter(page, options, sessionId, template,
   const rowEgress = await row.getByTestId('session-inspector-row-egress').textContent();
   if (!rowTemplate?.includes(template.name)) {
     throw new Error(`Expected inspector row template ${template.name}, got ${rowTemplate}`);
+  }
+  if (!rowProject?.includes(project.name)) {
+    throw new Error(`Expected inspector row project ${project.name}, got ${rowProject}`);
+  }
+  if (!rowAdmission?.includes('project_quota_available')) {
+    throw new Error(`Expected inspector row project admission, got ${rowAdmission}`);
   }
   if (!rowBrowserContext?.includes(browserContext.name)) {
     throw new Error(`Expected inspector row browser context ${browserContext.name}, got ${rowBrowserContext}`);
@@ -279,6 +307,8 @@ async function verifyInspectorTemplateFilter(page, options, sessionId, template,
   const liveRow = page.locator(`[data-testid="session-row"][data-session-id="${sessionId}"]`);
   await liveRow.waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   await liveRow.click();
+  const selectedProject = await page.getByTestId('session-selected-project').textContent();
+  const selectedAdmission = await page.getByTestId('session-selected-admission').textContent();
   const selectedTemplate = await page.getByTestId('session-selected-template').textContent();
   const selectedBrowserContext = await poll(
     'live selected session browser context name',
@@ -291,6 +321,12 @@ async function verifyInspectorTemplateFilter(page, options, sessionId, template,
   if (!selectedTemplate?.includes(template.name)) {
     throw new Error(`Expected live selected session template ${template.name}, got ${selectedTemplate}`);
   }
+  if (!selectedProject?.includes(project.name)) {
+    throw new Error(`Expected live selected session project ${project.name}, got ${selectedProject}`);
+  }
+  if (!selectedAdmission?.includes('project_quota_available')) {
+    throw new Error(`Expected live selected session admission, got ${selectedAdmission}`);
+  }
   if (!selectedBrowserContext?.includes(browserContext.name)) {
     throw new Error(`Expected live selected session browser context ${browserContext.name}, got ${selectedBrowserContext}`);
   }
@@ -299,12 +335,24 @@ async function verifyInspectorTemplateFilter(page, options, sessionId, template,
   }
 }
 
-function verifyCreatedSession(session, sessionId, template, browserContext, egressProfile) {
+function verifyCreatedSession(session, sessionId, template, project, browserContext, egressProfile) {
   if (session.id !== sessionId) {
     throw new Error(`Expected API session ${sessionId}, got ${session.id}`);
   }
   if (session.template_id !== template.id) {
     throw new Error(`Expected template_id ${template.id}, got ${session.template_id}`);
+  }
+  if (
+    session.project_id !== project.id
+    || session.project?.id !== project.id
+    || session.admission?.state !== 'allowed'
+    || session.admission?.reason_code !== 'project_quota_available'
+  ) {
+    throw new Error(`Expected project admission for ${project.id}, got ${JSON.stringify({
+      project_id: session.project_id,
+      project: session.project,
+      admission: session.admission,
+    })}`);
   }
   if (session.owner_mode !== 'collaborative') {
     throw new Error(`Expected collaborative owner mode, got ${session.owner_mode}`);
@@ -329,6 +377,28 @@ function verifyCreatedSession(session, sessionId, template, browserContext, egre
   if (session.integration_context?.source !== 'admin-smoke-template') {
     throw new Error(`Expected template integration context, got ${JSON.stringify(session.integration_context)}`);
   }
+}
+
+async function createProject(page, options) {
+  const accessToken = await getAdminAccessToken(page);
+  const name = `Admin smoke project ${Date.now()}`;
+  return await fetchJson(`${apiOrigin(options)}/api/v1/projects`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      name,
+      description: 'Admin configurator smoke project',
+      labels: { suite: 'admin-session-configurator-smoke' },
+      quotas: {
+        max_active_sessions: 1,
+        max_active_workflow_runs: 2,
+        max_retained_storage_bytes: 1048576,
+      },
+    }),
+  });
 }
 
 async function createEgressProfile(page, options) {
@@ -381,6 +451,10 @@ async function createSessionTemplate(page, options, egressProfile) {
       },
     }),
   });
+}
+
+async function selectProject(page, project, options) {
+  await selectOptionWhenAvailable(page, page.getByTestId('session-create-project'), project.id, options);
 }
 
 async function selectSessionTemplate(page, template, options) {
@@ -481,6 +555,33 @@ async function cleanupCreatedBrowserContext(page, options, contextId, log) {
   });
 }
 
+async function cleanupCreatedProject(page, options, project, log) {
+  if (!project?.id) {
+    return;
+  }
+  const accessToken = await getAdminAccessToken(page).catch(() => '');
+  if (!accessToken) {
+    log(`Skipped cleanup for project ${project.id}; no admin access token is available.`);
+    return;
+  }
+  await fetchJson(`${apiOrigin(options)}/api/v1/projects/${project.id}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: project.name,
+      description: project.description,
+      labels: project.labels ?? {},
+      quotas: project.quotas ?? {},
+      state: 'archived',
+    }),
+  }).catch((error) => {
+    log(`Project cleanup for ${project.id} failed: ${error.message}`);
+  });
+}
+
 async function waitForSessionDetailUrl(page, options) {
   await page.waitForURL(/\/sessions\/[^/]+$/, { timeout: options.connectTimeoutMs });
   const sessionId = decodeURIComponent(new URL(page.url()).pathname.split('/').filter(Boolean).at(-1) ?? '');
@@ -490,10 +591,12 @@ async function waitForSessionDetailUrl(page, options) {
   return sessionId;
 }
 
-async function emitSummary(page, options, session, template, log) {
+async function emitSummary(page, options, session, template, project, log) {
   const summary = {
     pageUrl: options.pageUrl,
     sessionId: session.id,
+    projectId: project.id,
+    projectName: project.name,
     templateId: template.id,
     templateName: template.name,
     ownerMode: session.owner_mode,

--- a/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
@@ -34,6 +34,7 @@ async function run() {
   const page = await context.newPage();
   let accessToken = '';
   let sessionId = '';
+  let projectId = '';
   let contextId = '';
   let clonedContextId = '';
   let importedContextId = '';
@@ -89,6 +90,43 @@ async function run() {
     const profile = runBpaneCli(['profile', 'show'], cliEnv);
     if (profile.profile !== 'smoke' || profile.values?.base_url !== apiOrigin(options)) {
       throw new Error('CLI profile show did not return the smoke profile.');
+    }
+
+    const project = runBpaneCli([
+      'project',
+      'create',
+      `support-tenant-${runLabel}`,
+      '--description',
+      'Operator CLI smoke project',
+      '--label',
+      'suite=bpane-cli-smoke',
+      '--label',
+      `run_id=${runLabel}`,
+      '--max-active-sessions',
+      '3',
+      '--max-active-workflow-runs',
+      '4',
+      '--max-retained-storage-bytes',
+      '1073741824',
+    ], cliEnv);
+    projectId = project.id;
+    if (!projectId || project.quotas?.max_active_sessions !== 3 || project.state !== 'active') {
+      throw new Error(`CLI project create returned an invalid project: ${JSON.stringify(project)}`);
+    }
+
+    const listedProjects = runBpaneCli(['project', 'list'], cliEnv);
+    if (!Array.isArray(listedProjects.projects) || !listedProjects.projects.some((item) => item.id === projectId)) {
+      throw new Error(`CLI project list did not include ${projectId}.`);
+    }
+
+    const fetchedProject = runBpaneCli(['project', 'get', projectId], cliEnv);
+    if (fetchedProject.id !== projectId || fetchedProject.labels?.run_id !== runLabel) {
+      throw new Error(`CLI project get returned unexpected project data: ${JSON.stringify(fetchedProject)}`);
+    }
+
+    const projectUsage = runBpaneCli(['project', 'usage', projectId], cliEnv);
+    if (projectUsage.project_id !== projectId || projectUsage.active_sessions !== 0) {
+      throw new Error(`CLI project usage returned unexpected data: ${JSON.stringify(projectUsage)}`);
     }
 
     const egressProfile = runBpaneCli([
@@ -155,6 +193,8 @@ async function run() {
       `customer-debug-${runLabel}`,
       '--description',
       'Operator CLI smoke template',
+      '--project-id',
+      projectId,
       '--label',
       'suite=bpane-cli-smoke',
       '--default-label',
@@ -326,6 +366,8 @@ async function run() {
       'create',
       '--template-id',
       templateId,
+      '--project-id',
+      projectId,
       '--browser-context-id',
       contextId,
       '--label',
@@ -341,6 +383,9 @@ async function run() {
     }
     if (
       created.template_id !== templateId
+      || created.project_id !== projectId
+      || created.project?.id !== projectId
+      || created.admission?.state !== 'allowed'
       || created.browser_context?.mode !== 'reusable'
       || created.browser_context?.context_id !== contextId
       || created.network_identity?.locale !== 'de-DE'
@@ -528,6 +573,12 @@ async function run() {
     }
     contextId = '';
 
+    const archivedProject = runBpaneCli(['project', 'archive', projectId], cliEnv);
+    if (archivedProject.id !== projectId || archivedProject.state !== 'archived') {
+      throw new Error(`CLI project archive did not archive the project: ${JSON.stringify(archivedProject)}`);
+    }
+    projectId = '';
+
     log('Operator CLI smoke passed.');
   } finally {
     if (clonedContextId && accessToken) {
@@ -559,6 +610,9 @@ async function run() {
         headers: { Authorization: `Bearer ${accessToken}` },
       }).catch(() => {});
     }
+    if (projectId && accessToken) {
+      await archiveProject(options, accessToken, projectId).catch(() => {});
+    }
     await cleanupAdminSmoke(page, options, log);
     if (configDir) {
       await fs.rm(configDir, { recursive: true, force: true }).catch(() => {});
@@ -584,6 +638,30 @@ async function clearMcpBridge(options) {
     const detail = await response.text().catch(() => '');
     throw new Error(`Could not clear MCP bridge control session: HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
   }
+}
+
+async function archiveProject(options, accessToken, projectId) {
+  const projectResponse = await fetch(`${apiOrigin(options)}/api/v1/projects/${projectId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!projectResponse.ok) {
+    return;
+  }
+  const project = await projectResponse.json();
+  await fetch(`${apiOrigin(options)}/api/v1/projects/${projectId}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      name: project.name,
+      description: project.description,
+      labels: project.labels ?? {},
+      quotas: project.quotas ?? {},
+      state: 'archived',
+    }),
+  });
 }
 
 function runBpaneCli(args, env) {

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -5,7 +5,7 @@ info:
   description: >
     Frozen v1 owner-scoped BrowserPane control-plane contract. This document
     covers the canonical `/api/v1` surfaces for sessions, session templates,
-    browser contexts, egress profiles, automation tasks, recordings, workflows,
+    projects, browser contexts, egress profiles, automation tasks, recordings, workflows,
     reusable files, credentials, approved extensions, and admin realtime snapshots. Legacy global compatibility routes such as
     `/api/session/status` and `/api/session/mcp-owner` are intentionally excluded
     from this freeze and remain transitional.
@@ -18,6 +18,7 @@ tags:
   - name: Admin Events
   - name: Sessions
   - name: Session Templates
+  - name: Projects
   - name: Egress Profiles
   - name: Browser Contexts
   - name: Session Runtime
@@ -424,6 +425,114 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/projects:
+    get:
+      tags: [Projects]
+      summary: List owner-scoped projects
+      operationId: listProjects
+      responses:
+        '200':
+          description: Owner-scoped project list with current usage counters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    post:
+      tags: [Projects]
+      summary: Create an owner-scoped project
+      operationId: createProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertProjectRequest'
+      responses:
+        '201':
+          description: Project created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/projects/{project_id}:
+    parameters:
+      - $ref: '#/components/parameters/ProjectId'
+    get:
+      tags: [Projects]
+      summary: Fetch one owner-scoped project
+      operationId: getProject
+      responses:
+        '200':
+          description: Project with current usage counters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    put:
+      tags: [Projects]
+      summary: Replace one owner-scoped project
+      operationId: updateProject
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertProjectRequest'
+      responses:
+        '200':
+          description: Updated project
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/projects/{project_id}/usage:
+    parameters:
+      - $ref: '#/components/parameters/ProjectId'
+    get:
+      tags: [Projects]
+      summary: Fetch current sanitized usage counters for one project
+      operationId: getProjectUsage
+      responses:
+        '200':
+          description: Project usage counters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectUsageResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
   /api/v1/egress-profiles:
@@ -2647,6 +2756,13 @@ components:
         format: uuid
     SessionTemplateId:
       name: template_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+    ProjectId:
+      name: project_id
       in: path
       required: true
       schema:
@@ -5145,6 +5261,191 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BrowserContextResource'
+    ProjectState:
+      type: string
+      enum:
+        - active
+        - archived
+    ProjectQuotas:
+      type: object
+      additionalProperties: false
+      properties:
+        max_active_sessions:
+          type: integer
+          minimum: 1
+          nullable: true
+        max_active_workflow_runs:
+          type: integer
+          minimum: 1
+          nullable: true
+        max_retained_storage_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+          nullable: true
+    ProjectUsageResource:
+      type: object
+      required:
+        - project_id
+        - active_sessions
+        - max_active_sessions
+        - active_workflow_runs
+        - max_active_workflow_runs
+        - retained_storage_bytes
+        - max_retained_storage_bytes
+        - observed_at
+      properties:
+        project_id:
+          type: string
+          format: uuid
+        active_sessions:
+          type: integer
+          minimum: 0
+        max_active_sessions:
+          type: integer
+          minimum: 1
+          nullable: true
+        active_workflow_runs:
+          type: integer
+          minimum: 0
+        max_active_workflow_runs:
+          type: integer
+          minimum: 1
+          nullable: true
+        retained_storage_bytes:
+          type: integer
+          format: int64
+          minimum: 0
+        max_retained_storage_bytes:
+          type: integer
+          format: int64
+          minimum: 1
+          nullable: true
+        observed_at:
+          type: string
+          format: date-time
+    UpsertProjectRequest:
+      type: object
+      additionalProperties: false
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        quotas:
+          $ref: '#/components/schemas/ProjectQuotas'
+        state:
+          $ref: '#/components/schemas/ProjectState'
+    ProjectResource:
+      type: object
+      required:
+        - id
+        - name
+        - description
+        - labels
+        - quotas
+        - state
+        - usage
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        quotas:
+          $ref: '#/components/schemas/ProjectQuotas'
+        state:
+          $ref: '#/components/schemas/ProjectState'
+        usage:
+          $ref: '#/components/schemas/ProjectUsageResource'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    SessionProjectResource:
+      type: object
+      required:
+        - id
+        - name
+        - state
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        state:
+          $ref: '#/components/schemas/ProjectState'
+    ProjectListResponse:
+      type: object
+      required: [projects]
+      properties:
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectResource'
+    ProjectAdmissionState:
+      type: string
+      enum:
+        - allowed
+        - queued
+        - rejected
+    ProjectAdmissionReasonCode:
+      type: string
+      enum:
+        - owner_scope_unbounded
+        - project_quota_available
+        - active_session_quota_exceeded
+        - project_archived
+    ProjectAdmissionDecision:
+      type: object
+      required:
+        - state
+        - reason_code
+        - message
+        - project_id
+        - active_sessions
+        - max_active_sessions
+        - checked_at
+      properties:
+        state:
+          $ref: '#/components/schemas/ProjectAdmissionState'
+        reason_code:
+          $ref: '#/components/schemas/ProjectAdmissionReasonCode'
+        message:
+          type: string
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
+        active_sessions:
+          type: integer
+          minimum: 0
+          nullable: true
+        max_active_sessions:
+          type: integer
+          minimum: 1
+          nullable: true
+        checked_at:
+          type: string
+          format: date-time
     EgressProfileState:
       type: string
       enum:
@@ -5586,6 +5887,9 @@ components:
       required:
         - id
         - state
+        - project_id
+        - project
+        - admission
         - template_id
         - browser_context
         - network_identity
@@ -5614,6 +5918,16 @@ components:
           format: uuid
         state:
           $ref: '#/components/schemas/SessionLifecycleState'
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
+        project:
+          allOf:
+            - $ref: '#/components/schemas/SessionProjectResource'
+          nullable: true
+        admission:
+          $ref: '#/components/schemas/ProjectAdmissionDecision'
         template_id:
           type: string
           nullable: true
@@ -5679,6 +5993,10 @@ components:
       type: object
       additionalProperties: false
       properties:
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
         template_id:
           type: string
           nullable: true
@@ -5713,6 +6031,10 @@ components:
       type: object
       additionalProperties: false
       properties:
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
         owner_mode:
           $ref: '#/components/schemas/SessionOwnerMode'
         viewport:
@@ -6145,6 +6467,9 @@ components:
       type: object
       required:
         - state
+        - project_id
+        - project
+        - admission
         - runtime_state
         - runtime_resume_mode
         - presence_state
@@ -6169,6 +6494,16 @@ components:
       properties:
         state:
           $ref: '#/components/schemas/SessionLifecycleState'
+        project_id:
+          type: string
+          format: uuid
+          nullable: true
+        project:
+          allOf:
+            - $ref: '#/components/schemas/SessionProjectResource'
+          nullable: true
+        admission:
+          $ref: '#/components/schemas/ProjectAdmissionDecision'
         runtime_state:
           $ref: '#/components/schemas/SessionRuntimeState'
         runtime_resume_mode:


### PR DESCRIPTION
## Summary

This PR adds the first project/admission-control package for BrowserPane.

Operators can now create owner-scoped projects, assign sessions or session-template defaults to a project, and enforce a project active-session quota before runtime launch. The session resource stores a stable admission decision, so API clients, the admin app, and the CLI can explain whether a session was admitted under a project quota or left owner-scoped.

Example use case: a support team creates a `customer-acme-support` project with `max_active_sessions=1`. The first debug session is admitted and visible in the admin live view, inspector, detail page, and CLI. A second active session for the same project is rejected with `active_session_quota_exceeded` instead of failing later as an opaque runtime-capacity problem.

## Changes

- Add project CRUD and usage APIs under `/api/v1/projects`.
- Add Postgres migration and in-memory/Postgres store support for projects, project quotas, project usage, and session admission metadata.
- Add `project_id` to session create and session-template defaults.
- Enforce active-session quota and archived-project rejection before session creation/runtime launch.
- Surface project/admission metadata in session resources and status responses.
- Add admin project loading/selection plus project/admission display in live, inspector, and detail views.
- Add CLI project commands and project-scoped session/template creation support.
- Update OpenAPI and README for the first project/admission contract.
- Split the deferred production project-governance scope to #132.

## Validation

- `cargo test -p bpane-gateway`
- `cargo test -p bpane-gateway projects -- --nocapture`
- `cargo test -p bpane-gateway --test compose_api_surface compose_projects_api_surface -- --ignored --test-threads=1`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm test -- session-create-configurator session-view-model control-client`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && npm test -- js/__tests__/bpane-cli.test.ts`
- `cd code/web/bpane-client && npm run build`
- `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`
- `cd code/web/bpane-client && npm run smoke:admin-session-configurator -- --headless`

Closes #27.
Refs #132.