### PR TITLE
Add service-principal registry and access-review linkage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Current product shape:
 - Exclusive browser-owner mode: optional in `bpane-gateway` via `--exclusive-browser-owner`; default is disabled.
 - Viewer cap: configurable in `bpane-gateway` via `--max-viewers`, default `10` for restricted browser viewers.
 - MCP automation: supported via `mcp-bridge` and gateway ownership APIs.
+- Service-principal registry: owner-scoped external OIDC client metadata is supported through `/api/v1/service-principals`; disabled registered principals cannot be assigned as new automation delegates.
 - Browser extensions: owner-approved unpacked extensions are supported for docker-backed sessions and workflow runs; `static_single` does not support session extension sets.
 - Egress traffic logging is proxy-side. BrowserPane should expose sanitized
   session/profile/container correlation metadata, while the configured egress
@@ -67,7 +68,7 @@ Current product shape:
   - WebTransport gateway and shared-session coordinator.
   - `transport.rs`: browser connection loop, per-client policy, relay behavior.
   - `session_hub.rs`: fan-out, late-join bootstrap, viewer cap, telemetry.
-  - `session_control.rs`: versioned session-control store and Postgres integration, including projects with admission quotas, session templates, browser contexts, workflows, credential bindings, file workspaces, and approved extension metadata.
+  - `session_control.rs`: versioned session-control store and Postgres integration, including projects with admission quotas, service principals, session templates, browser contexts, workflows, credential bindings, file workspaces, and approved extension metadata.
   - `browser_contexts/retention.rs`: background cleanup for ready reusable browser contexts whose per-context retention window expired; runtime-backed cleanup skips active writers and removes docker profile volumes through the session manager. Browser context resources can also carry per-context profile storage limits; the API reports over-limit usage and blocks new reusable sessions from contexts whose inspected profile storage exceeds that limit. Inactive reusable contexts can be cloned into new owner-scoped reusable contexts, exported as zip archives, or imported from BrowserPane export archives into new reusable contexts; docker-backed runtimes copy, package, or restore profile volume data when present.
   - `session_manager.rs`: internal gateway boundary for session runtime lifecycle. The rest of the gateway should depend on this façade instead of backend details.
   - `credential_provider.rs`: credential binding secret-provider boundary. Local compose uses HashiCorp Vault dev mode and the current implementation targets Vault KV v2.

--- a/ARCH.md
+++ b/ARCH.md
@@ -259,12 +259,16 @@ service.
   - if a browser client is already active, that browser-defined input/ownership
     state remains authoritative while MCP automation attaches alongside it
 - **Auth** (`auth/`): OIDC/JWT validation for browser and API clients, plus legacy HMAC token compatibility for migration and tests
-- **Identity/access review** (`api/identity.rs`): bearer-principal summary plus sanitized owner-scoped resource counts, project usage, and delegated automation-principal summaries
+- **Identity/access review** (`api/identity.rs`, `api/service_principals.rs`): bearer-principal summary, owner-scoped service-principal registry metadata, sanitized resource counts, project usage, and delegated automation-principal summaries
 - **Heartbeat**: disconnects after 15s without CONTROL ping
 - **HTTP API** (`api.rs`, :8932):
   - canonical frozen v1 contract: `openapi/bpane-control-v1.yaml`
   - `GET /api/v1/identity/me` — normalized current bearer principal, classified as user, service principal, or legacy dev token
-  - `GET /api/v1/identity/access-review` — sanitized owner-scoped access review with project usage, resource counts, and automation delegations
+  - `GET /api/v1/identity/access-review` — sanitized owner-scoped access review with service-principal registry metadata, project usage, resource counts, and automation delegations
+  - `POST /api/v1/service-principals` — register an owner-scoped external OIDC client as a service principal
+  - `GET /api/v1/service-principals` — list owner-scoped service principals with lifecycle and last-observed metadata
+  - `GET /api/v1/service-principals/{id}` — fetch one owner-scoped service principal
+  - `PUT /api/v1/service-principals/{id}` — replace one owner-scoped service principal, including active/disabled state
   - `POST /api/v1/sessions` — create a persistent session resource
   - `GET /api/v1/sessions` — list owner-scoped sessions, with catalog filters for template id, lifecycle/runtime state, labels, integration context, limit, and offset
   - `GET /api/v1/sessions/{id}` — fetch one owner-scoped session resource
@@ -479,7 +483,7 @@ The default dev stack no longer uses a shared token file.
 - the admin console discovers the OIDC provider and performs Authorization Code + PKCE
 - local browser users authenticate against Keycloak on `http://localhost:8091`
 - the local demo user is `demo / demo-demo`
-- after login, the admin console lists owner-scoped `/api/v1/sessions`, projects, session templates, egress profiles, browser contexts, and the current `/api/v1/identity/access-review`; it lets the user join an existing session, start a new one with optional project, template, network-identity, egress-profile, and reusable-context bindings, inspect project/admission metadata on live rows and session detail views, inspect the current principal, resource counts, project usage, and delegated automation principals in the Identity tab, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
+- after login, the admin console lists owner-scoped `/api/v1/sessions`, projects, session templates, egress profiles, browser contexts, and the current `/api/v1/identity/access-review`; it lets the user join an existing session, start a new one with optional project, template, network-identity, egress-profile, and reusable-context bindings, inspect project/admission metadata on live rows and session detail views, inspect the current principal, resource counts, project usage, registered service principals, and delegated automation principals in the Identity tab, inspect API-backed reusable context references, active writer state, profile storage usage, storage-limit state, and retention expiry, clone or export inactive reusable contexts, import BrowserPane export archives as new reusable contexts, and delete unused contexts in the operations overlay or `/admin/browser-contexts`, then uses the selected session resource's connect metadata
 - docker-backed reusable browser contexts mount a context-scoped Chromium profile volume at the session profile path while keeping uploads, downloads, and session-file mounts in the session-scoped data volume; runtime admission allows only one active writer per reusable context
 - browser-context retention cleanup is metadata-driven per context and removes expired reusable profile data only when the runtime manager confirms there is no active writer
 - the console then mints a short-lived `session_connect_ticket` through `POST /api/v1/sessions/{id}/access-tokens`
@@ -548,7 +552,7 @@ The supported local operator CLI lives in
 `code/web/bpane-client/scripts/bpane-cli.mjs`, is exposed as the package binary
 `bpane`, and has a repo-level wrapper at `scripts/bpane`.
 
-- Commands cover profile inspection/init, identity me/access-review, project create/list/get/usage/update/archive,
+- Commands cover profile inspection/init, identity me/access-review, service-principal create/list/get/update/disable, project create/list/get/usage/update/archive,
   egress-profile create/list/get, session create/list/get/status with project
   and network-identity options, access-ticket and automation-access minting,
   connection disconnect, stop, kill, and bounded cleanup. Egress-profile

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Current support and scope:
 - Shared sessions: collaborative by default, intended for small curated groups rather than broadcast-scale delivery.
 - Owner/viewer mode: optional exclusive-owner mode is supported in the gateway; restricted viewers are read-only.
 - Camera: disabled by default in the compose stack and requires browser H.264 encode support plus a mapped `v4l2loopback` device.
-- Control plane: owner-scoped v1 APIs now cover identity/access-review summaries, projects, sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
+- Control plane: owner-scoped v1 APIs now cover identity/access-review summaries, service principals, projects, sessions, session templates, egress profiles, automation tasks, session recordings, workflow definitions/runs, file workspaces, credential bindings, and approved extensions.
 - Workflow execution: Git-backed workflow versions run through a gateway-managed `workflow-worker`; the current executor model is Playwright.
 - Workflow boundary: BrowserPane currently focuses on executing and supervising browser workflows. Broader scheduling, DAG orchestration, and cross-system coordination are expected to sit above BrowserPane rather than inside it.
 
@@ -94,7 +94,7 @@ At a high level, BrowserPane has five responsibilities:
 2. Capture and classify that surface efficiently.
 3. Transport state, input, and media between host and browser.
 4. Render the remote session in a regular web page.
-5. Coordinate durable control-plane resources for projects, sessions,
+5. Coordinate durable control-plane resources for identity, projects, sessions,
    workflows, recordings, files, credentials, extensions, and automation
    ownership.
 
@@ -290,6 +290,10 @@ Canonical contract:
 - `DELETE /api/v1/sessions/{id}`
 - `GET /api/v1/identity/me`
 - `GET /api/v1/identity/access-review`
+- `POST /api/v1/service-principals`
+- `GET /api/v1/service-principals`
+- `GET /api/v1/service-principals/{id}`
+- `PUT /api/v1/service-principals/{id}`
 - `POST /api/v1/browser-contexts`
 - `GET /api/v1/browser-contexts`
 - `GET /api/v1/browser-contexts/{id}`
@@ -339,10 +343,15 @@ show whether a session was admitted under a project quota or left owner-scoped.
 Identity resources expose a sanitized access-review foundation:
 `GET /api/v1/identity/me` returns the current bearer principal as `user`,
 `service_principal`, or `legacy_dev_token`, while
-`GET /api/v1/identity/access-review` returns project usage, owner-scoped
-resource counts, and currently delegated automation principals. The admin
-Operations Overlay has a matching Identity tab, and the operator CLI exposes
-the same payload through `identity me` and `identity access-review`.
+`GET /api/v1/identity/access-review` returns registered service-principal
+metadata, project usage, owner-scoped resource counts, and currently delegated
+automation principals. Owners can register external OIDC clients through
+`/api/v1/service-principals`, use active/disabled state for lifecycle review,
+and block new automation delegation to disabled registered clients while keeping
+existing session metadata inspectable for cleanup. The admin Operations Overlay
+has a matching Identity tab, and the operator CLI exposes the same payload
+through `identity me`, `identity access-review`, and `service-principal`
+commands.
 Network identity metadata lets callers declare locale, language preferences,
 timezone, geolocation, browser identity, user-agent override, and an
 `egress_profile_id` on either a session template or an explicit session create
@@ -567,6 +576,14 @@ Common identity and access-review operations:
 ```bash
 ./scripts/bpane identity me
 ./scripts/bpane identity access-review
+./scripts/bpane service-principal create "MCP bridge" \
+  --client-id bpane-mcp-bridge \
+  --issuer http://localhost:8091/realms/browserpane-dev \
+  --scope session:delegate
+./scripts/bpane service-principal list
+./scripts/bpane service-principal get <service-principal-id>
+./scripts/bpane service-principal update <service-principal-id> --state active
+./scripts/bpane service-principal disable <service-principal-id>
 ```
 
 Common session-template operations:
@@ -745,10 +762,11 @@ destructive cleanup.
 The operator CLI integration smoke is
 `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`. It logs in
 through the admin app, creates a session, initializes a CLI profile, exercises
-identity/access-review, project/session-template/browser-context/egress catalog operations,
-session access/status/diagnostics/disconnect/stop/kill/cleanup, and validates
-standalone MCP health, authorize, set-default, doctor, preflight, repair,
-revoke, and clear-default flows.
+identity/access-review, service-principal registry lifecycle,
+project/session-template/browser-context/egress catalog operations, session
+access/status/diagnostics/disconnect/stop/kill/cleanup, and validates standalone
+MCP health, authorize, set-default, doctor, preflight, repair, revoke, and
+clear-default flows.
 
 Current runtime notes:
 

