### PR TITLE
Add identity access review foundation

### DIFF
--- a/ARCH.md
+++ b/ARCH.md
@@ -5,8 +5,9 @@
 BrowserPane is a browser-native remote browser and workflow platform. It renders
 a Linux desktop inside a browser `<div>` using WebTransport, WebCodecs, and
 WebGL 2 while exposing owner-scoped control-plane APIs for sessions, egress
-profiles, recordings, workflows, files, credentials, and approved extensions. The
-container size drives the remote resolution pixel-for-pixel.
+profiles, recordings, workflows, files, credentials, approved extensions, and
+identity/access-review summaries. The container size drives the remote
+resolution pixel-for-pixel.
 
 The canonical frozen v1 session-control contract is [openapi/bpane-control-v1.yaml](openapi/bpane-control-v1.yaml).
 
@@ -258,9 +259,12 @@ service.
   - if a browser client is already active, that browser-defined input/ownership
     state remains authoritative while MCP automation attaches alongside it
 - **Auth** (`auth/`): OIDC/JWT validation for browser and API clients, plus legacy HMAC token compatibility for migration and tests
+- **Identity/access review** (`api/identity.rs`): bearer-principal summary plus sanitized owner-scoped resource counts, project usage, and delegated automation-principal summaries
 - **Heartbeat**: disconnects after 15s without CONTROL ping
 - **HTTP API** (`api.rs`, :8932):
   - canonical frozen v1 contract: `openapi/bpane-control-v1.yaml`
+  - `GET /api/v1/identity/me` — normalized current bearer principal, classified as user, service principal, or legacy dev token
+  - `GET /api/v1/identity/access-review` — sanitized owner-scoped access review with project usage, resource counts, and automation delegations
   - `POST /api/v1/sessions` — create a persistent session resource
   - `GET /api/v1/sessions` — list owner-scoped sessions, with catalog filters for template id, lifecycle/runtime state, labels, integration context, limit, and offset
   - `GET /api/v1/sessions/{id}` — fetch one owner-scoped session resource
@@ -475,7 +479,7 @@ The default dev stack no longer uses a shared token file.
 - the admin console discovers the OIDC provider and performs Authorization Code + PKCE
 - local browser users authenticate against Keycloak on `http://localhost:8091`
 - the local demo user is `demo / demo-demo`
-- after login, the admin console lists owner-scoped `/api/v1/sessions`, projects, session templates, egress profiles, and browser contexts; it lets the user join an existing session, start a new one with optional project, template, network-identity, egress-profile, and reusable-context bindings, inspect project/admission metadata on live rows and session detail views, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
+- after login, the admin console lists owner-scoped `/api/v1/sessions`, projects, session templates, egress profiles, browser contexts, and the current `/api/v1/identity/access-review`; it lets the user join an existing session, start a new one with optional project, template, network-identity, egress-profile, and reusable-context bindings, inspect project/admission metadata on live rows and session detail views, inspect the current principal, resource counts, project usage, and delegated automation principals in the Identity tab, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
 - docker-backed reusable browser contexts mount a context-scoped Chromium profile volume at the session profile path while keeping uploads, downloads, and session-file mounts in the session-scoped data volume; runtime admission allows only one active writer per reusable context
 - browser-context retention cleanup is metadata-driven per context and removes expired reusable profile data only when the runtime manager confirms there is no active writer
 - the console then mints a short-lived `session_connect_ticket` through `POST /api/v1/sessions/{id}/access-tokens`
@@ -544,7 +548,7 @@ The supported local operator CLI lives in
 `code/web/bpane-client/scripts/bpane-cli.mjs`, is exposed as the package binary
 `bpane`, and has a repo-level wrapper at `scripts/bpane`.
 
-- Commands cover profile inspection/init, project create/list/get/usage/update/archive,
+- Commands cover profile inspection/init, identity me/access-review, project create/list/get/usage/update/archive,
   egress-profile create/list/get, session create/list/get/status with project
   and network-identity options, access-ticket and automation-access minting,
   connection disconnect, stop, kill, and bounded cleanup. Egress-profile

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current support and scope:
 - Shared sessions: collaborative by default, intended for small curated groups rather than broadcast-scale delivery.
 - Owner/viewer mode: optional exclusive-owner mode is supported in the gateway; restricted viewers are read-only.
 - Camera: disabled by default in the compose stack and requires browser H.264 encode support plus a mapped `v4l2loopback` device.
-- Control plane: owner-scoped v1 APIs now cover projects, sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
+- Control plane: owner-scoped v1 APIs now cover identity/access-review summaries, projects, sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
 - Workflow execution: Git-backed workflow versions run through a gateway-managed `workflow-worker`; the current executor model is Playwright.
 - Workflow boundary: BrowserPane currently focuses on executing and supervising browser workflows. Broader scheduling, DAG orchestration, and cross-system coordination are expected to sit above BrowserPane rather than inside it.
 
@@ -122,7 +122,7 @@ bpane-gateway also talks to:
 | Project | Responsibility |
 | --- | --- |
 | `code/apps/bpane-host` | Linux host agent. Captures the desktop surface, classifies tiles, drives ROI H.264 video, emits audio, injects input, and handles clipboard, file transfer, resize, and camera ingress plumbing. |
-| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for projects, sessions, session templates, automation tasks, recordings, workflows, files, credentials, and extensions. |
+| `code/apps/bpane-gateway` | WebTransport entry point, shared-session coordinator, runtime lifecycle boundary, and owner-scoped control-plane API for identity/access review, projects, sessions, session templates, automation tasks, recordings, workflows, files, credentials, and extensions. |
 | `code/shared/bpane-protocol` | Shared binary wire contract. Defines channels, frame envelopes, typed protocol messages, and incremental frame decoding used by the Rust services and validated against the browser client. |
 | `code/web/bpane-client` | Real browser client. Renders tiles/video, decodes media, captures keyboard/mouse/clipboard input, and manages browser-side audio, camera, and file-transfer flows. |
 | `code/integrations/mcp-bridge` | Automation bridge for MCP/Playwright-style control flows. Exposes compatibility Streamable HTTP on `/mcp`, session-scoped Streamable HTTP on `/sessions/{id}/mcp`, compatibility SSE on `/sse`, session-scoped SSE on `/sessions/{id}/sse`, and integrates with gateway ownership APIs so automation can attach alongside interactive browser users through delegated session control. |
@@ -288,6 +288,8 @@ Canonical contract:
 - `GET /api/v1/sessions`
 - `GET /api/v1/sessions/{id}`
 - `DELETE /api/v1/sessions/{id}`
+- `GET /api/v1/identity/me`
+- `GET /api/v1/identity/access-review`
 - `POST /api/v1/browser-contexts`
 - `GET /api/v1/browser-contexts`
 - `GET /api/v1/browser-contexts/{id}`
@@ -334,6 +336,13 @@ the session and enforces active-session quota and archived-project checks before
 runtime launch. Session resources and `/status` include the project summary and
 admission reason so the admin live view, inspector, CLI, and API clients all
 show whether a session was admitted under a project quota or left owner-scoped.
+Identity resources expose a sanitized access-review foundation:
+`GET /api/v1/identity/me` returns the current bearer principal as `user`,
+`service_principal`, or `legacy_dev_token`, while
+`GET /api/v1/identity/access-review` returns project usage, owner-scoped
+resource counts, and currently delegated automation principals. The admin
+Operations Overlay has a matching Identity tab, and the operator CLI exposes
+the same payload through `identity me` and `identity access-review`.
 Network identity metadata lets callers declare locale, language preferences,
 timezone, geolocation, browser identity, user-agent override, and an
 `egress_profile_id` on either a session template or an explicit session create
@@ -553,6 +562,13 @@ Common session operations:
 ./scripts/bpane session kill <session-id>
 ```
 
+Common identity and access-review operations:
+
+```bash
+./scripts/bpane identity me
+./scripts/bpane identity access-review
+```
+
 Common session-template operations:
 
 ```bash
@@ -729,7 +745,7 @@ destructive cleanup.
 The operator CLI integration smoke is
 `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`. It logs in
 through the admin app, creates a session, initializes a CLI profile, exercises
-project/session-template/browser-context/egress catalog operations,
+identity/access-review, project/session-template/browser-context/egress catalog operations,
 session access/status/diagnostics/disconnect/stop/kill/cleanup, and validates
 standalone MCP health, authorize, set-default, doctor, preflight, repair,
 revoke, and clear-default flows.

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -96,6 +96,7 @@ mod errors;
 mod extensions;
 mod file_workspaces;
 mod http_helpers;
+mod identity;
 mod projects;
 mod recordings;
 mod resources;