--- a/code/apps/bpane-gateway/migrations/20260529000100_service_principals.sql
+++ b/code/apps/bpane-gateway/migrations/20260529000100_service_principals.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS control_service_principals (
+    id UUID PRIMARY KEY,
+    owner_subject TEXT NOT NULL,
+    owner_issuer TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    client_id TEXT NOT NULL,
+    issuer TEXT NOT NULL,
+    labels JSONB NOT NULL DEFAULT '{}'::jsonb,
+    scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+    allowed_project_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+    state TEXT NOT NULL DEFAULT 'active',
+    last_seen_at TIMESTAMPTZ,
+    last_delegated_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    UNIQUE (owner_subject, owner_issuer, issuer, client_id)
+);
+
+CREATE INDEX IF NOT EXISTS control_service_principals_owner_idx
+    ON control_service_principals (owner_subject, owner_issuer, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS control_service_principals_external_identity_idx
+    ON control_service_principals (owner_subject, owner_issuer, issuer, client_id);

--- a/code/apps/bpane-gateway/src/api.rs
+++ b/code/apps/bpane-gateway/src/api.rs
@@ -42,15 +42,17 @@ use crate::session_control::{
     EgressProfileState, FailSessionRecordingRequest, PersistBrowserContextRequest,
     PersistCompletedSessionRecordingRequest, PersistEgressDiagnosticsProbeResult,
     PersistEgressProfileReachabilityProbeResult, PersistEgressProfileRequest,
-    PersistProjectRequest, PersistSessionFileBindingRequest, PersistSessionTemplateRequest,
-    ProjectAdmissionDecision, ProjectListResponse, ProjectResource, ProjectUsageResource,
-    SessionBrowserContextMode, SessionEffectiveEgress, SessionLifecycleState, SessionListResponse,
-    SessionNetworkIdentity, SessionOwnerMode, SessionRecordingFormat, SessionRecordingListResponse,
-    SessionRecordingMode, SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
+    PersistProjectRequest, PersistServicePrincipalRequest, PersistSessionFileBindingRequest,
+    PersistSessionTemplateRequest, ProjectAdmissionDecision, ProjectListResponse, ProjectResource,
+    ProjectUsageResource, ServicePrincipalListResponse, ServicePrincipalResource,
+    ServicePrincipalState, SessionBrowserContextMode, SessionEffectiveEgress,
+    SessionLifecycleState, SessionListResponse, SessionNetworkIdentity, SessionOwnerMode,
+    SessionRecordingFormat, SessionRecordingListResponse, SessionRecordingMode,
+    SessionRecordingPolicy, SessionRecordingResource, SessionRecordingState,
     SessionRecordingTerminationReason, SessionResource, SessionStore, SessionStoreError,
     SessionTemplateDefaults, SessionTemplateListResponse, SessionTemplateResource,
     SetAutomationDelegateRequest, StoredBrowserContext, StoredEgressProfile, StoredProject,
-    StoredSession, StoredSessionRecording,
+    StoredServicePrincipal, StoredSession, StoredSessionRecording,
 };
 use crate::session_files::{
     SessionFileBindingListResponse, SessionFileBindingResource, SessionFileListResponse,
@@ -102,6 +104,7 @@ mod recordings;
 mod resources;
 mod router;
 mod runtime_access;
+mod service_principals;
 mod session_bindings;
 mod session_files;
 mod session_templates;

--- a/code/apps/bpane-gateway/src/api/identity.rs
+++ b/code/apps/bpane-gateway/src/api/identity.rs
@@ -26,6 +26,7 @@ struct IdentityPrincipalResource {
 #[derive(Debug, Clone, Serialize)]
 struct IdentityResourceCounts {
     projects: usize,
+    service_principals: usize,
     sessions: usize,
     active_sessions: usize,
     session_templates: usize,
@@ -47,9 +48,21 @@ struct IdentityDelegatedPrincipalResource {
     client_id: String,
     issuer: String,
     display_name: Option<String>,
+    registered: bool,
+    registered_service_principal_id: Option<Uuid>,
+    state: Option<ServicePrincipalState>,
     session_count: usize,
     active_session_count: usize,
     session_ids: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct IdentityServicePrincipalReviewResource {
+    #[serde(flatten)]
+    service_principal: ServicePrincipalResource,
+    delegated_session_count: usize,
+    active_delegated_session_count: usize,
+    delegated_session_ids: Vec<Uuid>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -58,6 +71,7 @@ struct IdentityAccessReviewResponse {
     generated_at: DateTime<Utc>,
     projects: Vec<ProjectResource>,
     resource_counts: IdentityResourceCounts,
+    service_principals: Vec<IdentityServicePrincipalReviewResource>,
     delegated_principals: Vec<IdentityDelegatedPrincipalResource>,
 }
 
@@ -84,6 +98,7 @@ async fn get_current_identity(
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    mark_current_service_principal_seen(&state, &principal).await?;
     Ok(Json(identity_principal_resource(&principal)))
 }
 
@@ -94,9 +109,15 @@ async fn get_identity_access_review(
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    mark_current_service_principal_seen(&state, &principal).await?;
     let projects = state
         .session_store
         .list_projects_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?;
+    let service_principals = state
+        .session_store
+        .list_service_principals_for_owner(&principal)
         .await
         .map_err(map_session_store_error)?;
     let sessions = state
@@ -156,9 +177,12 @@ async fn get_identity_access_review(
         .iter()
         .filter(|session| session.state.is_runtime_candidate())
         .count();
-    let delegated_principals = delegated_principal_resources(&sessions);
+    let delegated_principals = delegated_principal_resources(&sessions, &service_principals);
+    let service_principal_reviews =
+        service_principal_review_resources(&service_principals, &sessions);
     let resource_counts = IdentityResourceCounts {
         projects: projects.len(),
+        service_principals: service_principals.len(),
         sessions: sessions.len(),
         active_sessions,
         session_templates: session_templates.len(),
@@ -186,8 +210,24 @@ async fn get_identity_access_review(
         generated_at: now,
         projects,
         resource_counts,
+        service_principals: service_principal_reviews,
         delegated_principals,
     }))
+}
+
+async fn mark_current_service_principal_seen(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let Some(client_id) = principal.client_id.as_deref() else {
+        return Ok(());
+    };
+    state
+        .session_store
+        .mark_service_principal_seen_for_owner(principal, &principal.issuer, client_id)
+        .await
+        .map_err(map_session_store_error)?;
+    Ok(())
 }
 
 async fn project_resources(
@@ -239,7 +279,21 @@ fn classify_principal(principal: &AuthenticatedPrincipal) -> IdentityPrincipalTy
 
 fn delegated_principal_resources(
     sessions: &[StoredSession],
+    service_principals: &[StoredServicePrincipal],
 ) -> Vec<IdentityDelegatedPrincipalResource> {
+    let service_principal_index = service_principals
+        .iter()
+        .map(|service_principal| {
+            (
+                DelegatedPrincipalKey {
+                    client_id: service_principal.client_id.clone(),
+                    issuer: service_principal.issuer.clone(),
+                    display_name: None,
+                },
+                service_principal,
+            )
+        })
+        .collect::<HashMap<_, _>>();
     let mut groups: HashMap<DelegatedPrincipalKey, IdentityDelegatedPrincipalResource> =
         HashMap::new();
     for session in sessions {
@@ -257,6 +311,9 @@ fn delegated_principal_resources(
                 client_id: delegate.client_id.clone(),
                 issuer: delegate.issuer.clone(),
                 display_name: delegate.display_name.clone(),
+                registered: false,
+                registered_service_principal_id: None,
+                state: None,
                 session_count: 0,
                 active_session_count: 0,
                 session_ids: Vec::new(),
@@ -270,12 +327,76 @@ fn delegated_principal_resources(
 
     let mut resources = groups.into_values().collect::<Vec<_>>();
     for resource in &mut resources {
+        if let Some(service_principal) = service_principal_index.get(&DelegatedPrincipalKey {
+            client_id: resource.client_id.clone(),
+            issuer: resource.issuer.clone(),
+            display_name: None,
+        }) {
+            resource.registered = true;
+            resource.registered_service_principal_id = Some(service_principal.id);
+            resource.state = Some(service_principal.state);
+        }
         resource.session_ids.sort_unstable();
     }
     resources.sort_by(|left, right| {
         left.client_id
             .cmp(&right.client_id)
             .then(left.issuer.cmp(&right.issuer))
+    });
+    resources
+}
+
+fn service_principal_review_resources(
+    service_principals: &[StoredServicePrincipal],
+    sessions: &[StoredSession],
+) -> Vec<IdentityServicePrincipalReviewResource> {
+    let mut resources = service_principals
+        .iter()
+        .map(|service_principal| {
+            let mut delegated_session_ids = sessions
+                .iter()
+                .filter(|session| {
+                    session
+                        .automation_delegate
+                        .as_ref()
+                        .is_some_and(|delegate| {
+                            delegate.client_id == service_principal.client_id
+                                && delegate.issuer == service_principal.issuer
+                        })
+                })
+                .map(|session| session.id)
+                .collect::<Vec<_>>();
+            delegated_session_ids.sort_unstable();
+            let active_delegated_session_count = sessions
+                .iter()
+                .filter(|session| {
+                    session.state.is_runtime_candidate()
+                        && session
+                            .automation_delegate
+                            .as_ref()
+                            .is_some_and(|delegate| {
+                                delegate.client_id == service_principal.client_id
+                                    && delegate.issuer == service_principal.issuer
+                            })
+                })
+                .count();
+            IdentityServicePrincipalReviewResource {
+                service_principal: service_principal.to_resource(),
+                delegated_session_count: delegated_session_ids.len(),
+                active_delegated_session_count,
+                delegated_session_ids,
+            }
+        })
+        .collect::<Vec<_>>();
+    resources.sort_by(|left, right| {
+        left.service_principal
+            .client_id
+            .cmp(&right.service_principal.client_id)
+            .then(
+                left.service_principal
+                    .issuer
+                    .cmp(&right.service_principal.issuer),
+            )
     });
     resources
 }

--- a/code/apps/bpane-gateway/src/api/router.rs
+++ b/code/apps/bpane-gateway/src/api/router.rs
@@ -20,6 +20,7 @@ pub(crate) fn build_api_router(state: Arc<ApiState>) -> Router {
         .merge(extensions::extension_routes())
         .merge(identity::identity_routes())
         .merge(projects::project_routes())
+        .merge(service_principals::service_principal_routes())
         .merge(egress_profiles::egress_profile_routes())
         .merge(credential_bindings::credential_binding_routes())
         .merge(file_workspaces::file_workspace_routes())

--- a/code/apps/bpane-gateway/src/api/service_principals.rs
+++ b/code/apps/bpane-gateway/src/api/service_principals.rs
@@ -1,0 +1,126 @@
+use axum::routing::{get, post};
+
+use super::*;
+
+pub(super) fn service_principal_routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route(
+            "/api/v1/service-principals",
+            post(create_service_principal).get(list_service_principals),
+        )
+        .route(
+            "/api/v1/service-principals/{service_principal_id}",
+            get(get_service_principal).put(update_service_principal),
+        )
+}
+
+async fn list_service_principals(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ServicePrincipalListResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let service_principals = state
+        .session_store
+        .list_service_principals_for_owner(&principal)
+        .await
+        .map_err(map_session_store_error)?
+        .into_iter()
+        .map(|service_principal| service_principal.to_resource())
+        .collect::<Vec<_>>();
+    Ok(Json(ServicePrincipalListResponse { service_principals }))
+}
+
+async fn create_service_principal(
+    headers: HeaderMap,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertServicePrincipalRequest>,
+) -> Result<(StatusCode, Json<ServicePrincipalResource>), (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let service_principal = state
+        .session_store
+        .create_service_principal(&principal, persist_service_principal_request(request))
+        .await
+        .map_err(map_session_store_error)?;
+    Ok((StatusCode::CREATED, Json(service_principal.to_resource())))
+}
+
+async fn get_service_principal(
+    headers: HeaderMap,
+    Path(service_principal_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ServicePrincipalResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let service_principal =
+        load_service_principal(&state, &principal, service_principal_id).await?;
+    Ok(Json(service_principal.to_resource()))
+}
+
+async fn update_service_principal(
+    headers: HeaderMap,
+    Path(service_principal_id): Path<Uuid>,
+    State(state): State<Arc<ApiState>>,
+    Json(request): Json<UpsertServicePrincipalRequest>,
+) -> Result<Json<ServicePrincipalResource>, (StatusCode, Json<ErrorResponse>)> {
+    let principal = authorize_api_request(&headers, &state.auth_validator)
+        .await
+        .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let service_principal = state
+        .session_store
+        .update_service_principal_for_owner(
+            &principal,
+            service_principal_id,
+            persist_service_principal_request(request),
+        )
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("service principal {service_principal_id} not found"),
+                }),
+            )
+        })?;
+    Ok(Json(service_principal.to_resource()))
+}
+
+fn persist_service_principal_request(
+    request: UpsertServicePrincipalRequest,
+) -> PersistServicePrincipalRequest {
+    PersistServicePrincipalRequest {
+        name: request.name,
+        description: request.description,
+        client_id: request.client_id,
+        issuer: request.issuer,
+        labels: request.labels,
+        scopes: request.scopes,
+        allowed_project_ids: request.allowed_project_ids,
+        state: request.state,
+    }
+}
+
+async fn load_service_principal(
+    state: &ApiState,
+    principal: &AuthenticatedPrincipal,
+    service_principal_id: Uuid,
+) -> Result<StoredServicePrincipal, (StatusCode, Json<ErrorResponse>)> {
+    state
+        .session_store
+        .get_service_principal_for_owner(principal, service_principal_id)
+        .await
+        .map_err(map_session_store_error)?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("service principal {service_principal_id} not found"),
+                }),
+            )
+        })
+}

--- a/code/apps/bpane-gateway/src/api/sessions/ownership.rs
+++ b/code/apps/bpane-gateway/src/api/sessions/ownership.rs
@@ -9,9 +9,36 @@ pub(super) async fn set_automation_owner(
     let principal = authorize_api_request(&headers, &state.auth_validator)
         .await
         .map_err(|error| (StatusCode::UNAUTHORIZED, Json(ErrorResponse { error })))?;
+    let delegate_issuer = request
+        .issuer
+        .clone()
+        .unwrap_or_else(|| principal.issuer.clone());
+    let registered_delegate = state
+        .session_store
+        .get_service_principal_for_owner_by_external_identity(
+            &principal,
+            &delegate_issuer,
+            &request.client_id,
+        )
+        .await
+        .map_err(map_session_store_error)?;
+    if registered_delegate
+        .as_ref()
+        .is_some_and(|delegate| delegate.state == ServicePrincipalState::Disabled)
+    {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: format!(
+                    "service principal {} from issuer {} is disabled",
+                    request.client_id, delegate_issuer
+                ),
+            }),
+        ));
+    }
     let stored = state
         .session_store
-        .set_automation_delegate_for_owner(&principal, session_id, request)
+        .set_automation_delegate_for_owner(&principal, session_id, request.clone())
         .await
         .map_err(map_session_store_error)?
         .ok_or_else(|| {
@@ -22,6 +49,17 @@ pub(super) async fn set_automation_owner(
                 }),
             )
         })?;
+    if registered_delegate.is_some() {
+        let _ = state
+            .session_store
+            .mark_service_principal_delegated_for_owner(
+                &principal,
+                &delegate_issuer,
+                &request.client_id,
+            )
+            .await
+            .map_err(map_session_store_error)?;
+    }
 
     Ok(Json(
         session_resource(&state, &stored, None)

--- a/code/apps/bpane-gateway/src/api/tests.rs
+++ b/code/apps/bpane-gateway/src/api/tests.rs
@@ -51,6 +51,7 @@ mod identity;
 mod network_identity;
 mod projects;
 mod recordings;
+mod service_principals;
 mod session_files;
 mod session_templates;
 mod sessions;

--- a/code/apps/bpane-gateway/src/api/tests/service_principals.rs
+++ b/code/apps/bpane-gateway/src/api/tests/service_principals.rs
@@ -1,0 +1,326 @@
+use super::*;
+
+#[tokio::test]
+async fn owner_can_create_list_fetch_and_update_service_principals() {
+    let (app, token) = test_router();
+
+    let invalid = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/service-principals")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": " ",
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": "https://issuer.example"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+
+    let created = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/service-principals")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "MCP bridge",
+                        "description": "Bridge automation identity",
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": "https://issuer.example",
+                        "labels": { "system": "mcp" },
+                        "scopes": ["session:delegate"],
+                        "allowed_project_ids": [],
+                        "state": "active"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::CREATED);
+    let created_body = response_json(created).await;
+    let service_principal_id = created_body["id"].as_str().unwrap().to_string();
+    assert_eq!(created_body["name"], "MCP bridge");
+    assert_eq!(created_body["client_id"], "bpane-mcp-bridge");
+    assert_eq!(created_body["issuer"], "https://issuer.example");
+    assert_eq!(created_body["labels"]["system"], "mcp");
+    assert_eq!(created_body["scopes"][0], "session:delegate");
+    assert_eq!(created_body["state"], "active");
+    assert!(created_body["last_seen_at"].is_null());
+    assert!(created_body["last_delegated_at"].is_null());
+
+    let duplicate = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/service-principals")
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Duplicate MCP bridge",
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": "https://issuer.example"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status(), StatusCode::CONFLICT);
+
+    let listed = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/service-principals")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), StatusCode::OK);
+    let listed_body = response_json(listed).await;
+    assert_eq!(
+        listed_body["service_principals"]
+            .as_array()
+            .expect("service principals should be an array")
+            .len(),
+        1
+    );
+    assert_eq!(
+        listed_body["service_principals"][0]["id"],
+        service_principal_id
+    );
+
+    let fetched = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/service-principals/{service_principal_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched.status(), StatusCode::OK);
+    let fetched_body = response_json(fetched).await;
+    assert_eq!(fetched_body["id"], service_principal_id);
+
+    let updated = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/service-principals/{service_principal_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "Disabled MCP bridge",
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": "https://issuer.example",
+                        "labels": { "system": "mcp", "state": "review" },
+                        "scopes": ["session:delegate", "workflow:run"],
+                        "allowed_project_ids": [],
+                        "state": "disabled"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(updated.status(), StatusCode::OK);
+    let updated_body = response_json(updated).await;
+    assert_eq!(updated_body["id"], service_principal_id);
+    assert_eq!(updated_body["name"], "Disabled MCP bridge");
+    assert_eq!(updated_body["labels"]["state"], "review");
+    assert_eq!(updated_body["scopes"][1], "workflow:run");
+    assert_eq!(updated_body["state"], "disabled");
+}
+
+#[tokio::test]
+async fn disabled_service_principals_block_delegation_and_access_review_correlates_registry() {
+    let (app, token) = test_router();
+    let issuer = "https://issuer.example";
+
+    let service_principal = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/service-principals")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "name": "MCP bridge",
+                            "client_id": "bpane-mcp-bridge",
+                            "issuer": issuer,
+                            "state": "disabled"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let service_principal_id = service_principal["id"].as_str().unwrap().to_string();
+
+    let session = response_json(
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/sessions")
+                    .header("authorization", bearer(&token))
+                    .header("content-type", "application/json")
+                    .body(Body::from(json!({}).to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap(),
+    )
+    .await;
+    let session_id = session["id"].as_str().unwrap().to_string();
+
+    let blocked = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/automation-owner"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": issuer,
+                        "display_name": "BrowserPane MCP bridge"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(blocked.status(), StatusCode::CONFLICT);
+    let blocked_body = response_json(blocked).await;
+    assert!(blocked_body["error"].as_str().unwrap().contains("disabled"));
+
+    let enabled = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri(format!("/api/v1/service-principals/{service_principal_id}"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "name": "MCP bridge",
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": issuer,
+                        "state": "active"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(enabled.status(), StatusCode::OK);
+
+    let delegated = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/sessions/{session_id}/automation-owner"))
+                .header("authorization", bearer(&token))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "client_id": "bpane-mcp-bridge",
+                        "issuer": issuer,
+                        "display_name": "BrowserPane MCP bridge"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(delegated.status(), StatusCode::OK);
+
+    let fetched = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/service-principals/{service_principal_id}"))
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched.status(), StatusCode::OK);
+    let fetched_body = response_json(fetched).await;
+    assert!(fetched_body["last_delegated_at"].is_string());
+
+    let review = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/identity/access-review")
+                .header("authorization", bearer(&token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(review.status(), StatusCode::OK);
+    let review_body = response_json(review).await;
+    assert_eq!(review_body["resource_counts"]["service_principals"], 1);
+    assert_eq!(
+        review_body["service_principals"][0]["id"],
+        service_principal_id
+    );
+    assert_eq!(
+        review_body["service_principals"][0]["delegated_session_count"],
+        1
+    );
+    assert_eq!(
+        review_body["service_principals"][0]["active_delegated_session_count"],
+        1
+    );
+    assert_eq!(
+        review_body["service_principals"][0]["delegated_session_ids"][0],
+        session_id
+    );
+    assert_eq!(review_body["delegated_principals"][0]["registered"], true);
+    assert_eq!(
+        review_body["delegated_principals"][0]["registered_service_principal_id"],
+        service_principal_id
+    );
+    assert_eq!(review_body["delegated_principals"][0]["state"], "active");
+}

--- a/code/apps/bpane-gateway/src/api/types.rs
+++ b/code/apps/bpane-gateway/src/api/types.rs
@@ -24,9 +24,10 @@ use crate::session_control::{
     BrowserContextPersistenceMode, CreateSessionRequest, EgressCustomCaConfig,
     EgressDiagnosticsResource, EgressProfileState, EgressProxyConfig,
     EgressTrafficObservationConfig, ProjectAdmissionDecision, ProjectQuotas, ProjectState,
-    SessionConnectInfo, SessionEffectiveEgress, SessionLifecycleState, SessionNetworkIdentity,
-    SessionOwnerMode, SessionProjectResource, SessionRecordingFormat, SessionRecordingMode,
-    SessionResource, SessionStatusSummary, SessionStore, SessionTemplateDefaults,
+    ServicePrincipalState, SessionConnectInfo, SessionEffectiveEgress, SessionLifecycleState,
+    SessionNetworkIdentity, SessionOwnerMode, SessionProjectResource, SessionRecordingFormat,
+    SessionRecordingMode, SessionResource, SessionStatusSummary, SessionStore,
+    SessionTemplateDefaults,
 };
 use crate::session_files::SessionFileBindingMode;
 use crate::session_hub::{SessionConnectionTelemetryRole, SessionTelemetrySnapshot};
@@ -329,6 +330,27 @@ pub(super) struct UpsertProjectRequest {
 
 fn default_project_state() -> ProjectState {
     ProjectState::Active
+}
+
+#[derive(Deserialize)]
+pub(super) struct UpsertServicePrincipalRequest {
+    pub(super) name: String,
+    #[serde(default)]
+    pub(super) description: Option<String>,
+    pub(super) client_id: String,
+    pub(super) issuer: String,
+    #[serde(default)]
+    pub(super) labels: HashMap<String, String>,
+    #[serde(default)]
+    pub(super) scopes: Vec<String>,
+    #[serde(default)]
+    pub(super) allowed_project_ids: Vec<Uuid>,
+    #[serde(default = "default_service_principal_state")]
+    pub(super) state: ServicePrincipalState,
+}
+
+fn default_service_principal_state() -> ServicePrincipalState {
+    ServicePrincipalState::Active
 }
 
 #[derive(Deserialize)]

--- a/code/apps/bpane-gateway/src/session_control/in_memory.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory.rs
@@ -7,6 +7,7 @@ mod egress_profiles;
 mod projects;
 mod recordings;
 mod runtime_assignments;
+mod service_principals;
 mod session_files;
 mod session_templates;
 mod sessions;

--- a/code/apps/bpane-gateway/src/session_control/in_memory/service_principals.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/service_principals.rs
@@ -1,0 +1,188 @@
+use super::*;
+
+fn owned_service_principal_matches(
+    service_principal: &StoredServicePrincipal,
+    principal: &AuthenticatedPrincipal,
+) -> bool {
+    service_principal.owner_subject == principal.subject
+        && service_principal.owner_issuer == principal.issuer
+}
+
+fn external_identity_matches(
+    service_principal: &StoredServicePrincipal,
+    issuer: &str,
+    client_id: &str,
+) -> bool {
+    service_principal.issuer == issuer && service_principal.client_id == client_id
+}
+
+impl InMemorySessionStore {
+    pub(in crate::session_control) async fn create_service_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<StoredServicePrincipal, SessionStoreError> {
+        let now = Utc::now();
+        let mut service_principals = self.service_principals.lock().await;
+        if service_principals.iter().any(|service_principal| {
+            owned_service_principal_matches(service_principal, principal)
+                && external_identity_matches(service_principal, &request.issuer, &request.client_id)
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "service principal {} from issuer {} already exists",
+                request.client_id, request.issuer
+            )));
+        }
+        let service_principal = StoredServicePrincipal {
+            id: Uuid::now_v7(),
+            owner_subject: principal.subject.clone(),
+            owner_issuer: principal.issuer.clone(),
+            name: request.name,
+            description: request.description,
+            client_id: request.client_id,
+            issuer: request.issuer,
+            labels: request.labels,
+            scopes: request.scopes,
+            allowed_project_ids: request.allowed_project_ids,
+            state: request.state,
+            last_seen_at: None,
+            last_delegated_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        service_principals.push(service_principal.clone());
+        Ok(service_principal)
+    }
+
+    pub(in crate::session_control) async fn list_service_principals_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredServicePrincipal>, SessionStoreError> {
+        let mut service_principals = self
+            .service_principals
+            .lock()
+            .await
+            .iter()
+            .filter(|service_principal| {
+                owned_service_principal_matches(service_principal, principal)
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        service_principals.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+        Ok(service_principals)
+    }
+
+    pub(in crate::session_control) async fn get_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        Ok(self
+            .service_principals
+            .lock()
+            .await
+            .iter()
+            .find(|service_principal| {
+                service_principal.id == id
+                    && owned_service_principal_matches(service_principal, principal)
+            })
+            .cloned())
+    }
+
+    pub(in crate::session_control) async fn get_service_principal_for_owner_by_external_identity(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        Ok(self
+            .service_principals
+            .lock()
+            .await
+            .iter()
+            .find(|service_principal| {
+                owned_service_principal_matches(service_principal, principal)
+                    && external_identity_matches(service_principal, issuer, client_id)
+            })
+            .cloned())
+    }
+
+    pub(in crate::session_control) async fn update_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let mut service_principals = self.service_principals.lock().await;
+        if service_principals.iter().any(|service_principal| {
+            service_principal.id != id
+                && owned_service_principal_matches(service_principal, principal)
+                && external_identity_matches(service_principal, &request.issuer, &request.client_id)
+        }) {
+            return Err(SessionStoreError::Conflict(format!(
+                "service principal {} from issuer {} already exists",
+                request.client_id, request.issuer
+            )));
+        }
+        let Some(service_principal) = service_principals.iter_mut().find(|service_principal| {
+            service_principal.id == id
+                && owned_service_principal_matches(service_principal, principal)
+        }) else {
+            return Ok(None);
+        };
+        service_principal.name = request.name;
+        service_principal.description = request.description;
+        service_principal.client_id = request.client_id;
+        service_principal.issuer = request.issuer;
+        service_principal.labels = request.labels;
+        service_principal.scopes = request.scopes;
+        service_principal.allowed_project_ids = request.allowed_project_ids;
+        service_principal.state = request.state;
+        service_principal.updated_at = Utc::now();
+        Ok(Some(service_principal.clone()))
+    }
+
+    pub(in crate::session_control) async fn mark_service_principal_seen_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.update_service_principal_timestamp(principal, issuer, client_id, true)
+            .await
+    }
+
+    pub(in crate::session_control) async fn mark_service_principal_delegated_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.update_service_principal_timestamp(principal, issuer, client_id, false)
+            .await
+    }
+
+    async fn update_service_principal_timestamp(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+        seen: bool,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let mut service_principals = self.service_principals.lock().await;
+        let Some(service_principal) = service_principals.iter_mut().find(|service_principal| {
+            owned_service_principal_matches(service_principal, principal)
+                && external_identity_matches(service_principal, issuer, client_id)
+        }) else {
+            return Ok(None);
+        };
+        let now = Utc::now();
+        if seen {
+            service_principal.last_seen_at = Some(now);
+        } else {
+            service_principal.last_delegated_at = Some(now);
+        }
+        service_principal.updated_at = now;
+        Ok(Some(service_principal.clone()))
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
+++ b/code/apps/bpane-gateway/src/session_control/in_memory/state.rs
@@ -3,6 +3,7 @@ use super::*;
 pub(in crate::session_control) struct InMemoryStoreState {
     pub(in crate::session_control) browser_contexts: Mutex<Vec<StoredBrowserContext>>,
     pub(in crate::session_control) projects: Mutex<Vec<StoredProject>>,
+    pub(in crate::session_control) service_principals: Mutex<Vec<StoredServicePrincipal>>,
     pub(in crate::session_control) sessions: Mutex<Vec<StoredSession>>,
     pub(in crate::session_control) session_templates: Mutex<Vec<StoredSessionTemplate>>,
     pub(in crate::session_control) egress_profiles: Mutex<Vec<StoredEgressProfile>>,
@@ -46,6 +47,7 @@ impl InMemoryStoreState {
         Self {
             browser_contexts: Mutex::new(Vec::new()),
             projects: Mutex::new(Vec::new()),
+            service_principals: Mutex::new(Vec::new()),
             sessions: Mutex::new(Vec::new()),
             session_templates: Mutex::new(Vec::new()),
             egress_profiles: Mutex::new(Vec::new()),

--- a/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/mod.rs
@@ -10,6 +10,7 @@ mod file_workspaces;
 mod projects;
 mod recordings;
 mod runtime_assignments;
+mod service_principals;
 mod session_files;
 mod session_templates;
 mod sessions;

--- a/code/apps/bpane-gateway/src/session_control/postgres/service_principals.rs
+++ b/code/apps/bpane-gateway/src/session_control/postgres/service_principals.rs
@@ -1,0 +1,364 @@
+use super::*;
+
+const SERVICE_PRINCIPAL_COLUMNS: &str = r#"
+    id,
+    owner_subject,
+    owner_issuer,
+    name,
+    description,
+    client_id,
+    issuer,
+    labels,
+    scopes,
+    allowed_project_ids,
+    state,
+    last_seen_at,
+    last_delegated_at,
+    created_at,
+    updated_at
+"#;
+
+pub(super) struct ServicePrincipalRepository<'a> {
+    store: &'a PostgresSessionStore,
+}
+
+impl PostgresSessionStore {
+    fn service_principal_repository(&self) -> ServicePrincipalRepository<'_> {
+        ServicePrincipalRepository { store: self }
+    }
+
+    pub(in crate::session_control) async fn create_service_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<StoredServicePrincipal, SessionStoreError> {
+        self.service_principal_repository()
+            .create_service_principal(principal, request)
+            .await
+    }
+
+    pub(in crate::session_control) async fn list_service_principals_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .list_service_principals_for_owner(principal)
+            .await
+    }
+
+    pub(in crate::session_control) async fn get_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .get_service_principal_for_owner(principal, id)
+            .await
+    }
+
+    pub(in crate::session_control) async fn get_service_principal_for_owner_by_external_identity(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .get_service_principal_for_owner_by_external_identity(principal, issuer, client_id)
+            .await
+    }
+
+    pub(in crate::session_control) async fn update_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .update_service_principal_for_owner(principal, id, request)
+            .await
+    }
+
+    pub(in crate::session_control) async fn mark_service_principal_seen_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .mark_service_principal_timestamp(principal, issuer, client_id, "last_seen_at")
+            .await
+    }
+
+    pub(in crate::session_control) async fn mark_service_principal_delegated_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        self.service_principal_repository()
+            .mark_service_principal_timestamp(principal, issuer, client_id, "last_delegated_at")
+            .await
+    }
+}
+
+impl ServicePrincipalRepository<'_> {
+    async fn create_service_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<StoredServicePrincipal, SessionStoreError> {
+        let now = Utc::now();
+        let query = format!(
+            r#"
+            INSERT INTO control_service_principals (
+                id,
+                owner_subject,
+                owner_issuer,
+                name,
+                description,
+                client_id,
+                issuer,
+                labels,
+                scopes,
+                allowed_project_ids,
+                state,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10::jsonb, $11, $12, $12)
+            RETURNING
+                {SERVICE_PRINCIPAL_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_one(
+                &query,
+                &[
+                    &Uuid::now_v7(),
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &request.client_id,
+                    &request.issuer,
+                    &json_labels(&request.labels),
+                    &json_string_array(&request.scopes),
+                    &json_uuid_array(&request.allowed_project_ids),
+                    &request.state.as_str(),
+                    &now,
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "service principal {} from issuer {} already exists",
+                        request.client_id, request.issuer
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to create service principal: {error}"))
+            })?;
+        row_to_stored_service_principal(&row)
+    }
+
+    async fn list_service_principals_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredServicePrincipal>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {SERVICE_PRINCIPAL_COLUMNS}
+            FROM control_service_principals
+            WHERE owner_subject = $1
+              AND owner_issuer = $2
+            ORDER BY created_at DESC
+            "#
+        );
+        let rows = self
+            .store
+            .db
+            .client()
+            .await?
+            .query(&query, &[&principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to list service principals: {error}"))
+            })?;
+        rows.iter().map(row_to_stored_service_principal).collect()
+    }
+
+    async fn get_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {SERVICE_PRINCIPAL_COLUMNS}
+            FROM control_service_principals
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(&query, &[&id, &principal.subject, &principal.issuer])
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!("failed to fetch service principal: {error}"))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_service_principal)
+            .transpose()
+    }
+
+    async fn get_service_principal_for_owner_by_external_identity(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let query = format!(
+            r#"
+            SELECT
+                {SERVICE_PRINCIPAL_COLUMNS}
+            FROM control_service_principals
+            WHERE owner_subject = $1
+              AND owner_issuer = $2
+              AND issuer = $3
+              AND client_id = $4
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                &query,
+                &[&principal.subject, &principal.issuer, &issuer, &client_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to fetch service principal by external identity: {error}"
+                ))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_service_principal)
+            .transpose()
+    }
+
+    async fn update_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let query = format!(
+            r#"
+            UPDATE control_service_principals
+            SET
+                name = $4,
+                description = $5,
+                client_id = $6,
+                issuer = $7,
+                labels = $8::jsonb,
+                scopes = $9::jsonb,
+                allowed_project_ids = $10::jsonb,
+                state = $11,
+                updated_at = NOW()
+            WHERE id = $1
+              AND owner_subject = $2
+              AND owner_issuer = $3
+            RETURNING
+                {SERVICE_PRINCIPAL_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                &query,
+                &[
+                    &id,
+                    &principal.subject,
+                    &principal.issuer,
+                    &request.name,
+                    &request.description,
+                    &request.client_id,
+                    &request.issuer,
+                    &json_labels(&request.labels),
+                    &json_string_array(&request.scopes),
+                    &json_uuid_array(&request.allowed_project_ids),
+                    &request.state.as_str(),
+                ],
+            )
+            .await
+            .map_err(|error| {
+                if error.code().is_some_and(|code| code.code() == "23505") {
+                    return SessionStoreError::Conflict(format!(
+                        "service principal {} from issuer {} already exists",
+                        request.client_id, request.issuer
+                    ));
+                }
+                SessionStoreError::Backend(format!("failed to update service principal: {error}"))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_service_principal)
+            .transpose()
+    }
+
+    async fn mark_service_principal_timestamp(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+        column: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        let query = format!(
+            r#"
+            UPDATE control_service_principals
+            SET
+                {column} = NOW(),
+                updated_at = NOW()
+            WHERE owner_subject = $1
+              AND owner_issuer = $2
+              AND issuer = $3
+              AND client_id = $4
+            RETURNING
+                {SERVICE_PRINCIPAL_COLUMNS}
+            "#
+        );
+        let row = self
+            .store
+            .db
+            .client()
+            .await?
+            .query_opt(
+                &query,
+                &[&principal.subject, &principal.issuer, &issuer, &client_id],
+            )
+            .await
+            .map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "failed to update service principal timestamp: {error}"
+                ))
+            })?;
+        row.as_ref()
+            .map(row_to_stored_service_principal)
+            .transpose()
+    }
+}

--- a/code/apps/bpane-gateway/src/session_control/rows.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows.rs
@@ -12,15 +12,17 @@ pub(super) use automation_tasks::{
 };
 pub(super) use encoding::{
     describe_postgres_error, json_applied_extensions, json_labels, json_recording_policy,
-    json_string_array, json_workflow_run_credential_bindings, json_workflow_run_produced_files,
-    json_workflow_run_source_snapshot, json_workflow_run_workspace_inputs, json_workflow_source,
-    recording_mime_type, sync_workflow_run_with_task,
+    json_string_array, json_uuid_array, json_workflow_run_credential_bindings,
+    json_workflow_run_produced_files, json_workflow_run_source_snapshot,
+    json_workflow_run_workspace_inputs, json_workflow_source, recording_mime_type,
+    sync_workflow_run_with_task,
 };
 pub(super) use resources::{
     row_to_stored_browser_context, row_to_stored_credential_binding, row_to_stored_egress_profile,
     row_to_stored_extension_definition, row_to_stored_extension_version,
     row_to_stored_file_workspace, row_to_stored_file_workspace_file, row_to_stored_project,
-    row_to_stored_session_file, row_to_stored_session_file_binding, row_to_stored_session_template,
+    row_to_stored_service_principal, row_to_stored_session_file,
+    row_to_stored_session_file_binding, row_to_stored_session_template,
     row_to_stored_workflow_definition, row_to_stored_workflow_definition_version,
 };
 pub(super) use runtime_assignments::{

--- a/code/apps/bpane-gateway/src/session_control/rows/encoding.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/encoding.rs
@@ -109,6 +109,15 @@ pub(in crate::session_control) fn json_string_array(values: &[String]) -> Value 
     )
 }
 
+pub(in crate::session_control) fn json_uuid_array(values: &[Uuid]) -> Value {
+    Value::Array(
+        values
+            .iter()
+            .map(|value| Value::String(value.to_string()))
+            .collect::<Vec<_>>(),
+    )
+}
+
 pub(in crate::session_control) fn row_to_json_string_array(
     value: Value,
     field_name: &str,
@@ -124,6 +133,22 @@ pub(in crate::session_control) fn row_to_json_string_array(
                 .with_context(|| format!("{field_name} entries must be strings"))
                 .map(|entry| entry.to_string())
                 .map_err(|error| SessionStoreError::Backend(error.to_string()))
+        })
+        .collect()
+}
+
+pub(in crate::session_control) fn row_to_json_uuid_array(
+    value: Value,
+    field_name: &str,
+) -> Result<Vec<Uuid>, SessionStoreError> {
+    row_to_json_string_array(value, field_name)?
+        .into_iter()
+        .map(|entry| {
+            entry.parse::<Uuid>().map_err(|error| {
+                SessionStoreError::Backend(format!(
+                    "{field_name} entries must be UUID strings: {error}"
+                ))
+            })
         })
         .collect()
 }