--- a/code/apps/bpane-gateway/src/api/identity.rs
+++ b/code/apps/bpane-gateway/src/api/identity.rs
@@ -1,0 +1,281 @@
+use std::collections::HashMap;
+
+use axum::routing::get;
+use chrono::DateTime;
+use serde::Serialize;
+
+use super::*;
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum IdentityPrincipalType {
+    User,
+    ServicePrincipal,
+    LegacyDevToken,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IdentityPrincipalResource {
+    subject: String,
+    issuer: String,
+    display_name: Option<String>,
+    client_id: Option<String>,
+    principal_type: IdentityPrincipalType,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IdentityResourceCounts {
+    projects: usize,
+    sessions: usize,
+    active_sessions: usize,
+    session_templates: usize,
+    browser_contexts: usize,
+    egress_profiles: usize,
+    credential_bindings: usize,
+    file_workspaces: usize,
+    workflow_definitions: usize,
+    workflow_runs: usize,
+    active_workflow_runs: usize,
+    automation_tasks: usize,
+    active_automation_tasks: usize,
+    extension_definitions: usize,
+    delegated_principals: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IdentityDelegatedPrincipalResource {
+    client_id: String,
+    issuer: String,
+    display_name: Option<String>,
+    session_count: usize,
+    active_session_count: usize,
+    session_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IdentityAccessReviewResponse {
+    principal: IdentityPrincipalResource,
+    generated_at: DateTime<Utc>,
+    projects: Vec<ProjectResource>,
+    resource_counts: IdentityResourceCounts,
+    delegated_principals: Vec<IdentityDelegatedPrincipalResource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct DelegatedPrincipalKey {
+    client_id: String,
+    issuer: String,
+    display_name: Option<String>,
+}
+
+pub(super) fn identity_routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route("/api/v1/identity/me", get(get_current_identity))
+        .route(
+            "/api/v1/identity/access-review",
+            get(get_identity_access_review),
+        )
+}
+
+async fn get_current_identity(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<IdentityPrincipalResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    Ok(Json(identity_principal_resource(&principal)))
+}
+
+async fn get_identity_access_review(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<IdentityAccessReviewResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let projects = state
+        .session_store
+        .list_projects_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let sessions = state
+        .session_store
+        .list_sessions_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let session_templates = state
+        .session_store
+        .list_session_templates_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let browser_contexts = state
+        .session_store
+        .list_browser_contexts_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let egress_profiles = state
+        .session_store
+        .list_egress_profiles_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let credential_bindings = state
+        .session_store
+        .list_credential_bindings_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let file_workspaces = state
+        .session_store
+        .list_file_workspaces_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let workflow_definitions = state
+        .session_store
+        .list_workflow_definitions_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let workflow_runs = state
+        .session_store
+        .list_workflow_runs_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let automation_tasks = state
+        .session_store
+        .list_automation_tasks_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let extension_definitions = state
+        .session_store
+        .list_extension_definitions_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+
+    let now = Utc::now();
+    let projects = project_resources(&state, &principal, projects).await?;
+    let active_sessions = sessions
+        .iter()
+        .filter(|session| session.state.is_runtime_candidate())
+        .count();
+    let delegated_principals = delegated_principal_resources(&sessions);
+    let resource_counts = IdentityResourceCounts {
+        projects: projects.len(),
+        sessions: sessions.len(),
+        active_sessions,
+        session_templates: session_templates.len(),
+        browser_contexts: browser_contexts.len(),
+        egress_profiles: egress_profiles.len(),
+        credential_bindings: credential_bindings.len(),
+        file_workspaces: file_workspaces.len(),
+        workflow_definitions: workflow_definitions.len(),
+        workflow_runs: workflow_runs.len(),
+        active_workflow_runs: workflow_runs
+            .iter()
+            .filter(|run| !run.state.is_terminal())
+            .count(),
+        automation_tasks: automation_tasks.len(),
+        active_automation_tasks: automation_tasks
+            .iter()
+            .filter(|task| !task.state.is_terminal())
+            .count(),
+        extension_definitions: extension_definitions.len(),
+        delegated_principals: delegated_principals.len(),
+    };
+
+    Ok(Json(IdentityAccessReviewResponse {
+        principal: identity_principal_resource(&principal),
+        generated_at: now,
+        projects,
+        resource_counts,
+        delegated_principals,
+    }))
+}
+
+async fn project_resources(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    projects: Vec<StoredProject>,
+) -> Result<Vec<ProjectResource>, (StatusCode, Json<ErrorResponse>)> {
+    let mut resources = Vec::with_capacity(projects.len());
+    for project in projects {
+        let active_sessions = state
+            .session_store
+            .count_active_sessions_for_project(principal, project.id)
+            .await
+            .map_err(map_session_store_error)?;
+        resources.push(project.to_resource(active_sessions, Utc::now()));
+    }
+    Ok(resources)
+}
+
+fn identity_principal_resource(principal: &AuthenticatedPrincipal) -> IdentityPrincipalResource {
+    IdentityPrincipalResource {
+        subject: principal.subject.clone(),
+        issuer: principal.issuer.clone(),
+        display_name: principal.display_name.clone(),
+        client_id: principal.client_id.clone(),
+        principal_type: classify_principal(principal),
+    }
+}
+
+fn classify_principal(principal: &AuthenticatedPrincipal) -> IdentityPrincipalType {
+    if principal.issuer == "bpane-gateway" && principal.subject.starts_with("legacy-dev-token:") {
+        return IdentityPrincipalType::LegacyDevToken;
+    }
+
+    let service_account_display = principal
+        .display_name
+        .as_deref()
+        .is_some_and(|value| value.starts_with("service-account-"));
+    let client_credentials_display = principal
+        .client_id
+        .as_deref()
+        .is_some_and(|client_id| principal.display_name.as_deref() == Some(client_id));
+    if service_account_display || client_credentials_display {
+        IdentityPrincipalType::ServicePrincipal
+    } else {
+        IdentityPrincipalType::User
+    }
+}
+
+fn delegated_principal_resources(
+    sessions: &[StoredSession],
+) -> Vec<IdentityDelegatedPrincipalResource> {
+    let mut groups: HashMap<DelegatedPrincipalKey, IdentityDelegatedPrincipalResource> =
+        HashMap::new();
+    for session in sessions {
+        let Some(delegate) = &session.automation_delegate else {
+            continue;
+        };
+        let key = DelegatedPrincipalKey {
+            client_id: delegate.client_id.clone(),
+            issuer: delegate.issuer.clone(),
+            display_name: delegate.display_name.clone(),
+        };
+        let entry = groups
+            .entry(key)
+            .or_insert_with(|| IdentityDelegatedPrincipalResource {
+                client_id: delegate.client_id.clone(),
+                issuer: delegate.issuer.clone(),
+                display_name: delegate.display_name.clone(),
+                session_count: 0,
+                active_session_count: 0,
+                session_ids: Vec::new(),
+            });
+        entry.session_count += 1;
+        if session.state.is_runtime_candidate() {
+            entry.active_session_count += 1;
+        }
+        entry.session_ids.push(session.id);
+    }
+
+    let mut resources = groups.into_values().collect::<Vec<_>>();
+    for resource in &mut resources {
+        resource.session_ids.sort_unstable();
+    }
+    resources.sort_by(|left, right| {
+        left.client_id
+            .cmp(&right.client_id)
+            .then(left.issuer.cmp(&right.issuer))
+    });
+    resources
+}

--- a/code/apps/bpane-gateway/src/api/router.rs
+++ b/code/apps/bpane-gateway/src/api/router.rs
@@ -18,6 +18,7 @@ pub(crate) fn build_api_router(state: Arc<ApiState>) -> Router {
         .merge(sessions::session_routes())
         .merge(browser_contexts::browser_context_routes())
         .merge(extensions::extension_routes())
+        .merge(identity::identity_routes())
         .merge(projects::project_routes())
         .merge(egress_profiles::egress_profile_routes())
         .merge(credential_bindings::credential_binding_routes())

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -47,6 +47,7 @@ mod browser_contexts;
 mod credential_bindings;
 mod extensions;
 mod file_workspaces;
+mod identity;
 mod network_identity;
 mod projects;
 mod recordings;

--- a/code/apps/bpane-gateway/src/api/tests/identity.rs
+++ b/code/apps/bpane-gateway/src/api/tests/identity.rs
@@ -1,0 +1,145 @@
+use super::*;
+
+#[tokio::test]
+async fn reports_current_identity_for_authenticated_principal() {
+    let (app, token) = test_router();
+
+    let unauthorized = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/identity/me")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/identity/me")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert_eq!(body["issuer"], "bpane-gateway");
+    assert_eq!(body["principal_type"], "legacy_dev_token");
+    assert!(body["subject"]
+        .as_str()
+        .unwrap()
+        .starts_with("legacy-dev-token:"));
+}
+
+#[tokio::test]
+async fn reports_access_review_with_project_usage_and_delegations() {
+    let (app, token) = test_router();
+
+    let project = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "support",
+                            "description": "Support escalations",
+                            "labels": { "team": "support" },
+                            "quotas": { "max_active_sessions": 3 }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let project_id = project["id"].as_str().unwrap().to_string();
+
+    let session = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "project_id": project_id,
+                            "labels": { "purpose": "review-smoke" }
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let delegated = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/automation-owner"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": "http://localhost:8091/realms/browserpane",
+                        "display_name": "BrowserPane MCP bridge"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delegated.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/identity/access-review")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+
+    assert_eq!(body["principal"]["principal_type"], "legacy_dev_token");
+    assert_eq!(body["resource_counts"]["projects"], 1);
+    assert_eq!(body["resource_counts"]["sessions"], 1);
+    assert_eq!(body["resource_counts"]["active_sessions"], 1);
+    assert_eq!(body["resource_counts"]["delegated_principals"], 1);
+    assert_eq!(body["projects"].as_array().unwrap().len(), 1);
+    assert_eq!(body["projects"][0]["id"], project_id);
+    assert_eq!(body["projects"][0]["usage"]["active_sessions"], 1);
+    assert_eq!(body["delegated_principals"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        body["delegated_principals"][0]["client_id"],
+        "bpane-mcp-bridge"
+    );
+    assert_eq!(body["delegated_principals"][0]["session_count"], 1);
+    assert_eq!(body["delegated_principals"][0]["active_session_count"], 1);
+    assert_eq!(
+        body["delegated_principals"][0]["session_ids"][0],
+        session_id
+    );
+}

--- a/code/apps/bpane-gateway/tests/compose_api_surface.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface.rs
@@ -2,10 +2,10 @@
 mod suite;
 
 use suite::{
-    automation_access_boundaries, browser_contexts, credentials_extensions, network_identity,
-    ownership_boundaries, projects, recording_artifacts, session_churn, session_compatibility,
-    session_templates, sessions_recordings, support, workflow_run_controls, workflows_events,
-    workspaces_automation,
+    automation_access_boundaries, browser_contexts, credentials_extensions, identity,
+    network_identity, ownership_boundaries, projects, recording_artifacts, session_churn,
+    session_compatibility, session_templates, sessions_recordings, support, workflow_run_controls,
+    workflows_events, workspaces_automation,
 };
 
 #[tokio::test]
@@ -51,6 +51,15 @@ async fn compose_network_identity_api_surface() -> anyhow::Result<()> {
     let harness = support::ComposeHarness::connect().await?;
     harness.cleanup_active_sessions().await?;
     network_identity::run(&harness).await
+}
+
+#[tokio::test]
+#[ignore = "requires running local compose stack"]
+async fn compose_identity_access_review_api_surface() -> anyhow::Result<()> {
+    let _guard = support::suite_lock().lock().await;
+    let harness = support::ComposeHarness::connect().await?;
+    harness.cleanup_active_sessions().await?;
+    identity::run(&harness).await
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/tests/compose_api_surface/identity.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/identity.rs
@@ -1,0 +1,174 @@
+use anyhow::{anyhow, Result};
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+use super::support::{json_array, json_id, label_map, ComposeHarness};
+
+pub async fn run(harness: &ComposeHarness) -> Result<()> {
+    assert_unauthorized(
+        harness
+            .get_json_outcome_without_bearer("/api/v1/identity/me", HeaderMap::new())
+            .await?,
+        "identity me without bearer",
+    )?;
+    assert_unauthorized(
+        harness
+            .get_json_outcome_without_bearer("/api/v1/identity/access-review", HeaderMap::new())
+            .await?,
+        "identity access-review without bearer",
+    )?;
+
+    let identity = harness.get_json("/api/v1/identity/me").await?;
+    let subject = identity
+        .get("subject")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("identity response did not include a subject: {identity}"))?;
+    let issuer = identity
+        .get("issuer")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("identity response did not include an issuer: {identity}"))?;
+    if subject.is_empty() || issuer.is_empty() {
+        return Err(anyhow!(
+            "identity response returned an empty subject or issuer: {identity}"
+        ));
+    }
+    if identity["principal_type"] != json!("service_principal") {
+        return Err(anyhow!(
+            "compose client credentials principal was not classified as a service principal: {identity}"
+        ));
+    }
+
+    let project = harness
+        .post_json(
+            "/api/v1/projects",
+            json!({
+                "name": harness.unique_name("identity-review-project"),
+                "description": "Compose e2e identity access review project",
+                "labels": label_map("identity-access-review"),
+                "quotas": {
+                    "max_active_sessions": 2,
+                    "max_active_workflow_runs": 2,
+                    "max_retained_storage_bytes": 1048576
+                }
+            }),
+        )
+        .await?;
+    let project_id = json_id(&project, "id")?;
+    let session = harness
+        .post_json(
+            "/api/v1/sessions",
+            json!({
+                "project_id": project_id,
+                "labels": {
+                    "scope": "identity-access-review"
+                }
+            }),
+        )
+        .await?;
+    let session_id = json_id(&session, "id")?;
+
+    let result = async {
+        let delegated = harness
+            .post_json(
+                &format!("/api/v1/sessions/{session_id}/automation-owner"),
+                json!({
+                    "client_id": "bpane-mcp-bridge",
+                    "issuer": "http://localhost:8091/realms/browserpane-dev",
+                    "display_name": "BrowserPane MCP bridge"
+                }),
+            )
+            .await?;
+        if delegated["automation_delegate"]["client_id"] != json!("bpane-mcp-bridge") {
+            return Err(anyhow!(
+                "automation delegation response did not expose the delegated principal: {delegated}"
+            ));
+        }
+
+        let review = harness.get_json("/api/v1/identity/access-review").await?;
+        if review["principal"]["subject"] != json!(subject)
+            || review["principal"]["issuer"] != json!(issuer)
+            || review["principal"]["principal_type"] != json!("service_principal")
+        {
+            return Err(anyhow!(
+                "identity access review principal did not match /identity/me: {review}"
+            ));
+        }
+        assert_count_at_least(&review, "projects", 1)?;
+        assert_count_at_least(&review, "sessions", 1)?;
+        assert_count_at_least(&review, "active_sessions", 1)?;
+        assert_count_at_least(&review, "delegated_principals", 1)?;
+
+        let projects = json_array(&review, "projects")?;
+        let reviewed_project = projects
+            .iter()
+            .find(|candidate| candidate.get("id") == Some(&json!(project_id)))
+            .ok_or_else(|| {
+                anyhow!(
+                    "identity access review did not include created project {project_id}: {review}"
+                )
+            })?;
+        if reviewed_project["usage"]["active_sessions"] != json!(1) {
+            return Err(anyhow!(
+                "identity access review did not count active project usage: {reviewed_project}"
+            ));
+        }
+
+        let delegated_principals = json_array(&review, "delegated_principals")?;
+        let delegated_principal = delegated_principals
+            .iter()
+            .find(|candidate| {
+                candidate.get("client_id") == Some(&json!("bpane-mcp-bridge"))
+                    && candidate
+                        .get("session_ids")
+                        .and_then(Value::as_array)
+                        .is_some_and(|session_ids| session_ids.contains(&json!(session_id)))
+            })
+            .ok_or_else(|| {
+                anyhow!(
+                    "identity access review did not include delegated session {session_id}: {review}"
+                )
+            })?;
+        if delegated_principal["active_session_count"]
+            .as_u64()
+            .unwrap_or_default()
+            < 1
+        {
+            return Err(anyhow!(
+                "identity access review did not count active delegated sessions: {delegated_principal}"
+            ));
+        }
+
+        Ok(())
+    }
+    .await;
+
+    let stop_result = harness.stop_session_eventually(&session_id).await;
+
+    result?;
+    stop_result?;
+    Ok(())
+}
+
+fn assert_unauthorized(outcome: super::support::JsonOutcome, context: &str) -> Result<()> {
+    if outcome.status != StatusCode::UNAUTHORIZED {
+        return Err(anyhow!(
+            "{context} returned {} instead of 401: {}",
+            outcome.status,
+            outcome.body
+        ));
+    }
+    Ok(())
+}
+
+fn assert_count_at_least(review: &Value, field: &str, minimum: u64) -> Result<()> {
+    let count = review["resource_counts"][field]
+        .as_u64()
+        .ok_or_else(|| anyhow!("identity access review count {field} was missing: {review}"))?;
+    if count < minimum {
+        return Err(anyhow!(
+            "identity access review count {field} was {count}, expected at least {minimum}: {review}"
+        ));
+    }
+    Ok(())
+}

--- a/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
@@ -1,6 +1,7 @@
 pub mod automation_access_boundaries;
 pub mod browser_contexts;
 pub mod credentials_extensions;
+pub mod identity;
 pub mod network_identity;
 pub mod ownership_boundaries;
 pub mod projects;

--- a/code/web/bpane-admin/src/lib/api/control-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.test.ts
@@ -129,6 +129,47 @@ const PROJECT = {
   updated_at: '2026-05-04T18:50:00Z',
 };
 
+const IDENTITY_PRINCIPAL = {
+  subject: 'demo',
+  issuer: 'http://localhost:8091/realms/browserpane',
+  display_name: 'demo',
+  client_id: 'bpane-web',
+  principal_type: 'user',
+};
+
+const ACCESS_REVIEW = {
+  principal: IDENTITY_PRINCIPAL,
+  generated_at: '2026-05-29T10:00:00Z',
+  projects: [PROJECT],
+  resource_counts: {
+    projects: 1,
+    sessions: 2,
+    active_sessions: 1,
+    session_templates: 1,
+    browser_contexts: 1,
+    egress_profiles: 1,
+    credential_bindings: 0,
+    file_workspaces: 1,
+    workflow_definitions: 1,
+    workflow_runs: 2,
+    active_workflow_runs: 1,
+    automation_tasks: 2,
+    active_automation_tasks: 1,
+    extension_definitions: 0,
+    delegated_principals: 1,
+  },
+  delegated_principals: [
+    {
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'http://localhost:8091/realms/browserpane',
+      display_name: 'BrowserPane MCP bridge',
+      session_count: 1,
+      active_session_count: 1,
+      session_ids: [SESSION.id],
+    },
+  ],
+};
+
 const TEMPLATE = {
   id: '019df5c8-3d03-7800-9e5d-79d69d9a21c0',
   name: 'Support triage',
@@ -208,6 +249,51 @@ describe('ControlClient', () => {
           authorization: 'Bearer owner-token',
         }),
       }),
+    );
+  });
+
+  it('loads identity and access-review resources with bearer auth', async () => {
+    const responses = [IDENTITY_PRINCIPAL, ACCESS_REVIEW];
+    const fetchImpl = vi.fn<FetchLike>(async () => new Response(JSON.stringify(responses.shift()), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    const principal = await client.getCurrentIdentity();
+    const review = await client.getIdentityAccessReview();
+
+    expect(principal).toMatchObject({
+      subject: 'demo',
+      principal_type: 'user',
+    });
+    expect(review).toMatchObject({
+      principal: { subject: 'demo', principal_type: 'user' },
+      resource_counts: {
+        projects: 1,
+        sessions: 2,
+        delegated_principals: 1,
+      },
+      delegated_principals: [
+        {
+          client_id: 'bpane-mcp-bridge',
+          session_ids: [SESSION.id],
+        },
+      ],
+    });
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL('http://localhost:8932/api/v1/identity/me'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL('http://localhost:8932/api/v1/identity/access-review'),
+      expect.objectContaining({ method: 'GET' }),
     );
   });
 

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -27,6 +27,8 @@ import type {
   FileWorkspaceFileResource,
   FileWorkspaceListResponse,
   FileWorkspaceResource,
+  IdentityAccessReviewResponse,
+  IdentityPrincipalResource,
   ProjectListResponse,
   ProjectResource,
   ProjectUsageResource,
@@ -76,6 +78,16 @@ export class ControlClient {
     this.#accessTokenProvider = options.accessTokenProvider;
     this.#onAuthenticationFailure = options.onAuthenticationFailure;
     this.#fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async getCurrentIdentity(): Promise<IdentityPrincipalResource> {
+    const payload = await this.#request('GET', '/api/v1/identity/me');
+    return ControlSessionMapper.toIdentityPrincipalResource(payload);
+  }
+
+  async getIdentityAccessReview(): Promise<IdentityAccessReviewResponse> {
+    const payload = await this.#request('GET', '/api/v1/identity/access-review');
+    return ControlSessionMapper.toIdentityAccessReview(payload);
   }
 
   async listSessions(filters: SessionListFilters = {}): Promise<SessionListResponse> {

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -15,6 +15,11 @@ import type {
   EgressProxyConfig,
   EgressTrafficObservationConfig,
   EgressTrafficObservationMode,
+  IdentityAccessReviewResponse,
+  IdentityDelegatedPrincipalResource,
+  IdentityPrincipalResource,
+  IdentityPrincipalType,
+  IdentityResourceCounts,
   ProjectAdmissionDecision,
   ProjectAdmissionReasonCode,
   ProjectAdmissionState,
@@ -54,6 +59,29 @@ import {
 } from './control-wire';
 
 export class ControlSessionMapper {
+  static toIdentityPrincipalResource(payload: unknown): IdentityPrincipalResource {
+    return toIdentityPrincipalResource(payload);
+  }
+
+  static toIdentityAccessReview(payload: unknown): IdentityAccessReviewResponse {
+    const object = expectRecord(payload, 'identity access review');
+    const projects = object.projects;
+    const delegatedPrincipals = object.delegated_principals;
+    if (!Array.isArray(projects)) {
+      throw new Error('identity access review must contain a projects array');
+    }
+    if (!Array.isArray(delegatedPrincipals)) {
+      throw new Error('identity access review must contain a delegated_principals array');
+    }
+    return {
+      principal: toIdentityPrincipalResource(object.principal),
+      generated_at: expectString(object.generated_at, 'identity access review generated_at'),
+      projects: projects.map((project) => this.toProjectResource(project)),
+      resource_counts: toIdentityResourceCounts(object.resource_counts),
+      delegated_principals: delegatedPrincipals.map((delegate) => toIdentityDelegatedPrincipal(delegate)),
+    };
+  }
+
   static toProjectList(payload: unknown): ProjectListResponse {
     const object = expectRecord(payload, 'project list response');
     const projects = object.projects;
@@ -278,6 +306,7 @@ const PROJECT_ADMISSION_REASON_CODES = [
   'active_session_quota_exceeded',
   'project_archived',
 ] satisfies readonly ProjectAdmissionReasonCode[];
+const IDENTITY_PRINCIPAL_TYPES = ['user', 'service_principal', 'legacy_dev_token'] satisfies readonly IdentityPrincipalType[];
 const EGRESS_PROFILE_STATES = ['ready', 'disabled'] satisfies readonly EgressProfileState[];
 const EGRESS_TRAFFIC_OBSERVATION_MODES = ['metadata_only', 'tls_intercept'] satisfies readonly EgressTrafficObservationMode[];
 const EGRESS_DIAGNOSTICS_HEALTHS = ['ready', 'unknown', 'attention', 'blocked', 'missing'] satisfies readonly EgressDiagnosticsHealth[];
@@ -307,6 +336,60 @@ function optionalRecord(value: unknown, label: string): Readonly<Record<string, 
     return value;
   }
   return expectRecord(value, label);
+}
+
+function toIdentityPrincipalResource(value: unknown): IdentityPrincipalResource {
+  const object = expectRecord(value, 'identity principal');
+  const displayName = optionalString(object.display_name, 'identity principal display_name');
+  const clientId = optionalString(object.client_id, 'identity principal client_id');
+  return {
+    subject: expectString(object.subject, 'identity principal subject'),
+    issuer: expectString(object.issuer, 'identity principal issuer'),
+    display_name: displayName ?? null,
+    client_id: clientId ?? null,
+    principal_type: expectEnum(
+      object.principal_type,
+      'identity principal principal_type',
+      IDENTITY_PRINCIPAL_TYPES,
+    ),
+  };
+}
+
+function toIdentityResourceCounts(value: unknown): IdentityResourceCounts {
+  const object = expectRecord(value, 'identity resource counts');
+  return {
+    projects: expectNumber(object.projects, 'identity resource counts projects'),
+    sessions: expectNumber(object.sessions, 'identity resource counts sessions'),
+    active_sessions: expectNumber(object.active_sessions, 'identity resource counts active_sessions'),
+    session_templates: expectNumber(object.session_templates, 'identity resource counts session_templates'),
+    browser_contexts: expectNumber(object.browser_contexts, 'identity resource counts browser_contexts'),
+    egress_profiles: expectNumber(object.egress_profiles, 'identity resource counts egress_profiles'),
+    credential_bindings: expectNumber(object.credential_bindings, 'identity resource counts credential_bindings'),
+    file_workspaces: expectNumber(object.file_workspaces, 'identity resource counts file_workspaces'),
+    workflow_definitions: expectNumber(object.workflow_definitions, 'identity resource counts workflow_definitions'),
+    workflow_runs: expectNumber(object.workflow_runs, 'identity resource counts workflow_runs'),
+    active_workflow_runs: expectNumber(object.active_workflow_runs, 'identity resource counts active_workflow_runs'),
+    automation_tasks: expectNumber(object.automation_tasks, 'identity resource counts automation_tasks'),
+    active_automation_tasks: expectNumber(object.active_automation_tasks, 'identity resource counts active_automation_tasks'),
+    extension_definitions: expectNumber(object.extension_definitions, 'identity resource counts extension_definitions'),
+    delegated_principals: expectNumber(object.delegated_principals, 'identity resource counts delegated_principals'),
+  };
+}
+
+function toIdentityDelegatedPrincipal(value: unknown): IdentityDelegatedPrincipalResource {
+  const object = expectRecord(value, 'identity delegated principal');
+  const displayName = optionalString(object.display_name, 'identity delegated principal display_name');
+  return {
+    client_id: expectString(object.client_id, 'identity delegated principal client_id'),
+    issuer: expectString(object.issuer, 'identity delegated principal issuer'),
+    display_name: displayName ?? null,
+    session_count: expectNumber(object.session_count, 'identity delegated principal session_count'),
+    active_session_count: expectNumber(
+      object.active_session_count,
+      'identity delegated principal active_session_count',
+    ),
+    session_ids: toStringArray(object.session_ids ?? [], 'identity delegated principal session_ids'),
+  };
 }
 
 function toProjectQuotas(value: unknown): ProjectQuotas {

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -180,6 +180,51 @@ export type ProjectListResponse = {
   readonly projects: readonly ProjectResource[];
 };
 
+export type IdentityPrincipalType = 'user' | 'service_principal' | 'legacy_dev_token';
+
+export type IdentityPrincipalResource = {
+  readonly subject: string;
+  readonly issuer: string;
+  readonly display_name?: string | null;
+  readonly client_id?: string | null;
+  readonly principal_type: IdentityPrincipalType;
+};
+
+export type IdentityResourceCounts = {
+  readonly projects: number;
+  readonly sessions: number;
+  readonly active_sessions: number;
+  readonly session_templates: number;
+  readonly browser_contexts: number;
+  readonly egress_profiles: number;
+  readonly credential_bindings: number;
+  readonly file_workspaces: number;
+  readonly workflow_definitions: number;
+  readonly workflow_runs: number;
+  readonly active_workflow_runs: number;
+  readonly automation_tasks: number;
+  readonly active_automation_tasks: number;
+  readonly extension_definitions: number;
+  readonly delegated_principals: number;
+};
+
+export type IdentityDelegatedPrincipalResource = {
+  readonly client_id: string;
+  readonly issuer: string;
+  readonly display_name?: string | null;
+  readonly session_count: number;
+  readonly active_session_count: number;
+  readonly session_ids: readonly string[];
+};
+
+export type IdentityAccessReviewResponse = {
+  readonly principal: IdentityPrincipalResource;
+  readonly generated_at: string;
+  readonly projects: readonly ProjectResource[];
+  readonly resource_counts: IdentityResourceCounts;
+  readonly delegated_principals: readonly IdentityDelegatedPrincipalResource[];
+};
+
 export type CreateProjectCommand = {
   readonly name: string;
   readonly description?: string | null;

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -16,6 +16,7 @@
     CreateSessionCommand,
     EgressDiagnosticsResource,
     EgressProfileResource,
+    IdentityAccessReviewResponse,
     ImportBrowserContextCommand,
     ProjectResource,
     SessionResource,
@@ -63,6 +64,7 @@
   let projects = $state<readonly ProjectResource[]>([]);
   let browserContexts = $state<readonly BrowserContextResource[]>([]);
   let egressProfiles = $state<readonly EgressProfileResource[]>([]);
+  let identityAccessReview = $state<IdentityAccessReviewResponse | null>(null);
   let selectedSession = $state<SessionResource | null>(null);
   let sessionsLoading = $state(false);
   let sessionsError = $state<string | null>(null);
@@ -70,6 +72,7 @@
   let projectsLoading = $state(false);
   let browserContextsLoading = $state(false);
   let egressProfilesLoading = $state(false);
+  let identityAccessReviewLoading = $state(false);
   let cloningBrowserContextId = $state<string | null>(null);
   let exportingBrowserContextId = $state<string | null>(null);
   let importingBrowserContext = $state(false);
@@ -77,6 +80,7 @@
   let projectError = $state<string | null>(null);
   let browserContextError = $state<string | null>(null);
   let egressProfileError = $state<string | null>(null);
+  let identityAccessReviewError = $state<string | null>(null);
   let globalMessage = $state<AdminMessageFeedback | null>(null);
   let pendingSelectedSessionId = $state<string | null>(null);
   let browserConnecting = $state(false);
@@ -110,6 +114,7 @@
     browserStatus, selectedSessionId: selectedSession?.id ?? null,
     sessionCount: sessions.length, browserContextCount: browserContexts.length,
     egressProfileCount: egressProfiles.length,
+    delegatedPrincipalCount: identityAccessReview?.resource_counts.delegated_principals ?? 0,
     fileCount: sessionFileCount, connected: browserConnected,
   }));
   const sessionListViewModel = $derived(SessionViewModelBuilder.list({
@@ -148,8 +153,28 @@
     void loadSessionTemplates();
     void loadBrowserContexts();
     void loadEgressProfiles();
+    void loadIdentityAccessReview();
     return () => { subscription.close(); disconnectBrowser(false); };
   });
+  async function loadIdentityAccessReview(showFeedback = false): Promise<void> {
+    identityAccessReviewLoading = true;
+    identityAccessReviewError = null;
+    try {
+      identityAccessReview = await controlClient.getIdentityAccessReview();
+      if (showFeedback) {
+        showGlobalMessage(
+          'success',
+          'Access review refreshed',
+          `${identityAccessReview.resource_counts.sessions} session${identityAccessReview.resource_counts.sessions === 1 ? '' : 's'} and ${identityAccessReview.resource_counts.delegated_principals} delegated principal${identityAccessReview.resource_counts.delegated_principals === 1 ? '' : 's'} refreshed.`,
+        );
+      }
+    } catch (error) {
+      identityAccessReviewError = errorMessage(error);
+      showGlobalMessage('warning', 'Access review unavailable', identityAccessReviewError);
+    } finally {
+      identityAccessReviewLoading = false;
+    }
+  }
   async function loadProjects(showFeedback = false): Promise<void> {
     projectsLoading = true;
     projectError = null;
@@ -323,6 +348,7 @@
       showGlobalMessage('success', 'Session created', `Created session ${shortAdminId(created.id)}.`);
       void loadProjects(false);
       void loadBrowserContexts(false);
+      void loadIdentityAccessReview(false);
       requestBrowserConnect();
     } catch (error) {
       sessionsError = errorMessage(error);
@@ -444,6 +470,7 @@
           ? await controlClient.stopSession(selectedSession.id)
           : await controlClient.killSession(selectedSession.id);
       upsertSession(updated);
+      void loadIdentityAccessReview(false);
     } catch (error) {
       sessionsError = errorMessage(error);
       throw error;
@@ -633,6 +660,7 @@
       {projects} {projectsLoading} {projectError}
       {sessions} {browserContexts} {browserContextsLoading} {browserContextError}
       {egressProfiles} {egressProfilesLoading} {egressProfileError}
+      {identityAccessReview} {identityAccessReviewLoading} {identityAccessReviewError}
       cloningContextId={cloningBrowserContextId}
       exportingContextId={exportingBrowserContextId}
       {browserPreferences} {browserConnected} {workspaceViewModel} {sessionListViewModel} {logEntries} {globalMessage}
@@ -649,6 +677,7 @@
       {importingBrowserContext}
       onRefreshBrowserContexts={loadBrowserContexts}
       onRefreshEgressProfiles={loadEgressProfiles}
+      onRefreshIdentityAccessReview={loadIdentityAccessReview}
       onDeleteBrowserContext={deleteBrowserContext}
       onSelectSessionId={selectSession} onRefreshSelectedSession={refreshSelectedSession}
       onReleaseSessionRuntime={() => runLifecycle('release')}

--- a/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminWorkspaceTabs.svelte
@@ -10,6 +10,7 @@
     Network,
     Radio,
     ScrollText,
+    UserCheck,
     Video,
   } from 'lucide-svelte';
   import type { ControlClient } from '../api/control-client';
@@ -21,6 +22,7 @@
     CreateSessionCommand,
     EgressDiagnosticsResource,
     EgressProfileResource,
+    IdentityAccessReviewResponse,
     ImportBrowserContextCommand,
     ProjectResource,
     SessionResource,
@@ -43,6 +45,7 @@
   import BrowserPolicySurface from './BrowserPolicySurface.svelte';
   import BrowserContextCatalogPanel from '../presentation/BrowserContextCatalogPanel.svelte';
   import EgressProfileCatalogPanel from '../presentation/EgressProfileCatalogPanel.svelte';
+  import IdentityAccessReviewPanel from '../presentation/IdentityAccessReviewPanel.svelte';
   import DisplayControlsSurface from './DisplayControlsSurface.svelte';
   import LiveSessionActionsSurface from './LiveSessionActionsSurface.svelte';
   import LogsSurface from './LogsSurface.svelte';
@@ -62,10 +65,12 @@
     readonly sessionTemplates?: readonly SessionTemplateResource[];
     readonly browserContexts?: readonly BrowserContextResource[];
     readonly egressProfiles?: readonly EgressProfileResource[];
+    readonly identityAccessReview?: IdentityAccessReviewResponse | null;
     readonly templatesLoading?: boolean;
     readonly projectsLoading?: boolean;
     readonly browserContextsLoading?: boolean;
     readonly egressProfilesLoading?: boolean;
+    readonly identityAccessReviewLoading?: boolean;
     readonly cloningContextId?: string | null;
     readonly exportingContextId?: string | null;
     readonly importingBrowserContext?: boolean;
@@ -73,6 +78,7 @@
     readonly projectError?: string | null;
     readonly browserContextError?: string | null;
     readonly egressProfileError?: string | null;
+    readonly identityAccessReviewError?: string | null;
     readonly mcpBridge: McpBridgeConfig | null;
     readonly liveConnection: LiveBrowserSessionConnection | null;
     readonly browserConnected: boolean;
@@ -87,6 +93,7 @@
     readonly onRefreshSessions: (showFeedback?: boolean) => Promise<void>;
     readonly onRefreshBrowserContexts: (showFeedback?: boolean) => Promise<void>;
     readonly onRefreshEgressProfiles: (showFeedback?: boolean) => Promise<void>;
+    readonly onRefreshIdentityAccessReview: (showFeedback?: boolean) => Promise<void>;
     readonly onCreateSession: (command?: CreateSessionCommand) => void;
     readonly onCreateBrowserContext?: (command: CreateBrowserContextCommand) => Promise<BrowserContextResource | void>;
     readonly onCreateEgressProfile?: (command: CreateEgressProfileCommand) => Promise<EgressProfileResource | void>;
@@ -118,8 +125,14 @@
     return panels.find((panel) => panel.id === id) ?? panels[0] ?? null;
   }
 
+  async function refreshSessionsAndIdentity(showFeedback = false): Promise<void> {
+    await props.onRefreshSessions(showFeedback);
+    await props.onRefreshIdentityAccessReview(false);
+  }
+
   const PANEL_ICONS = {
     sessions: ClipboardList,
+    identity: UserCheck,
     lifecycle: Activity,
     display: MonitorCog,
     files: FolderOpen,
@@ -218,7 +231,7 @@
           selectedSession={props.selectedSession}
           mcpBridge={props.mcpBridge}
           refreshVersion={props.mcpDelegationRefreshVersion}
-          onRefreshSessions={() => props.onRefreshSessions(false)}
+          onRefreshSessions={() => refreshSessionsAndIdentity(false)}
           onRefreshSelectedSession={props.onRefreshSelectedSession}
         />
       {:else if activePanel.id === 'contexts'}
@@ -245,6 +258,13 @@
           onCreateProfile={props.onCreateEgressProfile}
           onUpdateProfile={props.onUpdateEgressProfile}
           onRunProfileReachabilityProbe={props.onRunEgressProfileReachabilityProbe}
+        />
+      {:else if activePanel.id === 'identity'}
+        <IdentityAccessReviewPanel
+          review={props.identityAccessReview ?? null}
+          loading={props.identityAccessReviewLoading ?? false}
+          error={props.identityAccessReviewError ?? null}
+          onRefresh={() => void props.onRefreshIdentityAccessReview(true)}
         />
       {:else if activePanel.id === 'lifecycle'}
         <SessionLifecycleSurface

--- a/code/web/bpane-admin/src/lib/presentation/IdentityAccessReviewPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/IdentityAccessReviewPanel.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  import { RefreshCw } from 'lucide-svelte';
+  import type { IdentityAccessReviewResponse } from '../api/control-types';
+  import AdminMessage from './AdminMessage.svelte';
+  import { IdentityAccessReviewViewModelBuilder } from './identity-access-review-view-model';
+
+  type IdentityAccessReviewPanelProps = {
+    readonly review: IdentityAccessReviewResponse | null;
+    readonly loading?: boolean;
+    readonly error?: string | null;
+    readonly onRefresh: () => void;
+  };
+
+  let {
+    review,
+    loading = false,
+    error = null,
+    onRefresh,
+  }: IdentityAccessReviewPanelProps = $props();
+
+  const viewModel = $derived(review ? IdentityAccessReviewViewModelBuilder.build(review) : null);
+</script>
+
+<section class="grid min-w-0 gap-4" aria-label="Identity access review" data-testid="identity-access-review-panel">
+  <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
+    <p class="m-0 text-sm leading-normal text-admin-ink/68">
+      Review the authenticated principal, owner-scoped resource counts, and delegated automation access.
+    </p>
+    <button
+      class="admin-button-ghost inline-flex items-center gap-2"
+      type="button"
+      data-testid="identity-refresh"
+      disabled={loading}
+      onclick={onRefresh}
+    >
+      <RefreshCw size={15} class={loading ? 'animate-spin' : ''} aria-hidden="true" />
+      Refresh
+    </button>
+  </div>
+
+  {#if error}
+    <AdminMessage
+      variant="warning"
+      title="Identity review unavailable"
+      message={error}
+      testId="identity-access-review-error"
+      compact={true}
+    />
+  {/if}
+
+  {#if loading && !viewModel}
+    <AdminMessage
+      variant="loading"
+      title="Loading identity review"
+      message="Fetching the current principal and access summary."
+      testId="identity-access-review-loading"
+      compact={true}
+    />
+  {:else if !viewModel}
+    <AdminMessage
+      variant="empty"
+      title="No identity review loaded"
+      message="Refresh the panel to load the current access review."
+      testId="identity-access-review-empty"
+      compact={true}
+    />
+  {:else}
+    <section class="rounded-[14px] border border-[#90a6cc]/18 bg-[#111e32]/72 p-3" aria-label="Current principal">
+      <div class="grid min-w-0 gap-2">
+        <p class="admin-eyebrow m-0">Current principal</p>
+        <div class="grid min-w-0 gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+          <div class="min-w-0">
+            <strong class="block truncate text-base font-extrabold text-admin-ink" data-testid="identity-principal-title">
+              {viewModel.principalTitle}
+            </strong>
+            <p class="m-0 min-w-0 text-xs font-semibold leading-normal text-[#c1d0e8] [overflow-wrap:anywhere]" data-testid="identity-principal-subtitle">
+              {viewModel.principalSubtitle}
+            </p>
+          </div>
+          <span class="w-fit rounded-xl border border-admin-leaf/24 bg-admin-leaf/10 px-3 py-1 text-xs font-bold text-admin-leaf" data-testid="identity-principal-type">
+            {viewModel.principalTypeLabel}
+          </span>
+        </div>
+        <p class="m-0 text-xs font-semibold text-admin-ink/58" data-testid="identity-review-generated-at">
+          Generated {viewModel.generatedAtLabel}
+        </p>
+      </div>
+    </section>
+
+    <div class="grid grid-cols-2 gap-2 max-[760px]:grid-cols-1" data-testid="identity-resource-counts">
+      {#each viewModel.metrics as metric (metric.key)}
+        <span class="rounded-[12px] bg-admin-leaf/10 p-3 text-xs font-bold text-admin-ink/62 uppercase">
+          {metric.label}
+          <strong class="mt-1 block text-admin-ink normal-case" data-testid={metric.testId}>{metric.value}</strong>
+        </span>
+      {/each}
+    </div>
+
+    <section class="grid min-w-0 gap-2" aria-label="Project access" data-testid="identity-project-list">
+      <div class="flex items-center justify-between gap-2">
+        <p class="admin-eyebrow m-0">Projects</p>
+        <span class="text-xs font-bold text-admin-ink/58">{viewModel.projects.length}</span>
+      </div>
+      {#if viewModel.projects.length === 0}
+        <AdminMessage variant="empty" message="No projects are visible for this principal." compact={true} />
+      {:else}
+        <div class="grid gap-2">
+          {#each viewModel.projects as project (project.id)}
+            <article class="rounded-[12px] border border-[#90a6cc]/16 bg-admin-panel/62 p-3">
+              <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                <div class="min-w-0">
+                  <strong class="block truncate text-sm font-extrabold text-admin-ink">{project.name}</strong>
+                  <p class="m-0 truncate text-xs font-semibold text-admin-ink/54">{project.id}</p>
+                </div>
+                <span class="w-fit rounded-lg bg-admin-cream/72 px-2 py-1 text-xs font-bold text-admin-ink/68">{project.state}</span>
+              </div>
+              <div class="mt-3 grid grid-cols-3 gap-2 max-[760px]:grid-cols-1">
+                <span class="text-xs font-bold text-admin-ink/58">Sessions <strong class="block text-admin-ink">{project.activeSessions}</strong></span>
+                <span class="text-xs font-bold text-admin-ink/58">Workflows <strong class="block text-admin-ink">{project.activeWorkflowRuns}</strong></span>
+                <span class="text-xs font-bold text-admin-ink/58">Storage <strong class="block text-admin-ink">{project.retainedStorage}</strong></span>
+              </div>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
+    <section class="grid min-w-0 gap-2" aria-label="Delegated automation access" data-testid="identity-delegation-list">
+      <div class="flex items-center justify-between gap-2">
+        <p class="admin-eyebrow m-0">Delegated automation</p>
+        <span class="text-xs font-bold text-admin-ink/58">{viewModel.delegations.length}</span>
+      </div>
+      {#if viewModel.delegations.length === 0}
+        <AdminMessage variant="empty" message="No delegated automation principals are assigned to visible sessions." compact={true} />
+      {:else}
+        <div class="grid gap-2">
+          {#each viewModel.delegations as delegation (delegation.clientId + delegation.issuer)}
+            <article class="rounded-[12px] border border-[#90a6cc]/16 bg-admin-panel/62 p-3">
+              <strong class="block truncate text-sm font-extrabold text-admin-ink">{delegation.displayName}</strong>
+              <p class="m-0 min-w-0 text-xs font-semibold leading-normal text-admin-ink/58 [overflow-wrap:anywhere]">
+                {delegation.clientId} / {delegation.issuer}
+              </p>
+              <p class="mt-2 mb-0 text-xs font-bold text-admin-ink/72">
+                {delegation.sessionSummary}
+                <span class="block font-semibold text-admin-ink/54">{delegation.sessionIds}</span>
+              </p>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
+  {/if}
+</section>

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.test.ts
@@ -10,12 +10,14 @@ describe('AdminWorkspaceViewModelBuilder', () => {
       browserContextCount: 1,
       egressProfileCount: 2,
       fileCount: 1,
+      delegatedPrincipalCount: 1,
       connected: true,
     });
 
     expect(viewModel.browser.connectionLabel).toBe('connected');
     expect(viewModel.panels.map((panel) => panel.id)).toEqual([
       'sessions',
+      'identity',
       'contexts',
       'egress',
       'lifecycle',
@@ -37,11 +39,13 @@ describe('AdminWorkspaceViewModelBuilder', () => {
       browserContextCount: 0,
       egressProfileCount: 0,
       fileCount: 0,
+      delegatedPrincipalCount: 0,
       connected: false,
     });
 
     expect(viewModel.panels.filter((panel) => panel.implemented).map((panel) => panel.id)).toEqual([
       'sessions',
+      'identity',
       'contexts',
       'egress',
       'lifecycle',

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
@@ -1,5 +1,6 @@
 export type AdminFeaturePanelId =
   | 'sessions'
+  | 'identity'
   | 'contexts'
   | 'egress'
   | 'lifecycle'
@@ -41,6 +42,7 @@ export class AdminWorkspaceViewModelBuilder {
     readonly browserContextCount: number;
     readonly egressProfileCount: number;
     readonly fileCount: number;
+    readonly delegatedPrincipalCount: number;
     readonly connected: boolean;
   }): AdminWorkspaceViewModel {
     return {
@@ -56,6 +58,11 @@ export class AdminWorkspaceViewModelBuilder {
           'Disconnect',
           'MCP authorization',
         ], ['visible sessions', 'selected session']),
+        panel('identity', 'Identity', 'Principal and access review', 'Review the signed-in operator and delegated automation access.', `${input.delegatedPrincipalCount} delegates`, true, [
+          'Refresh principal',
+          'Review projects',
+          'Inspect delegations',
+        ], ['principal type', 'resource counts', 'delegations']),
         panel('contexts', 'Contexts', 'Reusable browser profile lifecycle', 'Inspect reusable Chromium state before attaching it to sessions.', `${input.browserContextCount} contexts`, true, [
           'Inspect profile catalog',
           'Copy API examples',

--- a/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { IdentityAccessReviewViewModelBuilder } from './identity-access-review-view-model';
+import type { IdentityAccessReviewResponse } from '../api/control-types';
+
+const REVIEW: IdentityAccessReviewResponse = {
+  principal: {
+    subject: 'demo',
+    issuer: 'http://localhost:8091/realms/browserpane',
+    display_name: 'demo',
+    client_id: 'bpane-web',
+    principal_type: 'user',
+  },
+  generated_at: '2026-05-29T10:00:00Z',
+  resource_counts: {
+    projects: 1,
+    sessions: 2,
+    active_sessions: 1,
+    session_templates: 1,
+    browser_contexts: 1,
+    egress_profiles: 1,
+    credential_bindings: 0,
+    file_workspaces: 1,
+    workflow_definitions: 1,
+    workflow_runs: 2,
+    active_workflow_runs: 1,
+    automation_tasks: 2,
+    active_automation_tasks: 1,
+    extension_definitions: 0,
+    delegated_principals: 1,
+  },
+  projects: [
+    {
+      id: 'project-1',
+      name: 'Support tenant',
+      description: null,
+      labels: { team: 'support' },
+      quotas: {
+        max_active_sessions: 3,
+        max_active_workflow_runs: 4,
+        max_retained_storage_bytes: 1048576,
+      },
+      state: 'active',
+      usage: {
+        project_id: 'project-1',
+        active_sessions: 1,
+        max_active_sessions: 3,
+        active_workflow_runs: 2,
+        max_active_workflow_runs: 4,
+        retained_storage_bytes: 524288,
+        max_retained_storage_bytes: 1048576,
+        observed_at: '2026-05-29T10:00:00Z',
+      },
+      created_at: '2026-05-29T09:00:00Z',
+      updated_at: '2026-05-29T10:00:00Z',
+    },
+  ],
+  delegated_principals: [
+    {
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'http://localhost:8091/realms/browserpane',
+      display_name: 'BrowserPane MCP bridge',
+      session_count: 1,
+      active_session_count: 1,
+      session_ids: ['019df4d2-f4f7-7b00-9e0c-79683b1c82f6'],
+    },
+  ],
+};
+
+describe('IdentityAccessReviewViewModelBuilder', () => {
+  it('formats identity review counts, projects, and delegations', () => {
+    const viewModel = IdentityAccessReviewViewModelBuilder.build(REVIEW);
+
+    expect(viewModel.principalTitle).toBe('demo');
+    expect(viewModel.principalTypeLabel).toBe('User');
+    expect(viewModel.metrics.find((metric) => metric.key === 'sessions')).toMatchObject({
+      label: 'Sessions',
+      value: '2',
+      testId: 'identity-resource-sessions',
+    });
+    expect(viewModel.projects[0]).toMatchObject({
+      name: 'Support tenant',
+      activeSessions: '1/3',
+      activeWorkflowRuns: '2/4',
+      retainedStorage: '512 KiB / 1.0 MiB',
+    });
+    expect(viewModel.delegations[0]).toMatchObject({
+      clientId: 'bpane-mcp-bridge',
+      displayName: 'BrowserPane MCP bridge',
+      sessionSummary: '1/1 active',
+      sessionIds: '019df4d2...82f6',
+    });
+  });
+});

--- a/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.ts
@@ -1,0 +1,153 @@
+import type {
+  IdentityAccessReviewResponse,
+  IdentityPrincipalType,
+  ProjectResource,
+} from '../api/control-types';
+
+export type IdentityMetricRow = {
+  readonly key: string;
+  readonly label: string;
+  readonly value: string;
+  readonly testId: string;
+};
+
+export type IdentityProjectRow = {
+  readonly id: string;
+  readonly name: string;
+  readonly state: string;
+  readonly activeSessions: string;
+  readonly activeWorkflowRuns: string;
+  readonly retainedStorage: string;
+};
+
+export type IdentityDelegationRow = {
+  readonly clientId: string;
+  readonly issuer: string;
+  readonly displayName: string;
+  readonly sessionSummary: string;
+  readonly sessionIds: string;
+};
+
+export type IdentityAccessReviewViewModel = {
+  readonly principalTitle: string;
+  readonly principalSubtitle: string;
+  readonly principalTypeLabel: string;
+  readonly generatedAtLabel: string;
+  readonly metrics: readonly IdentityMetricRow[];
+  readonly projects: readonly IdentityProjectRow[];
+  readonly delegations: readonly IdentityDelegationRow[];
+};
+
+export class IdentityAccessReviewViewModelBuilder {
+  static build(review: IdentityAccessReviewResponse): IdentityAccessReviewViewModel {
+    return {
+      principalTitle: review.principal.display_name ?? review.principal.subject,
+      principalSubtitle: `${review.principal.issuer} / ${review.principal.subject}`,
+      principalTypeLabel: principalTypeLabel(review.principal.principal_type),
+      generatedAtLabel: formatDateTime(review.generated_at),
+      metrics: [
+        metric('sessions', 'Sessions', review.resource_counts.sessions),
+        metric('active-sessions', 'Active sessions', review.resource_counts.active_sessions),
+        metric('projects', 'Projects', review.resource_counts.projects),
+        metric('contexts', 'Contexts', review.resource_counts.browser_contexts),
+        metric('egress', 'Egress profiles', review.resource_counts.egress_profiles),
+        metric('templates', 'Templates', review.resource_counts.session_templates),
+        metric('workflows', 'Workflow runs', review.resource_counts.workflow_runs),
+        metric('active-workflows', 'Active workflow runs', review.resource_counts.active_workflow_runs),
+        metric('automation', 'Automation tasks', review.resource_counts.automation_tasks),
+        metric('delegations', 'Delegations', review.resource_counts.delegated_principals),
+      ],
+      projects: review.projects.map(projectRow),
+      delegations: review.delegated_principals.map((delegate) => ({
+        clientId: delegate.client_id,
+        issuer: delegate.issuer,
+        displayName: delegate.display_name ?? delegate.client_id,
+        sessionSummary: `${delegate.active_session_count}/${delegate.session_count} active`,
+        sessionIds: delegate.session_ids.length > 0
+          ? delegate.session_ids.map(shortId).join(', ')
+          : 'no sessions',
+      })),
+    };
+  }
+}
+
+function metric(key: string, label: string, value: number): IdentityMetricRow {
+  return {
+    key,
+    label,
+    value: String(value),
+    testId: `identity-resource-${key}`,
+  };
+}
+
+function principalTypeLabel(type: IdentityPrincipalType): string {
+  switch (type) {
+    case 'service_principal':
+      return 'Service principal';
+    case 'legacy_dev_token':
+      return 'Legacy dev token';
+    case 'user':
+    default:
+      return 'User';
+  }
+}
+
+function projectRow(project: ProjectResource): IdentityProjectRow {
+  return {
+    id: project.id,
+    name: project.name,
+    state: project.state,
+    activeSessions: quotaLabel(
+      project.usage.active_sessions,
+      project.usage.max_active_sessions,
+    ),
+    activeWorkflowRuns: quotaLabel(
+      project.usage.active_workflow_runs,
+      project.usage.max_active_workflow_runs,
+    ),
+    retainedStorage: storageLabel(
+      project.usage.retained_storage_bytes,
+      project.usage.max_retained_storage_bytes,
+    ),
+  };
+}
+
+function quotaLabel(current: number, limit: number | null | undefined): string {
+  return limit === null || limit === undefined ? `${current}` : `${current}/${limit}`;
+}
+
+function storageLabel(current: number, limit: number | null | undefined): string {
+  const currentLabel = formatBytes(current);
+  return limit === null || limit === undefined
+    ? currentLabel
+    : `${currentLabel} / ${formatBytes(limit)}`;
+}
+
+function formatBytes(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return '0 B';
+  }
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let unitIndex = 0;
+  let next = value;
+  while (next >= 1024 && unitIndex < units.length - 1) {
+    next /= 1024;
+    unitIndex += 1;
+  }
+  return `${next >= 10 || unitIndex === 0 ? next.toFixed(0) : next.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function formatDateTime(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+function shortId(value: string): string {
+  return value.length > 13 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}

--- a/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
+++ b/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
@@ -283,6 +283,66 @@ describe('bpane operator CLI', () => {
     });
   });
 
+  it('reports the authenticated identity through the gateway API', async () => {
+    const io = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({
+      subject: 'legacy-dev-token:abc123',
+      issuer: 'bpane-gateway',
+      display_name: null,
+      client_id: null,
+      principal_type: 'legacy_dev_token',
+    }));
+
+    const code = await runBpaneCli(
+      ['identity', 'me', '--base-url', 'http://bpane.example/root/'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      io.io,
+      fetchImpl,
+    );
+
+    expect(code).toBe(EXIT_CODES.ok);
+    expect(parseStdout(io)).toMatchObject({
+      subject: 'legacy-dev-token:abc123',
+      principal_type: 'legacy_dev_token',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://bpane.example/api/v1/identity/me');
+    expect(calls[0].init.headers.Authorization).toBe('Bearer token-1');
+  });
+
+  it('reports the access-review payload through the gateway API', async () => {
+    const io = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({
+      principal: {
+        subject: 'demo',
+        issuer: 'http://localhost:8091/realms/browserpane',
+        display_name: 'demo',
+        client_id: 'bpane-web',
+        principal_type: 'user',
+      },
+      generated_at: '2026-05-29T10:00:00Z',
+      projects: [{ id: 'project-1', name: 'support', usage: { active_sessions: 1 } }],
+      resource_counts: { projects: 1, sessions: 1, delegated_principals: 1 },
+      delegated_principals: [{ client_id: 'bpane-mcp-bridge', session_count: 1 }],
+    }));
+
+    const code = await runBpaneCli(
+      ['identity', 'access-review'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      io.io,
+      fetchImpl,
+    );
+
+    expect(code).toBe(EXIT_CODES.ok);
+    expect(parseStdout(io)).toMatchObject({
+      principal: { subject: 'demo', principal_type: 'user' },
+      resource_counts: { projects: 1, sessions: 1, delegated_principals: 1 },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('http://localhost:8080/api/v1/identity/access-review');
+    expect(calls[0].init.headers.Authorization).toBe('Bearer token-1');
+  });
+
   it('lists sessions through the owner-scoped API', async () => {
     const io = createIo();
     const { calls, fetchImpl } = createFetch(jsonResponse({ sessions: [{ id: 'session-1' }] }));

--- a/code/web/bpane-client/scripts/bpane-cli.mjs
+++ b/code/web/bpane-client/scripts/bpane-cli.mjs
@@ -101,6 +101,8 @@ function usageText() {
     '  bpane profile init [profile-name] [options]',
     '  bpane profile list [options]',
     '  bpane profile show [profile-name] [options]',
+    '  bpane identity me [options]',
+    '  bpane identity access-review [options]',
     '  bpane session create [options]',
     '  bpane session list [options]',
     '  bpane session get <session-id> [options]',
@@ -2060,6 +2062,17 @@ async function handleSessionCommand(config, positionals, options) {
   throw new CliError('USAGE', `Unknown session command: ${action ?? ''}`.trim(), EXIT_CODES.usage);
 }
 
+async function handleIdentityCommand(config, positionals) {
+  const action = positionals[1];
+  if (action === 'me' && positionals.length === 2) {
+    return await requestGateway(config, '/api/v1/identity/me');
+  }
+  if (action === 'access-review' && positionals.length === 2) {
+    return await requestGateway(config, '/api/v1/identity/access-review');
+  }
+  throw new CliError('USAGE', `Unknown identity command: ${action ?? ''}`.trim(), EXIT_CODES.usage);
+}
+
 async function handleSessionTemplateCommand(config, positionals, options) {
   const action = positionals[1];
   if (action === 'create' && positionals.length <= 3) {
@@ -2508,6 +2521,9 @@ export async function runBpaneCli(argv, env = process.env, io = process, fetchIm
     let result;
     if (scope === 'profile') {
       result = await handleProfileCommand(options, env, positionals);
+    } else if (scope === 'identity') {
+      const config = await buildConfig(options, env, fetchImpl);
+      result = await handleIdentityCommand(config, positionals);
     } else if (scope === 'session') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleSessionCommand(config, positionals, options);

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -39,6 +39,7 @@ async function run() {
     sessionId = await resolveSelectedSessionId(page, options);
     await waitForMcpDelegationReady(page, options);
     await waitForBrowserConnected(page, options);
+    await verifyIdentityPanel(page, options);
     await expectSessionDisconnectControl(page);
     await verifySessionSwitchDisconnect(page, options, sessionId);
     await expectGlobalMessage(page, options, (message) => message.trim().length > 0);
@@ -106,6 +107,31 @@ async function verifyBrowserPolicyPanel(page) {
   if (!copyEnabled) {
     throw new Error('Expected policy CDP probe command to be copyable after browser connect.');
   }
+}
+
+async function verifyIdentityPanel(page, options) {
+  await openAdminTab(page, 'identity');
+  await page.getByTestId('identity-principal-type').waitFor({
+    state: 'visible',
+    timeout: options.connectTimeoutMs,
+  });
+  await poll(
+    'admin identity refresh enabled',
+    async () => await page.getByTestId('identity-refresh').isEnabled(),
+    Boolean,
+    options.connectTimeoutMs,
+    100,
+  );
+  await page.getByTestId('identity-refresh').click();
+  await poll(
+    'admin identity session count',
+    async () => Number(await page.getByTestId('identity-resource-sessions').textContent()),
+    (count) => Number.isFinite(count) && count >= 1,
+    options.connectTimeoutMs,
+    100,
+  );
+  await page.getByTestId('identity-project-list').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await page.getByTestId('identity-delegation-list').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
 }
 
 async function verifyRemainingPanels(page) {

--- a/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
@@ -92,6 +92,11 @@ async function run() {
       throw new Error('CLI profile show did not return the smoke profile.');
     }
 
+    const identity = runBpaneCli(['identity', 'me'], cliEnv);
+    if (!identity.subject || !identity.issuer || !['user', 'service_principal', 'legacy_dev_token'].includes(identity.principal_type)) {
+      throw new Error(`CLI identity me returned unexpected data: ${JSON.stringify(identity)}`);
+    }
+
     const project = runBpaneCli([
       'project',
       'create',
@@ -484,6 +489,19 @@ async function run() {
     const authorized = runBpaneCli(['mcp', 'authorize', sessionId], cliEnv);
     if (authorized.id !== sessionId) {
       throw new Error('CLI MCP authorize did not return the session.');
+    }
+
+    const accessReview = runBpaneCli(['identity', 'access-review'], cliEnv);
+    if (
+      accessReview.principal?.subject !== identity.subject
+      || accessReview.resource_counts?.sessions < 1
+      || accessReview.resource_counts?.projects < 1
+      || !Array.isArray(accessReview.projects)
+      || !accessReview.projects.some((item) => item.id === projectId)
+      || !Array.isArray(accessReview.delegated_principals)
+      || !accessReview.delegated_principals.some((item) => item.client_id === bridge.clientId)
+    ) {
+      throw new Error(`CLI identity access-review returned unexpected data: ${JSON.stringify(accessReview)}`);
     }
 
     const defaulted = runBpaneCli(['mcp', 'set-default', sessionId], cliEnv);

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -16,6 +16,7 @@ servers:
     description: Same-origin local web proxy
 tags:
   - name: Admin Events
+  - name: Identity
   - name: Sessions
   - name: Session Templates
   - name: Projects
@@ -54,6 +55,44 @@ paths:
           description: WebSocket upgraded; text messages contain admin snapshot events or admin.error payloads.
         '401':
           $ref: '#/components/responses/Unauthorized'
+  /api/v1/identity/me:
+    get:
+      tags: [Identity]
+      summary: Describe the authenticated owner principal
+      operationId: getCurrentIdentity
+      description: >
+        Returns normalized metadata for the bearer principal currently calling
+        the owner-scoped control plane. No secrets or raw token claims are
+        returned.
+      responses:
+        '200':
+          description: Authenticated principal metadata
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityPrincipalResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+  /api/v1/identity/access-review:
+    get:
+      tags: [Identity]
+      summary: Export the authenticated owner's access-review summary
+      operationId: getIdentityAccessReview
+      description: >
+        Returns a sanitized owner-scoped access review with the current
+        principal, project usage, resource counts, and delegated automation
+        principals visible through the session catalog.
+      responses:
+        '200':
+          description: Owner-scoped access review
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IdentityAccessReviewResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions:
     get:
       tags: [Sessions]
@@ -5401,6 +5440,153 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProjectResource'
+    IdentityPrincipalType:
+      type: string
+      enum:
+        - user
+        - service_principal
+        - legacy_dev_token
+    IdentityPrincipalResource:
+      type: object
+      additionalProperties: false
+      required:
+        - subject
+        - issuer
+        - display_name
+        - client_id
+        - principal_type
+      properties:
+        subject:
+          type: string
+        issuer:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        client_id:
+          type: string
+          nullable: true
+        principal_type:
+          $ref: '#/components/schemas/IdentityPrincipalType'
+    IdentityResourceCounts:
+      type: object
+      additionalProperties: false
+      required:
+        - projects
+        - sessions
+        - active_sessions
+        - session_templates
+        - browser_contexts
+        - egress_profiles
+        - credential_bindings
+        - file_workspaces
+        - workflow_definitions
+        - workflow_runs
+        - active_workflow_runs
+        - automation_tasks
+        - active_automation_tasks
+        - extension_definitions
+        - delegated_principals
+      properties:
+        projects:
+          type: integer
+          minimum: 0
+        sessions:
+          type: integer
+          minimum: 0
+        active_sessions:
+          type: integer
+          minimum: 0
+        session_templates:
+          type: integer
+          minimum: 0
+        browser_contexts:
+          type: integer
+          minimum: 0
+        egress_profiles:
+          type: integer
+          minimum: 0
+        credential_bindings:
+          type: integer
+          minimum: 0
+        file_workspaces:
+          type: integer
+          minimum: 0
+        workflow_definitions:
+          type: integer
+          minimum: 0
+        workflow_runs:
+          type: integer
+          minimum: 0
+        active_workflow_runs:
+          type: integer
+          minimum: 0
+        automation_tasks:
+          type: integer
+          minimum: 0
+        active_automation_tasks:
+          type: integer
+          minimum: 0
+        extension_definitions:
+          type: integer
+          minimum: 0
+        delegated_principals:
+          type: integer
+          minimum: 0
+    IdentityDelegatedPrincipalResource:
+      type: object
+      additionalProperties: false
+      required:
+        - client_id
+        - issuer
+        - display_name
+        - session_count
+        - active_session_count
+        - session_ids
+      properties:
+        client_id:
+          type: string
+        issuer:
+          type: string
+        display_name:
+          type: string
+          nullable: true
+        session_count:
+          type: integer
+          minimum: 0
+        active_session_count:
+          type: integer
+          minimum: 0
+        session_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+    IdentityAccessReviewResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - principal
+        - generated_at
+        - projects
+        - resource_counts
+        - delegated_principals
+      properties:
+        principal:
+          $ref: '#/components/schemas/IdentityPrincipalResource'
+        generated_at:
+          type: string
+          format: date-time
+        projects:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProjectResource'
+        resource_counts:
+          $ref: '#/components/schemas/IdentityResourceCounts'
+        delegated_principals:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityDelegatedPrincipalResource'
     ProjectAdmissionState:
       type: string
       enum:


### PR DESCRIPTION
## Summary

This PR implements the first BrowserPane identity/access-review slice for #52. It adds a normalized authenticated-principal surface, a sanitized owner-scoped access-review snapshot, CLI commands, and an admin Identity tab so operators can inspect who is calling the control plane, what resources are visible to that principal, and which automation principals are delegated to visible sessions.

The PR intentionally does not close #52. The remaining issue scope still covers service-principal lifecycle, API key/credential rotation, group/claim-to-project mapping, provisioning/deprovisioning, access-review exports, and audit/event integration.

## Changes

- Add `GET /api/v1/identity/me` and `GET /api/v1/identity/access-review`.
- Classify principals as `user`, `service_principal`, or `legacy_dev_token` without changing authentication behavior.
- Include project usage, resource counts, active session/workflow/task counts, and delegated automation principal summaries in the access-review response.
- Add `./scripts/bpane identity me` and `./scripts/bpane identity access-review`.
- Add an admin Operations Overlay Identity tab with loading, empty, error, and refresh states.
- Update OpenAPI, README, ARCH, CLI smoke, admin session smoke, and compose API coverage.

## Validation

- `cargo test -p bpane-gateway`
- `cargo test -p bpane-gateway --test compose_api_surface compose_identity_access_review_api_surface -- --ignored --test-threads=1`
- `cd code/web/bpane-client && npm test`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && npm run build`
- `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`
- `cd code/web/bpane-client && npm run smoke:admin-session -- --headless`
- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm run build`

Refs #52