--- a/code/apps/bpane-gateway/src/session_control/rows/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/rows/resources.rs
@@ -1,5 +1,5 @@
 use super::super::*;
-use super::encoding::row_to_json_string_array;
+use super::encoding::{row_to_json_string_array, row_to_json_uuid_array};
 
 pub(in crate::session_control) fn row_to_stored_browser_context(
     row: &Row,
@@ -101,6 +101,55 @@ pub(in crate::session_control) fn row_to_stored_project(
         labels,
         quotas,
         state,
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    })
+}
+
+pub(in crate::session_control) fn row_to_stored_service_principal(
+    row: &Row,
+) -> Result<StoredServicePrincipal, SessionStoreError> {
+    let state = row
+        .get::<_, String>("state")
+        .parse::<ServicePrincipalState>()
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?;
+    let labels_value: Value = row.get("labels");
+    let labels = labels_value
+        .as_object()
+        .context("service principal labels column must be a JSON object")
+        .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+        .iter()
+        .map(|(key, value)| {
+            Ok((
+                key.clone(),
+                value
+                    .as_str()
+                    .context("service principal label values must be strings")
+                    .map_err(|error| SessionStoreError::Backend(error.to_string()))?
+                    .to_string(),
+            ))
+        })
+        .collect::<Result<HashMap<_, _>, SessionStoreError>>()?;
+    let scopes = row_to_json_string_array(row.get("scopes"), "service principal scopes")?;
+    let allowed_project_ids = row_to_json_uuid_array(
+        row.get("allowed_project_ids"),
+        "service principal allowed_project_ids",
+    )?;
+
+    Ok(StoredServicePrincipal {
+        id: row.get("id"),
+        owner_subject: row.get("owner_subject"),
+        owner_issuer: row.get("owner_issuer"),
+        name: row.get("name"),
+        description: row.get("description"),
+        client_id: row.get("client_id"),
+        issuer: row.get("issuer"),
+        labels,
+        scopes,
+        allowed_project_ids,
+        state,
+        last_seen_at: row.get("last_seen_at"),
+        last_delegated_at: row.get("last_delegated_at"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
     })

--- a/code/apps/bpane-gateway/src/session_control/store/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/store/resources.rs
@@ -1,6 +1,136 @@
 use super::*;
 
 impl SessionStore {
+    pub async fn create_service_principal(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<StoredServicePrincipal, SessionStoreError> {
+        validate_service_principal_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.create_service_principal(principal, request).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.create_service_principal(principal, request).await
+            }
+        }
+    }
+
+    pub async fn list_service_principals_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+    ) -> Result<Vec<StoredServicePrincipal>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.list_service_principals_for_owner(principal).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.list_service_principals_for_owner(principal).await
+            }
+        }
+    }
+
+    pub async fn get_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store.get_service_principal_for_owner(principal, id).await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store.get_service_principal_for_owner(principal, id).await
+            }
+        }
+    }
+
+    pub async fn update_service_principal_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        id: Uuid,
+        request: PersistServicePrincipalRequest,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        validate_service_principal_request(&request)?;
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .update_service_principal_for_owner(principal, id, request)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .update_service_principal_for_owner(principal, id, request)
+                    .await
+            }
+        }
+    }
+
+    pub async fn get_service_principal_for_owner_by_external_identity(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .get_service_principal_for_owner_by_external_identity(
+                        principal, issuer, client_id,
+                    )
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .get_service_principal_for_owner_by_external_identity(
+                        principal, issuer, client_id,
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn mark_service_principal_seen_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .mark_service_principal_seen_for_owner(principal, issuer, client_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .mark_service_principal_seen_for_owner(principal, issuer, client_id)
+                    .await
+            }
+        }
+    }
+
+    pub async fn mark_service_principal_delegated_for_owner(
+        &self,
+        principal: &AuthenticatedPrincipal,
+        issuer: &str,
+        client_id: &str,
+    ) -> Result<Option<StoredServicePrincipal>, SessionStoreError> {
+        match &self.backend {
+            SessionStoreBackend::InMemory(store) => {
+                store
+                    .mark_service_principal_delegated_for_owner(principal, issuer, client_id)
+                    .await
+            }
+            SessionStoreBackend::Postgres(store) => {
+                store
+                    .mark_service_principal_delegated_for_owner(principal, issuer, client_id)
+                    .await
+            }
+        }
+    }
+
     pub async fn create_project(
         &self,
         principal: &AuthenticatedPrincipal,

--- a/code/apps/bpane-gateway/src/session_control/types/sessions.rs
+++ b/code/apps/bpane-gateway/src/session_control/types/sessions.rs
@@ -452,6 +452,107 @@ pub struct ProjectListResponse {
     pub projects: Vec<ProjectResource>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServicePrincipalState {
+    Active,
+    Disabled,
+}
+
+impl ServicePrincipalState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Disabled => "disabled",
+        }
+    }
+}
+
+impl FromStr for ServicePrincipalState {
+    type Err = &'static str;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "active" => Ok(Self::Active),
+            "disabled" => Ok(Self::Disabled),
+            _ => Err("unknown service principal state"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PersistServicePrincipalRequest {
+    pub name: String,
+    pub description: Option<String>,
+    pub client_id: String,
+    pub issuer: String,
+    pub labels: HashMap<String, String>,
+    pub scopes: Vec<String>,
+    pub allowed_project_ids: Vec<Uuid>,
+    pub state: ServicePrincipalState,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredServicePrincipal {
+    pub id: Uuid,
+    pub owner_subject: String,
+    pub owner_issuer: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub client_id: String,
+    pub issuer: String,
+    pub labels: HashMap<String, String>,
+    pub scopes: Vec<String>,
+    pub allowed_project_ids: Vec<Uuid>,
+    pub state: ServicePrincipalState,
+    pub last_seen_at: Option<DateTime<Utc>>,
+    pub last_delegated_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ServicePrincipalResource {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub client_id: String,
+    pub issuer: String,
+    pub labels: HashMap<String, String>,
+    pub scopes: Vec<String>,
+    pub allowed_project_ids: Vec<Uuid>,
+    pub state: ServicePrincipalState,
+    pub last_seen_at: Option<DateTime<Utc>>,
+    pub last_delegated_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ServicePrincipalListResponse {
+    pub service_principals: Vec<ServicePrincipalResource>,
+}
+
+impl StoredServicePrincipal {
+    pub fn to_resource(&self) -> ServicePrincipalResource {
+        ServicePrincipalResource {
+            id: self.id,
+            name: self.name.clone(),
+            description: self.description.clone(),
+            client_id: self.client_id.clone(),
+            issuer: self.issuer.clone(),
+            labels: self.labels.clone(),
+            scopes: self.scopes.clone(),
+            allowed_project_ids: self.allowed_project_ids.clone(),
+            state: self.state,
+            last_seen_at: self.last_seen_at,
+            last_delegated_at: self.last_delegated_at,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
+    }
+}
+
 impl StoredProject {
     pub fn usage(&self, active_sessions: u32, observed_at: DateTime<Utc>) -> ProjectUsageResource {
         ProjectUsageResource {
@@ -1394,7 +1495,7 @@ impl StoredSessionTemplate {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct SetAutomationDelegateRequest {
     pub client_id: String,
     #[serde(default)]

--- a/code/apps/bpane-gateway/src/session_control/validation/mod.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/mod.rs
@@ -17,7 +17,7 @@ pub(super) use resources::{
     validate_browser_context_request, validate_credential_binding_request,
     validate_egress_profile_request, validate_extension_definition_request,
     validate_extension_version_request, validate_file_workspace_file_request,
-    validate_file_workspace_request, validate_project_request,
+    validate_file_workspace_request, validate_project_request, validate_service_principal_request,
     validate_session_file_binding_request, validate_session_file_request,
 };
 pub(super) use sessions::{

--- a/code/apps/bpane-gateway/src/session_control/validation/resources.rs
+++ b/code/apps/bpane-gateway/src/session_control/validation/resources.rs
@@ -106,6 +106,62 @@ pub(in crate::session_control) fn validate_project_request(
     Ok(())
 }
 
+pub(in crate::session_control) fn validate_service_principal_request(
+    request: &PersistServicePrincipalRequest,
+) -> Result<(), SessionStoreError> {
+    if request.name.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "service principal name must not be empty".to_string(),
+        ));
+    }
+    if request.client_id.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "service principal client_id must not be empty".to_string(),
+        ));
+    }
+    if request.issuer.trim().is_empty() {
+        return Err(SessionStoreError::InvalidRequest(
+            "service principal issuer must not be empty".to_string(),
+        ));
+    }
+    if let Some(description) = &request.description {
+        if description.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "service principal description must not be empty when provided".to_string(),
+            ));
+        }
+    }
+    for (key, value) in &request.labels {
+        if key.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "service principal label keys must not be empty".to_string(),
+            ));
+        }
+        if value.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "service principal label values must not be empty".to_string(),
+            ));
+        }
+    }
+    for scope in &request.scopes {
+        if scope.trim().is_empty() {
+            return Err(SessionStoreError::InvalidRequest(
+                "service principal scopes must not contain empty values".to_string(),
+            ));
+        }
+    }
+    if request
+        .allowed_project_ids
+        .iter()
+        .any(|project_id| *project_id == Uuid::nil())
+    {
+        return Err(SessionStoreError::InvalidRequest(
+            "service principal allowed_project_ids must not contain nil UUIDs".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub(in crate::session_control) fn validate_credential_binding_request(
     request: &PersistCredentialBindingRequest,
 ) -> Result<(), SessionStoreError> {

--- a/code/apps/bpane-gateway/tests/compose_api_surface.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface.rs
@@ -3,9 +3,9 @@ mod suite;
 
 use suite::{
     automation_access_boundaries, browser_contexts, credentials_extensions, identity,
-    network_identity, ownership_boundaries, projects, recording_artifacts, session_churn,
-    session_compatibility, session_templates, sessions_recordings, support, workflow_run_controls,
-    workflows_events, workspaces_automation,
+    network_identity, ownership_boundaries, projects, recording_artifacts, service_principals,
+    session_churn, session_compatibility, session_templates, sessions_recordings, support,
+    workflow_run_controls, workflows_events, workspaces_automation,
 };
 
 #[tokio::test]
@@ -60,6 +60,15 @@ async fn compose_identity_access_review_api_surface() -> anyhow::Result<()> {
     let harness = support::ComposeHarness::connect().await?;
     harness.cleanup_active_sessions().await?;
     identity::run(&harness).await
+}
+
+#[tokio::test]
+#[ignore = "requires running local compose stack"]
+async fn compose_service_principals_api_surface() -> anyhow::Result<()> {
+    let _guard = support::suite_lock().lock().await;
+    let harness = support::ComposeHarness::connect().await?;
+    harness.cleanup_active_sessions().await?;
+    service_principals::run(&harness).await
 }
 
 #[tokio::test]

--- a/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/mod.rs
@@ -6,6 +6,7 @@ pub mod network_identity;
 pub mod ownership_boundaries;
 pub mod projects;
 pub mod recording_artifacts;
+pub mod service_principals;
 pub mod session_churn;
 pub mod session_compatibility;
 pub mod session_templates;

--- a/code/apps/bpane-gateway/tests/compose_api_surface/service_principals.rs
+++ b/code/apps/bpane-gateway/tests/compose_api_surface/service_principals.rs
@@ -1,0 +1,208 @@
+use anyhow::{anyhow, Result};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+
+use super::support::{json_array, json_id, label_map, ComposeHarness};
+
+const LOCAL_REALM_ISSUER: &str = "http://localhost:8091/realms/browserpane-dev";
+
+pub async fn run(harness: &ComposeHarness) -> Result<()> {
+    let invalid = harness
+        .post_json_outcome(
+            "/api/v1/service-principals",
+            json!({
+                "name": "",
+                "client_id": "bpane-mcp-bridge",
+                "issuer": LOCAL_REALM_ISSUER
+            }),
+        )
+        .await?;
+    if invalid.status != StatusCode::BAD_REQUEST {
+        return Err(anyhow!(
+            "invalid service principal create returned {} instead of 400: {}",
+            invalid.status,
+            invalid.body
+        ));
+    }
+
+    let client_id = harness.unique_name("registry-client");
+    let created = harness
+        .post_json(
+            "/api/v1/service-principals",
+            json!({
+                "name": harness.unique_name("compose-service-principal"),
+                "description": "Compose e2e service principal",
+                "client_id": client_id,
+                "issuer": LOCAL_REALM_ISSUER,
+                "labels": label_map("service-principals"),
+                "scopes": ["session:delegate"],
+                "allowed_project_ids": [],
+                "state": "disabled"
+            }),
+        )
+        .await?;
+    let service_principal_id = json_id(&created, "id")?;
+    if created["state"] != json!("disabled")
+        || created["client_id"] != json!(client_id)
+        || created["last_seen_at"] != Value::Null
+        || created["last_delegated_at"] != Value::Null
+    {
+        return Err(anyhow!(
+            "service principal create returned unexpected resource: {created}"
+        ));
+    }
+
+    let duplicate = harness
+        .post_json_outcome(
+            "/api/v1/service-principals",
+            json!({
+                "name": "duplicate",
+                "client_id": client_id,
+                "issuer": LOCAL_REALM_ISSUER
+            }),
+        )
+        .await?;
+    if duplicate.status != StatusCode::CONFLICT {
+        return Err(anyhow!(
+            "duplicate service principal create returned {} instead of 409: {}",
+            duplicate.status,
+            duplicate.body
+        ));
+    }
+
+    let listed = harness.get_json("/api/v1/service-principals").await?;
+    let listed_service_principals = json_array(&listed, "service_principals")?;
+    if !listed_service_principals
+        .iter()
+        .any(|candidate| candidate.get("id") == Some(&json!(service_principal_id)))
+    {
+        return Err(anyhow!(
+            "service principal list did not include {service_principal_id}: {listed}"
+        ));
+    }
+
+    let fetched = harness
+        .get_json(&format!(
+            "/api/v1/service-principals/{service_principal_id}"
+        ))
+        .await?;
+    if fetched["id"] != json!(service_principal_id)
+        || fetched["labels"]["scope"] != json!("service-principals")
+    {
+        return Err(anyhow!(
+            "service principal get returned unexpected resource: {fetched}"
+        ));
+    }
+
+    let session = harness.post_json("/api/v1/sessions", json!({})).await?;
+    let session_id = json_id(&session, "id")?;
+    let result = async {
+        let blocked = harness
+            .post_json_outcome(
+                &format!("/api/v1/sessions/{session_id}/automation-owner"),
+                json!({
+                    "client_id": client_id,
+                    "issuer": LOCAL_REALM_ISSUER,
+                    "display_name": "Disabled registry client"
+                }),
+            )
+            .await?;
+        if blocked.status != StatusCode::CONFLICT
+            || !blocked.body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("disabled")
+        {
+            return Err(anyhow!(
+                "disabled service principal delegation returned unexpected result {}: {}",
+                blocked.status,
+                blocked.body
+            ));
+        }
+
+        let updated = harness
+            .put_json(
+                &format!("/api/v1/service-principals/{service_principal_id}"),
+                json!({
+                    "name": created["name"],
+                    "description": "Compose e2e service principal enabled",
+                    "client_id": client_id,
+                    "issuer": LOCAL_REALM_ISSUER,
+                    "labels": label_map("service-principals"),
+                    "scopes": ["session:delegate", "workflow:run"],
+                    "allowed_project_ids": [],
+                    "state": "active"
+                }),
+            )
+            .await?;
+        if updated["state"] != json!("active") || updated["scopes"][1] != json!("workflow:run") {
+            return Err(anyhow!(
+                "service principal update returned unexpected resource: {updated}"
+            ));
+        }
+
+        let delegated = harness
+            .post_json(
+                &format!("/api/v1/sessions/{session_id}/automation-owner"),
+                json!({
+                    "client_id": client_id,
+                    "issuer": LOCAL_REALM_ISSUER,
+                    "display_name": "Enabled registry client"
+                }),
+            )
+            .await?;
+        if delegated["automation_delegate"]["client_id"] != json!(client_id) {
+            return Err(anyhow!(
+                "service principal delegation response did not expose delegate: {delegated}"
+            ));
+        }
+
+        let reviewed = harness.get_json("/api/v1/identity/access-review").await?;
+        if reviewed["resource_counts"]["service_principals"]
+            .as_u64()
+            .unwrap_or_default()
+            < 1
+        {
+            return Err(anyhow!(
+                "identity access review did not count registered service principals: {reviewed}"
+            ));
+        }
+        let service_principals = json_array(&reviewed, "service_principals")?;
+        let reviewed_service_principal = service_principals
+            .iter()
+            .find(|candidate| candidate.get("id") == Some(&json!(service_principal_id)))
+            .ok_or_else(|| {
+                anyhow!(
+                    "identity access review did not include service principal {service_principal_id}: {reviewed}"
+                )
+            })?;
+        if reviewed_service_principal["delegated_session_count"] != json!(1)
+            || reviewed_service_principal["last_delegated_at"] == Value::Null
+        {
+            return Err(anyhow!(
+                "identity access review did not correlate delegated service principal: {reviewed_service_principal}"
+            ));
+        }
+
+        let delegates = json_array(&reviewed, "delegated_principals")?;
+        let delegate = delegates
+            .iter()
+            .find(|candidate| candidate.get("client_id") == Some(&json!(client_id)))
+            .ok_or_else(|| anyhow!("identity access review did not include delegate {client_id}: {reviewed}"))?;
+        if delegate["registered"] != json!(true)
+            || delegate["registered_service_principal_id"] != json!(service_principal_id)
+        {
+            return Err(anyhow!(
+                "identity access review did not mark delegate as registered: {delegate}"
+            ));
+        }
+
+        Ok(())
+    }
+    .await;
+
+    let stop_result = harness.stop_session_eventually(&session_id).await;
+    result?;
+    stop_result?;
+    Ok(())
+}

--- a/code/web/bpane-admin/src/lib/api/control-client.test.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.test.ts
@@ -137,12 +137,29 @@ const IDENTITY_PRINCIPAL = {
   principal_type: 'user',
 };
 
+const SERVICE_PRINCIPAL = {
+  id: '019df8ec-a5e2-7b00-a14b-173e70c39f7d',
+  name: 'MCP bridge',
+  description: 'Bridge automation identity',
+  client_id: 'bpane-mcp-bridge',
+  issuer: 'http://localhost:8091/realms/browserpane',
+  labels: { system: 'mcp' },
+  scopes: ['session:delegate'],
+  allowed_project_ids: ['019df811-91a5-7b00-9fe5-93403ea57f19'],
+  state: 'active',
+  last_seen_at: null,
+  last_delegated_at: '2026-05-29T10:00:00Z',
+  created_at: '2026-05-29T09:00:00Z',
+  updated_at: '2026-05-29T10:00:00Z',
+};
+
 const ACCESS_REVIEW = {
   principal: IDENTITY_PRINCIPAL,
   generated_at: '2026-05-29T10:00:00Z',
   projects: [PROJECT],
   resource_counts: {
     projects: 1,
+    service_principals: 1,
     sessions: 2,
     active_sessions: 1,
     session_templates: 1,
@@ -158,11 +175,22 @@ const ACCESS_REVIEW = {
     extension_definitions: 0,
     delegated_principals: 1,
   },
+  service_principals: [
+    {
+      ...SERVICE_PRINCIPAL,
+      delegated_session_count: 1,
+      active_delegated_session_count: 1,
+      delegated_session_ids: [SESSION.id],
+    },
+  ],
   delegated_principals: [
     {
       client_id: 'bpane-mcp-bridge',
       issuer: 'http://localhost:8091/realms/browserpane',
       display_name: 'BrowserPane MCP bridge',
+      registered: true,
+      registered_service_principal_id: SERVICE_PRINCIPAL.id,
+      state: 'active',
       session_count: 1,
       active_session_count: 1,
       session_ids: [SESSION.id],
@@ -275,12 +303,20 @@ describe('ControlClient', () => {
       principal: { subject: 'demo', principal_type: 'user' },
       resource_counts: {
         projects: 1,
+        service_principals: 1,
         sessions: 2,
         delegated_principals: 1,
       },
+      service_principals: [
+        {
+          id: SERVICE_PRINCIPAL.id,
+          delegated_session_ids: [SESSION.id],
+        },
+      ],
       delegated_principals: [
         {
           client_id: 'bpane-mcp-bridge',
+          registered: true,
           session_ids: [SESSION.id],
         },
       ],
@@ -294,6 +330,88 @@ describe('ControlClient', () => {
       2,
       new URL('http://localhost:8932/api/v1/identity/access-review'),
       expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('manages service principal registry resources with bearer auth', async () => {
+    const responses = [
+      SERVICE_PRINCIPAL,
+      { service_principals: [SERVICE_PRINCIPAL] },
+      SERVICE_PRINCIPAL,
+      { ...SERVICE_PRINCIPAL, name: 'MCP bridge v2' },
+    ];
+    const fetchImpl = vi.fn<FetchLike>(async () => new Response(JSON.stringify(responses.shift()), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    const client = new ControlClient({
+      baseUrl: 'http://localhost:8932',
+      accessTokenProvider: () => 'owner-token',
+      fetchImpl,
+    });
+
+    const created = await client.createServicePrincipal({
+      name: 'MCP bridge',
+      description: 'Bridge automation identity',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'http://localhost:8091/realms/browserpane',
+      labels: { system: 'mcp' },
+      scopes: ['session:delegate'],
+      allowed_project_ids: ['019df811-91a5-7b00-9fe5-93403ea57f19'],
+    });
+    const listed = await client.listServicePrincipals();
+    await client.getServicePrincipal('service/principal with space');
+    await client.updateServicePrincipal(SERVICE_PRINCIPAL.id, {
+      name: 'MCP bridge v2',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'http://localhost:8091/realms/browserpane',
+      state: 'active',
+    });
+
+    expect(created.id).toBe(SERVICE_PRINCIPAL.id);
+    expect(listed.service_principals).toHaveLength(1);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      new URL('http://localhost:8932/api/v1/service-principals'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'MCP bridge',
+          description: 'Bridge automation identity',
+          client_id: 'bpane-mcp-bridge',
+          issuer: 'http://localhost:8091/realms/browserpane',
+          labels: { system: 'mcp' },
+          scopes: ['session:delegate'],
+          allowed_project_ids: ['019df811-91a5-7b00-9fe5-93403ea57f19'],
+          state: 'active',
+        }),
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      new URL('http://localhost:8932/api/v1/service-principals'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      new URL('http://localhost:8932/api/v1/service-principals/service%2Fprincipal%20with%20space'),
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      4,
+      new URL(`http://localhost:8932/api/v1/service-principals/${SERVICE_PRINCIPAL.id}`),
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({
+          name: 'MCP bridge v2',
+          client_id: 'bpane-mcp-bridge',
+          issuer: 'http://localhost:8091/realms/browserpane',
+          state: 'active',
+          labels: {},
+          scopes: [],
+          allowed_project_ids: [],
+        }),
+      }),
     );
   });
 

--- a/code/web/bpane-admin/src/lib/api/control-client.ts
+++ b/code/web/bpane-admin/src/lib/api/control-client.ts
@@ -16,6 +16,7 @@ import type {
   CreateBrowserContextCommand,
   CreateEgressProfileCommand,
   CreateProjectCommand,
+  CreateServicePrincipalCommand,
   ImportBrowserContextCommand,
   CreateSessionCommand,
   CreateFileWorkspaceCommand,
@@ -32,6 +33,8 @@ import type {
   ProjectListResponse,
   ProjectResource,
   ProjectUsageResource,
+  ServicePrincipalListResponse,
+  ServicePrincipalResource,
   SessionAccessTokenResponse,
   SessionFileBindingListResponse,
   SessionFileBindingResource,
@@ -88,6 +91,41 @@ export class ControlClient {
   async getIdentityAccessReview(): Promise<IdentityAccessReviewResponse> {
     const payload = await this.#request('GET', '/api/v1/identity/access-review');
     return ControlSessionMapper.toIdentityAccessReview(payload);
+  }
+
+  async listServicePrincipals(): Promise<ServicePrincipalListResponse> {
+    const payload = await this.#request('GET', '/api/v1/service-principals');
+    return ControlSessionMapper.toServicePrincipalList(payload);
+  }
+
+  async createServicePrincipal(command: CreateServicePrincipalCommand): Promise<ServicePrincipalResource> {
+    const payload = await this.#request('POST', '/api/v1/service-principals', {
+      ...command,
+      labels: command.labels ?? {},
+      scopes: command.scopes ?? [],
+      allowed_project_ids: command.allowed_project_ids ?? [],
+      state: command.state ?? 'active',
+    });
+    return ControlSessionMapper.toServicePrincipalResource(payload);
+  }
+
+  async getServicePrincipal(servicePrincipalId: string): Promise<ServicePrincipalResource> {
+    const payload = await this.#request('GET', `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`);
+    return ControlSessionMapper.toServicePrincipalResource(payload);
+  }
+
+  async updateServicePrincipal(
+    servicePrincipalId: string,
+    command: CreateServicePrincipalCommand,
+  ): Promise<ServicePrincipalResource> {
+    const payload = await this.#request('PUT', `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`, {
+      ...command,
+      labels: command.labels ?? {},
+      scopes: command.scopes ?? [],
+      allowed_project_ids: command.allowed_project_ids ?? [],
+      state: command.state ?? 'active',
+    });
+    return ControlSessionMapper.toServicePrincipalResource(payload);
   }
 
   async listSessions(filters: SessionListFilters = {}): Promise<SessionListResponse> {

--- a/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
+++ b/code/web/bpane-admin/src/lib/api/control-session-mapper.ts
@@ -20,6 +20,7 @@ import type {
   IdentityPrincipalResource,
   IdentityPrincipalType,
   IdentityResourceCounts,
+  IdentityServicePrincipalReviewResource,
   ProjectAdmissionDecision,
   ProjectAdmissionReasonCode,
   ProjectAdmissionState,
@@ -28,6 +29,9 @@ import type {
   ProjectResource,
   ProjectState,
   ProjectUsageResource,
+  ServicePrincipalListResponse,
+  ServicePrincipalResource,
+  ServicePrincipalState,
   SessionAutomationDelegate,
   SessionBrowserContextMode,
   SessionBrowserContextResource,
@@ -66,9 +70,13 @@ export class ControlSessionMapper {
   static toIdentityAccessReview(payload: unknown): IdentityAccessReviewResponse {
     const object = expectRecord(payload, 'identity access review');
     const projects = object.projects;
+    const servicePrincipals = object.service_principals;
     const delegatedPrincipals = object.delegated_principals;
     if (!Array.isArray(projects)) {
       throw new Error('identity access review must contain a projects array');
+    }
+    if (!Array.isArray(servicePrincipals)) {
+      throw new Error('identity access review must contain a service_principals array');
     }
     if (!Array.isArray(delegatedPrincipals)) {
       throw new Error('identity access review must contain a delegated_principals array');
@@ -78,8 +86,24 @@ export class ControlSessionMapper {
       generated_at: expectString(object.generated_at, 'identity access review generated_at'),
       projects: projects.map((project) => this.toProjectResource(project)),
       resource_counts: toIdentityResourceCounts(object.resource_counts),
+      service_principals: servicePrincipals.map((servicePrincipal) => toIdentityServicePrincipalReview(servicePrincipal)),
       delegated_principals: delegatedPrincipals.map((delegate) => toIdentityDelegatedPrincipal(delegate)),
     };
+  }
+
+  static toServicePrincipalList(payload: unknown): ServicePrincipalListResponse {
+    const object = expectRecord(payload, 'service principal list response');
+    const servicePrincipals = object.service_principals;
+    if (!Array.isArray(servicePrincipals)) {
+      throw new Error('service principal list response must contain a service_principals array');
+    }
+    return {
+      service_principals: servicePrincipals.map((servicePrincipal) => this.toServicePrincipalResource(servicePrincipal)),
+    };
+  }
+
+  static toServicePrincipalResource(payload: unknown): ServicePrincipalResource {
+    return toServicePrincipalResource(payload);
   }
 
   static toProjectList(payload: unknown): ProjectListResponse {
@@ -307,6 +331,7 @@ const PROJECT_ADMISSION_REASON_CODES = [
   'project_archived',
 ] satisfies readonly ProjectAdmissionReasonCode[];
 const IDENTITY_PRINCIPAL_TYPES = ['user', 'service_principal', 'legacy_dev_token'] satisfies readonly IdentityPrincipalType[];
+const SERVICE_PRINCIPAL_STATES = ['active', 'disabled'] satisfies readonly ServicePrincipalState[];
 const EGRESS_PROFILE_STATES = ['ready', 'disabled'] satisfies readonly EgressProfileState[];
 const EGRESS_TRAFFIC_OBSERVATION_MODES = ['metadata_only', 'tls_intercept'] satisfies readonly EgressTrafficObservationMode[];
 const EGRESS_DIAGNOSTICS_HEALTHS = ['ready', 'unknown', 'attention', 'blocked', 'missing'] satisfies readonly EgressDiagnosticsHealth[];
@@ -359,6 +384,7 @@ function toIdentityResourceCounts(value: unknown): IdentityResourceCounts {
   const object = expectRecord(value, 'identity resource counts');
   return {
     projects: expectNumber(object.projects, 'identity resource counts projects'),
+    service_principals: expectNumber(object.service_principals, 'identity resource counts service_principals'),
     sessions: expectNumber(object.sessions, 'identity resource counts sessions'),
     active_sessions: expectNumber(object.active_sessions, 'identity resource counts active_sessions'),
     session_templates: expectNumber(object.session_templates, 'identity resource counts session_templates'),
@@ -379,10 +405,17 @@ function toIdentityResourceCounts(value: unknown): IdentityResourceCounts {
 function toIdentityDelegatedPrincipal(value: unknown): IdentityDelegatedPrincipalResource {
   const object = expectRecord(value, 'identity delegated principal');
   const displayName = optionalString(object.display_name, 'identity delegated principal display_name');
+  const registeredServicePrincipalId = optionalString(
+    object.registered_service_principal_id,
+    'identity delegated principal registered_service_principal_id',
+  );
   return {
     client_id: expectString(object.client_id, 'identity delegated principal client_id'),
     issuer: expectString(object.issuer, 'identity delegated principal issuer'),
     display_name: displayName ?? null,
+    registered: expectBoolean(object.registered, 'identity delegated principal registered'),
+    registered_service_principal_id: registeredServicePrincipalId ?? null,
+    state: optionalServicePrincipalState(object.state, 'identity delegated principal state') ?? null,
     session_count: expectNumber(object.session_count, 'identity delegated principal session_count'),
     active_session_count: expectNumber(
       object.active_session_count,
@@ -390,6 +423,57 @@ function toIdentityDelegatedPrincipal(value: unknown): IdentityDelegatedPrincipa
     ),
     session_ids: toStringArray(object.session_ids ?? [], 'identity delegated principal session_ids'),
   };
+}
+
+function toIdentityServicePrincipalReview(value: unknown): IdentityServicePrincipalReviewResource {
+  const object = expectRecord(value, 'identity service principal review');
+  return {
+    ...toServicePrincipalResource(object),
+    delegated_session_count: expectNumber(
+      object.delegated_session_count,
+      'identity service principal review delegated_session_count',
+    ),
+    active_delegated_session_count: expectNumber(
+      object.active_delegated_session_count,
+      'identity service principal review active_delegated_session_count',
+    ),
+    delegated_session_ids: toStringArray(
+      object.delegated_session_ids ?? [],
+      'identity service principal review delegated_session_ids',
+    ),
+  };
+}
+
+function toServicePrincipalResource(value: unknown): ServicePrincipalResource {
+  const object = expectRecord(value, 'service principal resource');
+  const description = optionalString(object.description, 'service principal description');
+  const lastSeenAt = optionalString(object.last_seen_at, 'service principal last_seen_at');
+  const lastDelegatedAt = optionalString(object.last_delegated_at, 'service principal last_delegated_at');
+  return {
+    id: expectString(object.id, 'service principal id'),
+    name: expectString(object.name, 'service principal name'),
+    description: description ?? null,
+    client_id: expectString(object.client_id, 'service principal client_id'),
+    issuer: expectString(object.issuer, 'service principal issuer'),
+    labels: expectStringRecord(object.labels ?? {}, 'service principal labels'),
+    scopes: toStringArray(object.scopes ?? [], 'service principal scopes'),
+    allowed_project_ids: toStringArray(object.allowed_project_ids ?? [], 'service principal allowed_project_ids'),
+    state: expectEnum(object.state, 'service principal state', SERVICE_PRINCIPAL_STATES),
+    last_seen_at: lastSeenAt ?? null,
+    last_delegated_at: lastDelegatedAt ?? null,
+    created_at: expectString(object.created_at, 'service principal created_at'),
+    updated_at: expectString(object.updated_at, 'service principal updated_at'),
+  };
+}
+
+function optionalServicePrincipalState(
+  value: unknown,
+  label: string,
+): ServicePrincipalState | null | undefined {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  return expectEnum(value, label, SERVICE_PRINCIPAL_STATES);
 }
 
 function toProjectQuotas(value: unknown): ProjectQuotas {

--- a/code/web/bpane-admin/src/lib/api/control-types.ts
+++ b/code/web/bpane-admin/src/lib/api/control-types.ts
@@ -180,6 +180,39 @@ export type ProjectListResponse = {
   readonly projects: readonly ProjectResource[];
 };
 
+export type ServicePrincipalState = 'active' | 'disabled';
+
+export type ServicePrincipalResource = {
+  readonly id: string;
+  readonly name: string;
+  readonly description?: string | null;
+  readonly client_id: string;
+  readonly issuer: string;
+  readonly labels: Readonly<Record<string, string>>;
+  readonly scopes: readonly string[];
+  readonly allowed_project_ids: readonly string[];
+  readonly state: ServicePrincipalState;
+  readonly last_seen_at?: string | null;
+  readonly last_delegated_at?: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type ServicePrincipalListResponse = {
+  readonly service_principals: readonly ServicePrincipalResource[];
+};
+
+export type CreateServicePrincipalCommand = {
+  readonly name: string;
+  readonly description?: string | null;
+  readonly client_id: string;
+  readonly issuer: string;
+  readonly labels?: Readonly<Record<string, string>>;
+  readonly scopes?: readonly string[];
+  readonly allowed_project_ids?: readonly string[];
+  readonly state?: ServicePrincipalState;
+};
+
 export type IdentityPrincipalType = 'user' | 'service_principal' | 'legacy_dev_token';
 
 export type IdentityPrincipalResource = {
@@ -192,6 +225,7 @@ export type IdentityPrincipalResource = {
 
 export type IdentityResourceCounts = {
   readonly projects: number;
+  readonly service_principals: number;
   readonly sessions: number;
   readonly active_sessions: number;
   readonly session_templates: number;
@@ -212,9 +246,18 @@ export type IdentityDelegatedPrincipalResource = {
   readonly client_id: string;
   readonly issuer: string;
   readonly display_name?: string | null;
+  readonly registered: boolean;
+  readonly registered_service_principal_id?: string | null;
+  readonly state?: ServicePrincipalState | null;
   readonly session_count: number;
   readonly active_session_count: number;
   readonly session_ids: readonly string[];
+};
+
+export type IdentityServicePrincipalReviewResource = ServicePrincipalResource & {
+  readonly delegated_session_count: number;
+  readonly active_delegated_session_count: number;
+  readonly delegated_session_ids: readonly string[];
 };
 
 export type IdentityAccessReviewResponse = {
@@ -222,6 +265,7 @@ export type IdentityAccessReviewResponse = {
   readonly generated_at: string;
   readonly projects: readonly ProjectResource[];
   readonly resource_counts: IdentityResourceCounts;
+  readonly service_principals: readonly IdentityServicePrincipalReviewResource[];
   readonly delegated_principals: readonly IdentityDelegatedPrincipalResource[];
 };
 

--- a/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
+++ b/code/web/bpane-admin/src/lib/application/AdminSessionSurface.svelte
@@ -114,6 +114,7 @@
     browserStatus, selectedSessionId: selectedSession?.id ?? null,
     sessionCount: sessions.length, browserContextCount: browserContexts.length,
     egressProfileCount: egressProfiles.length,
+    servicePrincipalCount: identityAccessReview?.resource_counts.service_principals ?? 0,
     delegatedPrincipalCount: identityAccessReview?.resource_counts.delegated_principals ?? 0,
     fileCount: sessionFileCount, connected: browserConnected,
   }));
@@ -165,7 +166,7 @@
         showGlobalMessage(
           'success',
           'Access review refreshed',
-          `${identityAccessReview.resource_counts.sessions} session${identityAccessReview.resource_counts.sessions === 1 ? '' : 's'} and ${identityAccessReview.resource_counts.delegated_principals} delegated principal${identityAccessReview.resource_counts.delegated_principals === 1 ? '' : 's'} refreshed.`,
+          `${identityAccessReview.resource_counts.sessions} session${identityAccessReview.resource_counts.sessions === 1 ? '' : 's'}, ${identityAccessReview.resource_counts.service_principals} service principal${identityAccessReview.resource_counts.service_principals === 1 ? '' : 's'}, and ${identityAccessReview.resource_counts.delegated_principals} delegated principal${identityAccessReview.resource_counts.delegated_principals === 1 ? '' : 's'} refreshed.`,
         );
       }
     } catch (error) {

--- a/code/web/bpane-admin/src/lib/presentation/IdentityAccessReviewPanel.svelte
+++ b/code/web/bpane-admin/src/lib/presentation/IdentityAccessReviewPanel.svelte
@@ -24,7 +24,7 @@
 <section class="grid min-w-0 gap-4" aria-label="Identity access review" data-testid="identity-access-review-panel">
   <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
     <p class="m-0 text-sm leading-normal text-admin-ink/68">
-      Review the authenticated principal, owner-scoped resource counts, and delegated automation access.
+      Review the authenticated principal, owner-scoped resource counts, registered service principals, and delegated automation access.
     </p>
     <button
       class="admin-button-ghost inline-flex items-center gap-2"
@@ -125,6 +125,47 @@
       {/if}
     </section>
 
+    <section class="grid min-w-0 gap-2" aria-label="Service principal registry" data-testid="identity-service-principal-list">
+      <div class="flex items-center justify-between gap-2">
+        <p class="admin-eyebrow m-0">Service principals</p>
+        <span class="text-xs font-bold text-admin-ink/58">{viewModel.servicePrincipals.length}</span>
+      </div>
+      {#if viewModel.servicePrincipals.length === 0}
+        <AdminMessage variant="empty" message="No service principals are registered for this principal." compact={true} />
+      {:else}
+        <div class="grid gap-2">
+          {#each viewModel.servicePrincipals as servicePrincipal (servicePrincipal.id)}
+            <article class="rounded-[12px] border border-[#90a6cc]/16 bg-admin-panel/62 p-3">
+              <div class="grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                <div class="min-w-0">
+                  <strong class="block truncate text-sm font-extrabold text-admin-ink">{servicePrincipal.name}</strong>
+                  <p class="m-0 min-w-0 text-xs font-semibold leading-normal text-admin-ink/58 [overflow-wrap:anywhere]">
+                    {servicePrincipal.clientId} / {servicePrincipal.issuer}
+                  </p>
+                </div>
+                <span class={`w-fit rounded-lg px-2 py-1 text-xs font-bold ${
+                  servicePrincipal.state === 'active'
+                    ? 'bg-admin-leaf/12 text-admin-leaf'
+                    : 'bg-admin-danger/12 text-admin-danger'
+                }`}>
+                  {servicePrincipal.state}
+                </span>
+              </div>
+              <div class="mt-3 grid grid-cols-3 gap-2 max-[760px]:grid-cols-1">
+                <span class="text-xs font-bold text-admin-ink/58">Delegated <strong class="block text-admin-ink">{servicePrincipal.delegatedSummary}</strong></span>
+                <span class="text-xs font-bold text-admin-ink/58">Scopes <strong class="block text-admin-ink">{servicePrincipal.scopes}</strong></span>
+                <span class="text-xs font-bold text-admin-ink/58">Projects <strong class="block text-admin-ink">{servicePrincipal.projects}</strong></span>
+              </div>
+              <p class="mt-2 mb-0 text-xs font-semibold text-admin-ink/54">
+                {servicePrincipal.lastActivity}
+                <span class="block [overflow-wrap:anywhere]">{servicePrincipal.delegatedSessionIds}</span>
+              </p>
+            </article>
+          {/each}
+        </div>
+      {/if}
+    </section>
+
     <section class="grid min-w-0 gap-2" aria-label="Delegated automation access" data-testid="identity-delegation-list">
       <div class="flex items-center justify-between gap-2">
         <p class="admin-eyebrow m-0">Delegated automation</p>
@@ -141,7 +182,7 @@
                 {delegation.clientId} / {delegation.issuer}
               </p>
               <p class="mt-2 mb-0 text-xs font-bold text-admin-ink/72">
-                {delegation.sessionSummary}
+                {delegation.sessionSummary} / {delegation.registration} / {delegation.state}
                 <span class="block font-semibold text-admin-ink/54">{delegation.sessionIds}</span>
               </p>
             </article>

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.test.ts
@@ -10,6 +10,7 @@ describe('AdminWorkspaceViewModelBuilder', () => {
       browserContextCount: 1,
       egressProfileCount: 2,
       fileCount: 1,
+      servicePrincipalCount: 1,
       delegatedPrincipalCount: 1,
       connected: true,
     });
@@ -39,6 +40,7 @@ describe('AdminWorkspaceViewModelBuilder', () => {
       browserContextCount: 0,
       egressProfileCount: 0,
       fileCount: 0,
+      servicePrincipalCount: 0,
       delegatedPrincipalCount: 0,
       connected: false,
     });

--- a/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/admin-workspace-view-model.ts
@@ -42,6 +42,7 @@ export class AdminWorkspaceViewModelBuilder {
     readonly browserContextCount: number;
     readonly egressProfileCount: number;
     readonly fileCount: number;
+    readonly servicePrincipalCount: number;
     readonly delegatedPrincipalCount: number;
     readonly connected: boolean;
   }): AdminWorkspaceViewModel {
@@ -58,11 +59,12 @@ export class AdminWorkspaceViewModelBuilder {
           'Disconnect',
           'MCP authorization',
         ], ['visible sessions', 'selected session']),
-        panel('identity', 'Identity', 'Principal and access review', 'Review the signed-in operator and delegated automation access.', `${input.delegatedPrincipalCount} delegates`, true, [
+        panel('identity', 'Identity', 'Principal and access review', 'Review the signed-in operator and delegated automation access.', `${input.servicePrincipalCount} principals / ${input.delegatedPrincipalCount} delegates`, true, [
           'Refresh principal',
+          'Review service principals',
           'Review projects',
           'Inspect delegations',
-        ], ['principal type', 'resource counts', 'delegations']),
+        ], ['principal type', 'resource counts', 'service principals', 'delegations']),
         panel('contexts', 'Contexts', 'Reusable browser profile lifecycle', 'Inspect reusable Chromium state before attaching it to sessions.', `${input.browserContextCount} contexts`, true, [
           'Inspect profile catalog',
           'Copy API examples',

--- a/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.test.ts
+++ b/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.test.ts
@@ -13,6 +13,7 @@ const REVIEW: IdentityAccessReviewResponse = {
   generated_at: '2026-05-29T10:00:00Z',
   resource_counts: {
     projects: 1,
+    service_principals: 1,
     sessions: 2,
     active_sessions: 1,
     session_templates: 1,
@@ -54,11 +55,34 @@ const REVIEW: IdentityAccessReviewResponse = {
       updated_at: '2026-05-29T10:00:00Z',
     },
   ],
+  service_principals: [
+    {
+      id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f7',
+      name: 'BrowserPane MCP bridge',
+      description: 'Bridge automation identity',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'http://localhost:8091/realms/browserpane',
+      labels: { system: 'mcp' },
+      scopes: ['session:delegate'],
+      allowed_project_ids: ['project-1'],
+      state: 'active',
+      last_seen_at: null,
+      last_delegated_at: '2026-05-29T10:00:00Z',
+      delegated_session_count: 1,
+      active_delegated_session_count: 1,
+      delegated_session_ids: ['019df4d2-f4f7-7b00-9e0c-79683b1c82f6'],
+      created_at: '2026-05-29T09:00:00Z',
+      updated_at: '2026-05-29T10:00:00Z',
+    },
+  ],
   delegated_principals: [
     {
       client_id: 'bpane-mcp-bridge',
       issuer: 'http://localhost:8091/realms/browserpane',
       display_name: 'BrowserPane MCP bridge',
+      registered: true,
+      registered_service_principal_id: '019df4d2-f4f7-7b00-9e0c-79683b1c82f7',
+      state: 'active',
       session_count: 1,
       active_session_count: 1,
       session_ids: ['019df4d2-f4f7-7b00-9e0c-79683b1c82f6'],
@@ -83,9 +107,18 @@ describe('IdentityAccessReviewViewModelBuilder', () => {
       activeWorkflowRuns: '2/4',
       retainedStorage: '512 KiB / 1.0 MiB',
     });
+    expect(viewModel.servicePrincipals[0]).toMatchObject({
+      name: 'BrowserPane MCP bridge',
+      state: 'active',
+      scopes: 'session:delegate',
+      delegatedSummary: '1/1 active',
+      delegatedSessionIds: '019df4d2...82f6',
+    });
     expect(viewModel.delegations[0]).toMatchObject({
       clientId: 'bpane-mcp-bridge',
       displayName: 'BrowserPane MCP bridge',
+      registration: 'registered 019df4d2...82f7',
+      state: 'active',
       sessionSummary: '1/1 active',
       sessionIds: '019df4d2...82f6',
     });

--- a/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.ts
+++ b/code/web/bpane-admin/src/lib/presentation/identity-access-review-view-model.ts
@@ -24,8 +24,23 @@ export type IdentityDelegationRow = {
   readonly clientId: string;
   readonly issuer: string;
   readonly displayName: string;
+  readonly registration: string;
+  readonly state: string;
   readonly sessionSummary: string;
   readonly sessionIds: string;
+};
+
+export type IdentityServicePrincipalRow = {
+  readonly id: string;
+  readonly name: string;
+  readonly clientId: string;
+  readonly issuer: string;
+  readonly state: string;
+  readonly scopes: string;
+  readonly projects: string;
+  readonly delegatedSummary: string;
+  readonly delegatedSessionIds: string;
+  readonly lastActivity: string;
 };
 
 export type IdentityAccessReviewViewModel = {
@@ -35,6 +50,7 @@ export type IdentityAccessReviewViewModel = {
   readonly generatedAtLabel: string;
   readonly metrics: readonly IdentityMetricRow[];
   readonly projects: readonly IdentityProjectRow[];
+  readonly servicePrincipals: readonly IdentityServicePrincipalRow[];
   readonly delegations: readonly IdentityDelegationRow[];
 };
 
@@ -49,6 +65,7 @@ export class IdentityAccessReviewViewModelBuilder {
         metric('sessions', 'Sessions', review.resource_counts.sessions),
         metric('active-sessions', 'Active sessions', review.resource_counts.active_sessions),
         metric('projects', 'Projects', review.resource_counts.projects),
+        metric('service-principals', 'Service principals', review.resource_counts.service_principals),
         metric('contexts', 'Contexts', review.resource_counts.browser_contexts),
         metric('egress', 'Egress profiles', review.resource_counts.egress_profiles),
         metric('templates', 'Templates', review.resource_counts.session_templates),
@@ -58,10 +75,34 @@ export class IdentityAccessReviewViewModelBuilder {
         metric('delegations', 'Delegations', review.resource_counts.delegated_principals),
       ],
       projects: review.projects.map(projectRow),
+      servicePrincipals: review.service_principals.map((servicePrincipal) => ({
+        id: servicePrincipal.id,
+        name: servicePrincipal.name,
+        clientId: servicePrincipal.client_id,
+        issuer: servicePrincipal.issuer,
+        state: servicePrincipal.state,
+        scopes: servicePrincipal.scopes.length > 0 ? servicePrincipal.scopes.join(', ') : 'no scopes',
+        projects: servicePrincipal.allowed_project_ids.length > 0
+          ? servicePrincipal.allowed_project_ids.map(shortId).join(', ')
+          : 'all projects metadata unset',
+        delegatedSummary: `${servicePrincipal.active_delegated_session_count}/${servicePrincipal.delegated_session_count} active`,
+        delegatedSessionIds: servicePrincipal.delegated_session_ids.length > 0
+          ? servicePrincipal.delegated_session_ids.map(shortId).join(', ')
+          : 'no delegated sessions',
+        lastActivity: servicePrincipal.last_delegated_at
+          ? `delegated ${formatDateTime(servicePrincipal.last_delegated_at)}`
+          : servicePrincipal.last_seen_at
+            ? `seen ${formatDateTime(servicePrincipal.last_seen_at)}`
+            : 'not observed',
+      })),
       delegations: review.delegated_principals.map((delegate) => ({
         clientId: delegate.client_id,
         issuer: delegate.issuer,
         displayName: delegate.display_name ?? delegate.client_id,
+        registration: delegate.registered
+          ? `registered ${delegate.registered_service_principal_id ? shortId(delegate.registered_service_principal_id) : ''}`.trim()
+          : 'unregistered',
+        state: delegate.state ?? 'unregistered',
         sessionSummary: `${delegate.active_session_count}/${delegate.session_count} active`,
         sessionIds: delegate.session_ids.length > 0
           ? delegate.session_ids.map(shortId).join(', ')

--- a/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
+++ b/code/web/bpane-client/js/__tests__/bpane-cli.test.ts
@@ -1088,6 +1088,144 @@ describe('bpane operator CLI', () => {
     });
   });
 
+  it('manages service principals through the CLI', async () => {
+    const createServicePrincipalIo = createIo();
+    const { calls, fetchImpl } = createFetch(
+      jsonResponse({ id: 'service-principal-1', name: 'MCP bridge' }, 201),
+      jsonResponse({ service_principals: [{ id: 'service-principal-1' }] }),
+      jsonResponse({ id: 'service-principal-1', name: 'MCP bridge' }),
+      jsonResponse({
+        id: 'service-principal-1',
+        name: 'MCP bridge',
+        description: 'Existing service principal',
+        client_id: 'bpane-mcp-bridge',
+        issuer: 'https://issuer.example',
+        labels: { system: 'mcp' },
+        scopes: ['session:delegate'],
+        allowed_project_ids: ['project-1'],
+        state: 'active',
+      }),
+      jsonResponse({ id: 'service-principal-1', name: 'MCP bridge v2', state: 'active' }),
+      jsonResponse({
+        id: 'service-principal-1',
+        name: 'MCP bridge v2',
+        client_id: 'bpane-mcp-bridge',
+        issuer: 'https://issuer.example',
+        labels: { system: 'mcp', managed: 'true' },
+        scopes: ['session:delegate', 'workflow:run'],
+        allowed_project_ids: ['project-1'],
+        state: 'active',
+      }),
+      jsonResponse({ id: 'service-principal-1', name: 'MCP bridge v2', state: 'disabled' }),
+    );
+
+    const createCode = await runBpaneCli(
+      [
+        'service-principal',
+        'create',
+        'MCP bridge',
+        '--description',
+        'Bridge automation identity',
+        '--client-id',
+        'bpane-mcp-bridge',
+        '--issuer',
+        'https://issuer.example',
+        '--label',
+        'system=mcp',
+        '--scope',
+        'session:delegate',
+        '--allowed-project-id',
+        'project-1',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      createServicePrincipalIo.io,
+      fetchImpl,
+    );
+    expect(createCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(createServicePrincipalIo)).toEqual({ id: 'service-principal-1', name: 'MCP bridge' });
+    expect(calls[0].url).toBe('http://localhost:8080/api/v1/service-principals');
+    expect(calls[0].init.method).toBe('POST');
+    expect(JSON.parse(calls[0].init.body)).toEqual({
+      name: 'MCP bridge',
+      description: 'Bridge automation identity',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'https://issuer.example',
+      labels: { system: 'mcp' },
+      scopes: ['session:delegate'],
+      allowed_project_ids: ['project-1'],
+    });
+
+    const listIo = createIo();
+    const listCode = await runBpaneCli(
+      ['service-principal', 'list'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      listIo.io,
+      fetchImpl,
+    );
+    expect(listCode).toBe(EXIT_CODES.ok);
+    expect(parseStdout(listIo)).toEqual({ service_principals: [{ id: 'service-principal-1' }] });
+
+    const getIo = createIo();
+    const getCode = await runBpaneCli(
+      ['service-principal', 'get', 'service/principal with space'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      getIo.io,
+      fetchImpl,
+    );
+    expect(getCode).toBe(EXIT_CODES.ok);
+    expect(calls[2].url).toBe('http://localhost:8080/api/v1/service-principals/service%2Fprincipal%20with%20space');
+
+    const updateIo = createIo();
+    const updateCode = await runBpaneCli(
+      [
+        'service-principal',
+        'update',
+        'service-principal-1',
+        '--name',
+        'MCP bridge v2',
+        '--label',
+        'managed=true',
+        '--scope',
+        'workflow:run',
+      ],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      updateIo.io,
+      fetchImpl,
+    );
+    expect(updateCode).toBe(EXIT_CODES.ok);
+    expect(calls[3].url).toBe('http://localhost:8080/api/v1/service-principals/service-principal-1');
+    expect(calls[4].init.method).toBe('PUT');
+    expect(JSON.parse(calls[4].init.body)).toEqual({
+      name: 'MCP bridge v2',
+      description: 'Existing service principal',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'https://issuer.example',
+      labels: { system: 'mcp', managed: 'true' },
+      scopes: ['workflow:run'],
+      allowed_project_ids: ['project-1'],
+      state: 'active',
+    });
+
+    const disableIo = createIo();
+    const disableCode = await runBpaneCli(
+      ['service-principal', 'disable', 'service-principal-1'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      disableIo.io,
+      fetchImpl,
+    );
+    expect(disableCode).toBe(EXIT_CODES.ok);
+    expect(calls[6].init.method).toBe('PUT');
+    expect(JSON.parse(calls[6].init.body)).toEqual({
+      name: 'MCP bridge v2',
+      client_id: 'bpane-mcp-bridge',
+      issuer: 'https://issuer.example',
+      labels: { system: 'mcp', managed: 'true' },
+      scopes: ['session:delegate', 'workflow:run'],
+      allowed_project_ids: ['project-1'],
+      state: 'disabled',
+    });
+  });
+
   it('validates project CLI input before fetching', async () => {
     const missingNameIo = createIo();
     const { calls, fetchImpl } = createFetch(jsonResponse({ ok: true }));
@@ -1110,6 +1248,41 @@ describe('bpane operator CLI', () => {
     );
     expect(invalidQuotaCode).toBe(EXIT_CODES.usage);
     expect(parseStderr(invalidQuotaIo).error).toContain('--max-active-sessions');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('validates service-principal CLI input before fetching', async () => {
+    const missingNameIo = createIo();
+    const { calls, fetchImpl } = createFetch(jsonResponse({ ok: true }));
+
+    const missingNameCode = await runBpaneCli(
+      ['service-principal', 'create', '--client-id', 'bpane-mcp-bridge', '--issuer', 'https://issuer.example'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      missingNameIo.io,
+      fetchImpl,
+    );
+    expect(missingNameCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(missingNameIo).error).toContain('Service principal create requires');
+
+    const missingClientIo = createIo();
+    const missingClientCode = await runBpaneCli(
+      ['service-principal', 'create', 'MCP bridge', '--issuer', 'https://issuer.example'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      missingClientIo.io,
+      fetchImpl,
+    );
+    expect(missingClientCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(missingClientIo).error).toContain('requires --client-id');
+
+    const missingIssuerIo = createIo();
+    const missingIssuerCode = await runBpaneCli(
+      ['service-principal', 'create', 'MCP bridge', '--client-id', 'bpane-mcp-bridge'],
+      { BPANE_ACCESS_TOKEN: 'token-1' },
+      missingIssuerIo.io,
+      fetchImpl,
+    );
+    expect(missingIssuerCode).toBe(EXIT_CODES.usage);
+    expect(parseStderr(missingIssuerIo).error).toContain('requires --issuer');
     expect(calls).toHaveLength(0);
   });
 

--- a/code/web/bpane-client/scripts/bpane-cli.mjs
+++ b/code/web/bpane-client/scripts/bpane-cli.mjs
@@ -23,7 +23,9 @@ const KNOWN_OPTIONS = new Set([
   'browser-context-mode',
   'browser-identity',
   'bypass-rule',
+  'allowed-project-id',
   'cleanup-action',
+  'client-id',
   'config',
   'confirm',
   'custom-ca-name',
@@ -43,6 +45,7 @@ const KNOWN_OPTIONS = new Set([
   'input',
   'integration-json',
   'integration',
+  'issuer',
   'label',
   'language',
   'limit',
@@ -73,6 +76,7 @@ const KNOWN_OPTIONS = new Set([
   'retention-sec',
   'save-token',
   'set-default',
+  'scope',
   'runtime-state',
   'state',
   'template-id',
@@ -103,6 +107,11 @@ function usageText() {
     '  bpane profile show [profile-name] [options]',
     '  bpane identity me [options]',
     '  bpane identity access-review [options]',
+    '  bpane service-principal create [principal-name] [options]',
+    '  bpane service-principal list [options]',
+    '  bpane service-principal get <service-principal-id> [options]',
+    '  bpane service-principal update <service-principal-id> [options]',
+    '  bpane service-principal disable <service-principal-id> [options]',
     '  bpane session create [options]',
     '  bpane session list [options]',
     '  bpane session get <session-id> [options]',
@@ -193,6 +202,10 @@ function usageText() {
     '  --probe-timeout-ms <ms>      Session egress probe timeout. Requires an already-ready runtime.',
     '  --name <name>             Resource name for create/update commands.',
     '  --description <text>      Resource description for create/update commands.',
+    '  --client-id <id>          External service-principal client id.',
+    '  --issuer <url>            External service-principal issuer.',
+    '  --scope <name>            Repeatable service-principal scope metadata.',
+    '  --allowed-project-id <id> Repeatable service-principal project metadata.',
     '  --max-active-sessions <count> Project active-session quota.',
     '  --max-active-workflow-runs <count> Project active workflow-run quota.',
     '  --max-retained-storage-bytes <bytes> Project retained-storage quota.',
@@ -529,6 +542,14 @@ function requiredProjectId(positionals, commandLabel) {
     throw new CliError('USAGE', `Usage: bpane ${commandLabel} <project-id>`, EXIT_CODES.usage);
   }
   return projectId;
+}
+
+function requiredServicePrincipalId(positionals, commandLabel) {
+  const servicePrincipalId = positionals[2];
+  if (!servicePrincipalId || positionals.length > 3) {
+    throw new CliError('USAGE', `Usage: bpane ${commandLabel} <service-principal-id>`, EXIT_CODES.usage);
+  }
+  return servicePrincipalId;
 }
 
 function requiredBrowserContextId(positionals, commandLabel) {
@@ -1157,6 +1178,139 @@ function buildProjectUpdateRequest(existingProject, options, forcedState = null)
     body.quotas = quotas;
   }
   const state = forcedState ?? getOption(options, 'state') ?? existingProject?.state;
+  if (state) {
+    body.state = state;
+  }
+  return body;
+}
+
+function buildServicePrincipalRequest(options, fallbackName = null) {
+  const rawBody = parseJsonOption(options, 'body-json');
+  if (rawBody !== null) {
+    return rawBody;
+  }
+
+  const name = getOption(options, 'name') ?? fallbackName;
+  if (!name) {
+    throw new CliError(
+      'USAGE',
+      'Service principal create requires --name or a positional principal name.',
+      EXIT_CODES.usage,
+    );
+  }
+  const clientId = getOption(options, 'client-id') ?? getOption(options, 'mcp-client-id');
+  if (!clientId) {
+    throw new CliError(
+      'USAGE',
+      'Service principal create/update requires --client-id.',
+      EXIT_CODES.usage,
+    );
+  }
+  const issuer = getOption(options, 'issuer') ?? getOption(options, 'mcp-issuer');
+  if (!issuer) {
+    throw new CliError(
+      'USAGE',
+      'Service principal create/update requires --issuer.',
+      EXIT_CODES.usage,
+    );
+  }
+
+  const body = {
+    name,
+    client_id: clientId,
+    issuer,
+  };
+  const description = getOption(options, 'description');
+  if (description !== null) {
+    body.description = description;
+  }
+  const labels = parseKeyValueOptions(options, 'label');
+  if (Object.keys(labels).length) {
+    body.labels = labels;
+  }
+  const scopes = getOptions(options, 'scope').filter((scope) => scope !== '');
+  if (scopes.length) {
+    body.scopes = scopes;
+  }
+  const allowedProjectIds = getOptions(options, 'allowed-project-id').filter((projectId) => projectId !== '');
+  if (allowedProjectIds.length) {
+    body.allowed_project_ids = allowedProjectIds;
+  }
+  const state = getOption(options, 'state');
+  if (state) {
+    body.state = state;
+  }
+  return body;
+}
+
+function buildServicePrincipalUpdateRequest(existingServicePrincipal, options, forcedState = null) {
+  const rawBody = parseJsonOption(options, 'body-json');
+  if (rawBody !== null) {
+    return rawBody;
+  }
+
+  const name = getOption(options, 'name') ?? existingServicePrincipal?.name;
+  if (!name) {
+    throw new CliError(
+      'USAGE',
+      'Service principal update requires --name when the existing service principal response has no name.',
+      EXIT_CODES.usage,
+    );
+  }
+  const clientId =
+    getOption(options, 'client-id')
+    ?? getOption(options, 'mcp-client-id')
+    ?? existingServicePrincipal?.client_id;
+  if (!clientId) {
+    throw new CliError(
+      'USAGE',
+      'Service principal update requires --client-id when the existing response has no client_id.',
+      EXIT_CODES.usage,
+    );
+  }
+  const issuer =
+    getOption(options, 'issuer')
+    ?? getOption(options, 'mcp-issuer')
+    ?? existingServicePrincipal?.issuer;
+  if (!issuer) {
+    throw new CliError(
+      'USAGE',
+      'Service principal update requires --issuer when the existing response has no issuer.',
+      EXIT_CODES.usage,
+    );
+  }
+
+  const body = {
+    name,
+    client_id: clientId,
+    issuer,
+  };
+  const description = getOption(options, 'description');
+  if (description !== null) {
+    body.description = description;
+  } else if (existingServicePrincipal?.description != null) {
+    body.description = existingServicePrincipal.description;
+  }
+  const labels = {
+    ...(isObjectRecord(existingServicePrincipal?.labels) ? existingServicePrincipal.labels : {}),
+    ...parseKeyValueOptions(options, 'label'),
+  };
+  if (Object.keys(labels).length) {
+    body.labels = labels;
+  }
+  const scopes = getOptions(options, 'scope');
+  if (scopes.length) {
+    body.scopes = scopes.filter((scope) => scope !== '');
+  } else if (Array.isArray(existingServicePrincipal?.scopes)) {
+    body.scopes = existingServicePrincipal.scopes;
+  }
+  const allowedProjectIds = getOptions(options, 'allowed-project-id');
+  if (allowedProjectIds.length) {
+    body.allowed_project_ids = allowedProjectIds.filter((projectId) => projectId !== '');
+  } else if (Array.isArray(existingServicePrincipal?.allowed_project_ids)) {
+    body.allowed_project_ids = existingServicePrincipal.allowed_project_ids;
+  }
+  const state = forcedState ?? getOption(options, 'state') ?? existingServicePrincipal?.state;
   if (state) {
     body.state = state;
   }
@@ -2149,6 +2303,53 @@ async function handleProjectCommand(config, positionals, options) {
   throw new CliError('USAGE', `Unknown project command: ${action ?? ''}`.trim(), EXIT_CODES.usage);
 }
 
+async function handleServicePrincipalCommand(config, positionals, options) {
+  const action = positionals[1];
+  if (action === 'create' && positionals.length <= 3) {
+    return await requestGateway(config, '/api/v1/service-principals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildServicePrincipalRequest(options, positionals[2] ?? null)),
+    });
+  }
+  if (action === 'list' && positionals.length === 2) {
+    return await requestGateway(config, '/api/v1/service-principals');
+  }
+  if (action === 'get') {
+    const servicePrincipalId = requiredServicePrincipalId(positionals, 'service-principal get');
+    return await requestGateway(config, `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`);
+  }
+  if (action === 'update') {
+    const servicePrincipalId = requiredServicePrincipalId(positionals, 'service-principal update');
+    const existingServicePrincipal = await requestGateway(
+      config,
+      `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`,
+    );
+    return await requestGateway(config, `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildServicePrincipalUpdateRequest(existingServicePrincipal, options)),
+    });
+  }
+  if (action === 'disable') {
+    const servicePrincipalId = requiredServicePrincipalId(positionals, 'service-principal disable');
+    const existingServicePrincipal = await requestGateway(
+      config,
+      `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`,
+    );
+    return await requestGateway(config, `/api/v1/service-principals/${encodeURIComponent(servicePrincipalId)}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildServicePrincipalUpdateRequest(existingServicePrincipal, options, 'disabled')),
+    });
+  }
+  throw new CliError(
+    'USAGE',
+    `Unknown service-principal command: ${action ?? ''}`.trim(),
+    EXIT_CODES.usage,
+  );
+}
+
 async function handleEgressProfileCommand(config, positionals, options) {
   const action = positionals[1];
   if (action === 'create' && positionals.length <= 3) {
@@ -2533,6 +2734,9 @@ export async function runBpaneCli(argv, env = process.env, io = process, fetchIm
     } else if (scope === 'project') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleProjectCommand(config, positionals, options);
+    } else if (scope === 'service-principal') {
+      const config = await buildConfig(options, env, fetchImpl);
+      result = await handleServicePrincipalCommand(config, positionals, options);
     } else if (scope === 'egress-profile') {
       const config = await buildConfig(options, env, fetchImpl);
       result = await handleEgressProfileCommand(config, positionals, options);

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -131,6 +131,7 @@ async function verifyIdentityPanel(page, options) {
     100,
   );
   await page.getByTestId('identity-project-list').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
+  await page.getByTestId('identity-service-principal-list').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
   await page.getByTestId('identity-delegation-list').waitFor({ state: 'visible', timeout: options.connectTimeoutMs });
 }
 

--- a/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-admin-session-smoke.mjs
@@ -206,6 +206,7 @@ async function verifySessionSwitchDisconnect(page, options, originalSessionId) {
   if (disconnectEnabled) {
     throw new Error('Expected session area disconnect control to be disabled after switching away from the live session.');
   }
+  await stopSwitchTargetSession(accessToken, options, switchTarget.id);
 
   await page.locator(`[data-testid="session-row"][data-session-id="${originalSessionId}"]`).click();
   await poll(
@@ -228,6 +229,13 @@ async function createSwitchTargetSession(accessToken, options) {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ labels: { suite: 'admin-session-switch-smoke' } }),
+  });
+}
+
+async function stopSwitchTargetSession(accessToken, options, sessionId) {
+  await fetchJson(`${apiOrigin(options)}/api/v1/sessions/${sessionId}/kill`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
   });
 }
 

--- a/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
@@ -38,6 +38,7 @@ async function run() {
   let contextId = '';
   let clonedContextId = '';
   let importedContextId = '';
+  let servicePrincipalId = '';
   let configDir = '';
 
   try {
@@ -95,6 +96,57 @@ async function run() {
     const identity = runBpaneCli(['identity', 'me'], cliEnv);
     if (!identity.subject || !identity.issuer || !['user', 'service_principal', 'legacy_dev_token'].includes(identity.principal_type)) {
       throw new Error(`CLI identity me returned unexpected data: ${JSON.stringify(identity)}`);
+    }
+
+    const servicePrincipal = runBpaneCli([
+      'service-principal',
+      'create',
+      `mcp-bridge-${runLabel}`,
+      '--description',
+      'Operator CLI smoke service principal',
+      '--client-id',
+      bridge.clientId,
+      '--issuer',
+      bridge.issuer,
+      '--label',
+      'suite=bpane-cli-smoke',
+      '--label',
+      `run_id=${runLabel}`,
+      '--scope',
+      'session:delegate',
+    ], cliEnv);
+    servicePrincipalId = servicePrincipal.id;
+    if (!servicePrincipalId || servicePrincipal.client_id !== bridge.clientId || servicePrincipal.state !== 'active') {
+      throw new Error(`CLI service-principal create returned unexpected data: ${JSON.stringify(servicePrincipal)}`);
+    }
+
+    const listedServicePrincipals = runBpaneCli(['service-principal', 'list'], cliEnv);
+    if (
+      !Array.isArray(listedServicePrincipals.service_principals)
+      || !listedServicePrincipals.service_principals.some((item) => item.id === servicePrincipalId)
+    ) {
+      throw new Error(`CLI service-principal list did not include ${servicePrincipalId}.`);
+    }
+
+    const fetchedServicePrincipal = runBpaneCli(['service-principal', 'get', servicePrincipalId], cliEnv);
+    if (fetchedServicePrincipal.id !== servicePrincipalId || fetchedServicePrincipal.labels?.run_id !== runLabel) {
+      throw new Error(`CLI service-principal get returned unexpected data: ${JSON.stringify(fetchedServicePrincipal)}`);
+    }
+
+    const disabledServicePrincipal = runBpaneCli(['service-principal', 'disable', servicePrincipalId], cliEnv);
+    if (disabledServicePrincipal.state !== 'disabled') {
+      throw new Error(`CLI service-principal disable did not persist disabled state: ${JSON.stringify(disabledServicePrincipal)}`);
+    }
+
+    const enabledServicePrincipal = runBpaneCli([
+      'service-principal',
+      'update',
+      servicePrincipalId,
+      '--state',
+      'active',
+    ], cliEnv);
+    if (enabledServicePrincipal.state !== 'active') {
+      throw new Error(`CLI service-principal update did not re-enable the principal: ${JSON.stringify(enabledServicePrincipal)}`);
     }
 
     const project = runBpaneCli([
@@ -496,10 +548,13 @@ async function run() {
       accessReview.principal?.subject !== identity.subject
       || accessReview.resource_counts?.sessions < 1
       || accessReview.resource_counts?.projects < 1
+      || accessReview.resource_counts?.service_principals < 1
       || !Array.isArray(accessReview.projects)
       || !accessReview.projects.some((item) => item.id === projectId)
+      || !Array.isArray(accessReview.service_principals)
+      || !accessReview.service_principals.some((item) => item.id === servicePrincipalId && item.delegated_session_count >= 1)
       || !Array.isArray(accessReview.delegated_principals)
-      || !accessReview.delegated_principals.some((item) => item.client_id === bridge.clientId)
+      || !accessReview.delegated_principals.some((item) => item.client_id === bridge.clientId && item.registered === true)
     ) {
       throw new Error(`CLI identity access-review returned unexpected data: ${JSON.stringify(accessReview)}`);
     }

--- a/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
+++ b/code/web/bpane-client/scripts/run-bpane-cli-smoke.mjs
@@ -98,26 +98,10 @@ async function run() {
       throw new Error(`CLI identity me returned unexpected data: ${JSON.stringify(identity)}`);
     }
 
-    const servicePrincipal = runBpaneCli([
-      'service-principal',
-      'create',
-      `mcp-bridge-${runLabel}`,
-      '--description',
-      'Operator CLI smoke service principal',
-      '--client-id',
-      bridge.clientId,
-      '--issuer',
-      bridge.issuer,
-      '--label',
-      'suite=bpane-cli-smoke',
-      '--label',
-      `run_id=${runLabel}`,
-      '--scope',
-      'session:delegate',
-    ], cliEnv);
+    const servicePrincipal = ensureBridgeServicePrincipal(cliEnv, bridge, runLabel);
     servicePrincipalId = servicePrincipal.id;
     if (!servicePrincipalId || servicePrincipal.client_id !== bridge.clientId || servicePrincipal.state !== 'active') {
-      throw new Error(`CLI service-principal create returned unexpected data: ${JSON.stringify(servicePrincipal)}`);
+      throw new Error(`CLI service-principal ensure returned unexpected data: ${JSON.stringify(servicePrincipal)}`);
     }
 
     const listedServicePrincipals = runBpaneCli(['service-principal', 'list'], cliEnv);
@@ -702,6 +686,45 @@ async function loadMcpBridgeConfig(options) {
     throw new Error('Operator CLI smoke requires auth-config mcpBridge metadata.');
   }
   return bridge;
+}
+
+function ensureBridgeServicePrincipal(cliEnv, bridge, runLabel) {
+  const listed = runBpaneCli(['service-principal', 'list'], cliEnv);
+  const existing = listed.service_principals?.find((item) => (
+    item.client_id === bridge.clientId && item.issuer === bridge.issuer
+  ));
+  const args = existing
+    ? [
+        'service-principal',
+        'update',
+        existing.id,
+        '--name',
+        `mcp-bridge-${runLabel}`,
+        '--description',
+        'Operator CLI smoke service principal',
+        '--state',
+        'active',
+      ]
+    : [
+        'service-principal',
+        'create',
+        `mcp-bridge-${runLabel}`,
+        '--description',
+        'Operator CLI smoke service principal',
+        '--client-id',
+        bridge.clientId,
+        '--issuer',
+        bridge.issuer,
+      ];
+  return runBpaneCli([
+    ...args,
+    '--label',
+    'suite=bpane-cli-smoke',
+    '--label',
+    `run_id=${runLabel}`,
+    '--scope',
+    'session:delegate',
+  ], cliEnv);
 }
 
 async function clearMcpBridge(options) {

--- a/code/web/bpane-client/scripts/workflow-smoke-lib.mjs
+++ b/code/web/bpane-client/scripts/workflow-smoke-lib.mjs
@@ -256,6 +256,18 @@ export async function deleteSession(accessToken, options, sessionId) {
   }
 }
 
+export async function killSession(accessToken, options, sessionId) {
+  const response = await fetch(`${apiOrigin(options)}/api/v1/sessions/${sessionId}/kill`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (response.ok || response.status === 404) {
+    return;
+  }
+  const detail = await response.text().catch(() => '');
+  throw new Error(`HTTP ${response.status}${detail ? ` ${detail}` : ''}`);
+}
+
 export async function cleanupWorkflowSmokeSessions(accessToken, options, log = () => {}) {
   const response = await waitForWorkflowControlPlane(accessToken, options);
   const sessions = Array.isArray(response.sessions) ? response.sessions : [];
@@ -269,7 +281,7 @@ export async function cleanupWorkflowSmokeSessions(accessToken, options, log = (
     if (sessionState === 'stopped') {
       continue;
     }
-    await deleteSession(accessToken, options, sessionId);
+    await killSession(accessToken, options, sessionId);
     removed += 1;
   }
   if (removed > 0) {

--- a/openapi/bpane-control-v1.yaml
+++ b/openapi/bpane-control-v1.yaml
@@ -80,8 +80,9 @@ paths:
       operationId: getIdentityAccessReview
       description: >
         Returns a sanitized owner-scoped access review with the current
-        principal, project usage, resource counts, and delegated automation
-        principals visible through the session catalog.
+        principal, project usage, service-principal registry metadata, resource
+        counts, and delegated automation principals visible through the session
+        catalog.
       responses:
         '200':
           description: Owner-scoped access review
@@ -91,6 +92,102 @@ paths:
                 $ref: '#/components/schemas/IdentityAccessReviewResponse'
         '401':
           $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/service-principals:
+    get:
+      tags: [Identity]
+      summary: List owner-scoped service principals
+      operationId: listServicePrincipals
+      description: >
+        Returns registered external OIDC client metadata for the authenticated
+        owner. Responses are sanitized and never include client secrets, raw
+        token claims, or credential material.
+      responses:
+        '200':
+          description: Owner-scoped service-principal registry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServicePrincipalListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    post:
+      tags: [Identity]
+      summary: Register an owner-scoped service principal
+      operationId: createServicePrincipal
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertServicePrincipalRequest'
+      responses:
+        '201':
+          description: Service principal registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServicePrincipalResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+  /api/v1/service-principals/{service_principal_id}:
+    parameters:
+      - $ref: '#/components/parameters/ServicePrincipalId'
+    get:
+      tags: [Identity]
+      summary: Fetch one owner-scoped service principal
+      operationId: getServicePrincipal
+      responses:
+        '200':
+          description: Service-principal registry entry
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServicePrincipalResource'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          $ref: '#/components/responses/BackendUnavailable'
+    put:
+      tags: [Identity]
+      summary: Replace one owner-scoped service principal
+      operationId: updateServicePrincipal
+      description: >
+        Replaces service-principal metadata including lifecycle state. Disabled
+        registered principals cannot be assigned as new automation delegates,
+        but existing session metadata remains visible for cleanup.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertServicePrincipalRequest'
+      responses:
+        '200':
+          description: Service principal updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServicePrincipalResource'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '503':
           $ref: '#/components/responses/BackendUnavailable'
   /api/v1/sessions:
@@ -2807,6 +2904,13 @@ components:
       schema:
         type: string
         format: uuid
+    ServicePrincipalId:
+      name: service_principal_id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
     EgressProfileId:
       name: profile_id
       in: path
@@ -5440,6 +5544,117 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProjectResource'
+    ServicePrincipalState:
+      type: string
+      enum:
+        - active
+        - disabled
+    UpsertServicePrincipalRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+        - client_id
+        - issuer
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        client_id:
+          type: string
+          description: External OIDC client id.
+        issuer:
+          type: string
+          description: External OIDC issuer that minted tokens for this client.
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+          default: {}
+        scopes:
+          type: array
+          items:
+            type: string
+          default: []
+          description: Operator-defined scope metadata for future policy/audit use.
+        allowed_project_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+          default: []
+          description: Operator-defined project metadata for future policy/audit use.
+        state:
+          $ref: '#/components/schemas/ServicePrincipalState'
+    ServicePrincipalResource:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - name
+        - description
+        - client_id
+        - issuer
+        - labels
+        - scopes
+        - allowed_project_ids
+        - state
+        - last_seen_at
+        - last_delegated_at
+        - created_at
+        - updated_at
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        client_id:
+          type: string
+        issuer:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        scopes:
+          type: array
+          items:
+            type: string
+        allowed_project_ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        state:
+          $ref: '#/components/schemas/ServicePrincipalState'
+        last_seen_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_delegated_at:
+          type: string
+          format: date-time
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    ServicePrincipalListResponse:
+      type: object
+      required: [service_principals]
+      properties:
+        service_principals:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServicePrincipalResource'
     IdentityPrincipalType:
       type: string
       enum:
@@ -5473,6 +5688,7 @@ components:
       additionalProperties: false
       required:
         - projects
+        - service_principals
         - sessions
         - active_sessions
         - session_templates
@@ -5489,6 +5705,9 @@ components:
         - delegated_principals
       properties:
         projects:
+          type: integer
+          minimum: 0
+        service_principals:
           type: integer
           minimum: 0
         sessions:
@@ -5540,6 +5759,9 @@ components:
         - client_id
         - issuer
         - display_name
+        - registered
+        - registered_service_principal_id
+        - state
         - session_count
         - active_session_count
         - session_ids
@@ -5550,6 +5772,16 @@ components:
           type: string
         display_name:
           type: string
+          nullable: true
+        registered:
+          type: boolean
+        registered_service_principal_id:
+          type: string
+          format: uuid
+          nullable: true
+        state:
+          allOf:
+            - $ref: '#/components/schemas/ServicePrincipalState'
           nullable: true
         session_count:
           type: integer
@@ -5562,6 +5794,27 @@ components:
           items:
             type: string
             format: uuid
+    IdentityServicePrincipalReviewResource:
+      allOf:
+        - $ref: '#/components/schemas/ServicePrincipalResource'
+        - type: object
+          additionalProperties: false
+          required:
+            - delegated_session_count
+            - active_delegated_session_count
+            - delegated_session_ids
+          properties:
+            delegated_session_count:
+              type: integer
+              minimum: 0
+            active_delegated_session_count:
+              type: integer
+              minimum: 0
+            delegated_session_ids:
+              type: array
+              items:
+                type: string
+                format: uuid
     IdentityAccessReviewResponse:
       type: object
       additionalProperties: false
@@ -5570,6 +5823,7 @@ components:
         - generated_at
         - projects
         - resource_counts
+        - service_principals
         - delegated_principals
       properties:
         principal:
@@ -5583,6 +5837,10 @@ components:
             $ref: '#/components/schemas/ProjectResource'
         resource_counts:
           $ref: '#/components/schemas/IdentityResourceCounts'
+        service_principals:
+          type: array
+          items:
+            $ref: '#/components/schemas/IdentityServicePrincipalReviewResource'
         delegated_principals:
           type: array
           items:


### PR DESCRIPTION
## Summary
- Adds an owner-scoped service-principal registry for external OIDC clients.
- Extends identity access review with registered service principals, delegated-session linkage, and registered/unregistered delegated automation status.
- Adds CLI, admin Identity panel, OpenAPI, README, and ARCH coverage for the registry lifecycle.

## Business case and use case
BrowserPane already exposes who is calling the control plane and which automation clients are delegated to sessions, but service accounts were still implicit strings. Enterprise operators need a visible non-human identity inventory before they can safely add API keys, audit export, policy bindings, or automated deprovisioning.

Example: a support platform registers the local `bpane-mcp-bridge` OIDC client as an active BrowserPane service principal. When an operator delegates MCP to a session, the admin Identity tab now shows that the delegated client is registered and active, including scope/project metadata and delegated-session linkage. If that service principal is disabled, fresh delegation attempts fail clearly while existing metadata remains inspectable for cleanup.

## Validation
- `cargo test -p bpane-gateway service_principal -- --nocapture`
- `cargo test -p bpane-gateway identity -- --nocapture`
- `cargo test -p bpane-gateway`
- `cargo test -p bpane-gateway --test compose_api_surface compose_service_principals_api_surface -- --ignored --test-threads=1`
- `cd code/web/bpane-client && npm test -- --run js/__tests__/bpane-cli.test.ts`
- `cd code/web/bpane-client && npx tsc --noEmit`
- `cd code/web/bpane-client && npm run build`
- `cd code/web/bpane-admin && npm test`
- `cd code/web/bpane-admin && npm run check`
- `cd code/web/bpane-admin && npm run build`
- `cd code/web/bpane-client && npm run smoke:bpane-cli -- --headless`
- `cd code/web/bpane-client && npm run smoke:admin-session -- --headless`

Closes #135.